### PR TITLE
Allow manual entry of channel information in grid files using command line flag

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_grid.1.14/doc/make_grid.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_grid.1.14/doc/make_grid.doc.xml
@@ -34,6 +34,8 @@
 </option>
 <option><on>-cn <ar>channel</ar></on><od>process data from channel <ar>channel</ar> for stereo mode data.</od>
 </option>
+<option><on>-cn_fix <ar>channel</ar></on><od>manually set <ar>channel</ar> information written to output file.</od>
+</option>
 <option><on>-ebm <ar>ebeams</ar></on><od>exclude the beams listed in <ar>ebeams</ar>, which is a comma separated list of beam numbers.</od>
 </option>
 <option><on>-minrng <ar>minrange</ar></on><od>exclude data from range gates lower than <ar>minrange</ar>.</od>

--- a/codebase/superdarn/src.bin/tk/tool/make_grid.1.14/make_grid.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_grid.1.14/make_grid.c
@@ -257,6 +257,7 @@ int main(int argc,char *argv[]) {
     unsigned char vb=0;
 
     char *chnstr=NULL;
+    char *chnstr_fix=NULL;
     char *bmstr=NULL;
 
     char *stmestr=NULL;
@@ -294,6 +295,7 @@ int main(int argc,char *argv[]) {
     unsigned char gsflg=0,ionflg=0,bthflg=0;
     unsigned char nsflg=0,isflg=0;
     int channel=0;
+    int channel_fix=-1;
 
     int syncflg=1;
 
@@ -389,6 +391,7 @@ int main(int argc,char *argv[]) {
     OptionAdd(&opt,"i",'i',&avlen); /* Time interval to store in each grid record in seconds */
 
     OptionAdd(&opt,"cn",'t',&chnstr);   /* Process data from stereo channel a or b */
+    OptionAdd(&opt,"cn_fix",'t',&chnstr_fix);   /* User-defined channel number for output only */
     OptionAdd(&opt,"ebm",'t',&bmstr);   /* Comma separated list of beams to exclude */
     OptionAdd(&opt,"minrng",'i',&minrng); /* Exclude data from gates lower than minrng */
     OptionAdd(&opt,"maxrng",'i',&minrng); /* Exclude data from gates higher than maxrng */
@@ -453,6 +456,14 @@ int main(int argc,char *argv[]) {
         if (tolower(chnstr[0])=='a') channel=1;
         if (tolower(chnstr[0])=='b') channel=2;
     }
+    
+    /* If 'cn_fix' set then determine appropriate channel for output file */
+    if (chnstr_fix !=NULL) {
+        if (tolower(chnstr_fix[0])=='a') channel_fix=1;
+        if (tolower(chnstr_fix[0])=='b') channel_fix=2;
+        if (tolower(chnstr_fix[0])=='c') channel_fix=3;
+        if (tolower(chnstr_fix[0])=='d') channel_fix=4;
+    }
 
     if (bmstr !=NULL)  parse_ebeam(bmstr);
 
@@ -479,7 +490,8 @@ int main(int argc,char *argv[]) {
     if (vb) vbuf=vstr;
 
     /* Set GridTable channel number according to command line options */
-    if (channel !=-1) grid->chn=channel;
+    if (channel_fix !=-1) grid->chn=channel_fix;
+    else if (channel !=-1) grid->chn=channel;
     else grid->chn=0;
 
     /* Store the velocity, power, width, and velocity error bounding threshold


### PR DESCRIPTION
This is necessary because data from UAF radars are written to a separate rawacf file for each channel. Once these data are processed into fitacf and then grid files, the original channel information (which was only identifiable from the rawacf filename) is no longer retained in the grid file. Users are now able to manually set the channel information stored in grid files for these radars by passing values of a,b,c, or d with the 'cn_fix' flag which will store an integer value of 1, 2, 3, or 4 respectively in the output grid file.  

(The previous commit / pull request had a bug where channels for Stereo radars were not being properly set; this has now been corrected and successfully tested)