### PR TITLE
Fixing issues with normalising CRI

### DIFF
--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/badlags_s.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/badlags_s.c
@@ -74,11 +74,11 @@ void FitACFBadlagsStereo(struct FitPrm *ptr, struct FitACFBadSample *bptr) {
     	   }
     	   /* If txpl is a valid value, lets set it as smsep and throw off a warning */
     	   if (first == 0) {
-	   	fprintf( stderr, "FitACFBadlagsStereo: WARNING using txpl instead of smsep...\n")
+	   	fprintf( stderr, "FitACFBadlagsStereo: WARNING using txpl instead of smsep...\n");
 	        first=1;
            }
            ptr->smsep = ptr->txpl;
-   
+    }   
 
     while (i < (ptr->mppul - 1)) {
 	/* first, skip over any pulses that occur before the first sample */

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/badlags_s.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/badlags_s.c
@@ -44,7 +44,7 @@ int maxbad=MAXBAD;
 
 void FitACFBadlagsStereo(struct FitPrm *ptr, struct FitACFBadSample *bptr) {
     int i, k, l, n, sample;
-    int first=0, step;
+    int first=0;
     long ts, t1=0, t2=0;
     int nbad;
     
@@ -66,18 +66,19 @@ void FitACFBadlagsStereo(struct FitPrm *ptr, struct FitACFBadSample *bptr) {
     t2 = 0L;
     
     /* the loops below assume that smsep is not zero...this is not always the case */
-    if ( ptr->smsep > 0) {
-    	step = ptr->smsep;
-    } else if ( ptr->txpl > 0) {
-	   if (first == 0) {
+    if ( ptr->smsep <= 0 ) {
+    	   /* First lets do a check to see if txpl is valid so that we can use that in place of smsep */
+    	   if ( ptr->txpl <= 0){
+    	   	fprintf( stderr, "FitACFBadlagsStereo: ERROR, both smsep and txpl are invalid...\n");
+    		return;
+    	   }
+    	   /* If txpl is a valid value, lets set it as smsep and throw off a warning */
+    	   if (first == 0) {
 	   	fprintf( stderr, "FitACFBadlagsStereo: WARNING using txpl instead of smsep...\n")
 	        first=1;
            }
-           step = ptr->txpl;
-    } else {
-    	fprintf( stderr, "FitACFBadlagsStereo: error, both smsep and txpl are invalid...\n");
-    	return;
-    }
+           ptr->smsep = ptr->txpl;
+   
 
     while (i < (ptr->mppul - 1)) {
 	/* first, skip over any pulses that occur before the first sample */
@@ -95,7 +96,7 @@ void FitACFBadlagsStereo(struct FitPrm *ptr, struct FitACFBadSample *bptr) {
 	
 	while (ts < t1) {
 	    sample++;
-	    ts += step;
+	    ts += ptr->smsep;
 	}
 	
 	/* ok, we now have a sample which occurs after the pulse starts.
@@ -115,7 +116,7 @@ void FitACFBadlagsStereo(struct FitPrm *ptr, struct FitACFBadSample *bptr) {
 	    badtmp[k] = sample;
 	    k++;
 	    sample++;
-	    ts += step;
+	    ts += ptr->smsep;
 	}
     }
 
@@ -154,7 +155,7 @@ void FitACFBadlagsStereo(struct FitPrm *ptr, struct FitACFBadSample *bptr) {
 
 	while (ts < t1)	{
 	    sample++;
-	    ts += step;
+	    ts += ptr->smsep;
 	}
 	
 	/*  ok, we now have a sample which occurs after the pulse starts.
@@ -173,7 +174,7 @@ void FitACFBadlagsStereo(struct FitPrm *ptr, struct FitACFBadSample *bptr) {
 	    badtmp[k] = sample;
 	    k++;
 	    sample++;
-	    ts += step;
+	    ts += ptr->smsep;
 	}
     }
 

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fit_acf.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fit_acf.c
@@ -403,7 +403,7 @@ int fit_acf (struct complex *acf,int range,
 
   if (fabs(omega_high - omega_low) >= 2*ptr->v_err) {
     ptr->v = omega_base;
-    ptr->v_err = fabs(omega_high - omega_low);
+    ptr->v_err = - ptr->v_err;
     }
   }
   

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/rang_badlags.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/rang_badlags.c
@@ -52,8 +52,15 @@ void r_overlap(struct FitPrm *ptr) {
   int diff_pulse;
 
   /* define constants */
-  tau = ptr->mpinc / ptr->smsep;
- 
+  /* Found a few cases where smsep isn't written or is zero.  So lets use txpl
+     in its place */
+  if (ptr->smsep != 0) {
+     tau = ptr->mpinc / ptr->smsep;
+  } else {
+     fprintf( stderr, "r_overlap: WARNING, using txpl instead of smsep...\n");
+     tau = ptr->mpinc / ptr->txpl;
+  }
+
   for (ck_pulse = 0; ck_pulse < ptr->mppul; ++ck_pulse) {
     for (pulse = 0; pulse < ptr->mppul; ++pulse) {
       diff_pulse = ptr->pulse[ck_pulse] - 

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/rang_badlags.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/rang_badlags.c
@@ -85,7 +85,7 @@ void lag_overlap(int range,int *badlag,struct FitPrm *ptr) {
   int bad_pulse[PULSE_SIZE];  /* 1 if there is a bad pulse */
   int i;
   double nave;
-   
+  double tot_cri; /* cumulative CRI power */ 
   --range;  /* compensate for the index which starts from 0 instead of 1 */
 
   nave = (double) (ptr->nave);
@@ -94,17 +94,19 @@ void lag_overlap(int range,int *badlag,struct FitPrm *ptr) {
       bad_pulse[pulse] = 0;
 
   for (ck_pulse = 0;  ck_pulse < ptr->mppul; ++ck_pulse) {
+      tot_cri=(double) 0;  /* Zeroing total CRI power for the next pulse sample */ 
     for (pulse = 0; pulse < ptr->mppul; ++pulse) {
       ck_range = range_overlap[ck_pulse][pulse] + range;
       if ((pulse != ck_pulse) && (0 <= ck_range) && 
-	      (ck_range < ptr->nrang)) {
-        pwr_ratio = (long) 1;  /*pwr_ratio = (long) (nave * MIN_PWR_RATIO);*/
+	      (ck_range < ptr->nrang)) 
+              tot_cri=tot_cri+ptr->pwr0[ck_range];  /* Accumulating CRI power */	      
+     }
+        pwr_ratio = (long) 1;  /*Power ratio threshold*/
         min_pwr =  pwr_ratio * ptr->pwr0[range];
-        if(min_pwr < ptr->pwr0[ck_range])
+        if(min_pwr < tot_cri)    /* Comparing lag 0 power of the checked sample (pulse) with cumulative lag 0 power from all interfering ranges */
         bad_pulse[ck_pulse] = 1;
       }
-    } 
-  }           
+               
   
   /* mark the bad lag */
 

--- a/codebase/superdarn/src.lib/tk/sim_data.1.0/src/sim_data.c
+++ b/codebase/superdarn/src.lib/tk/sim_data.1.0/src/sim_data.c
@@ -393,7 +393,8 @@ void sim_data(double *t_d, double *t_g, double *t_c, double *v_dop, int * qflg,
             /*calculate phase of scattered signal depending on its location*/
             phase = -4.*PI*(smptime*(v_dop[r]+range_gates[r][i].velo)+range_gates[r][i].space)/lambda;
             /*record scattered signal as a raw sample*/
-            raw_samples[smpnum] += amplitude*(cos(phase) + I*sin(phase));
+            /* raw_samples[smpnum] += amplitude*(cos(phase) + I*sin(phase)); */
+            raw_samples[smpnum] += amp0[r]*amplitude*(cos(phase) + I*sin(phase));
           }
         }
 
@@ -457,7 +458,8 @@ void sim_data(double *t_d, double *t_g, double *t_c, double *v_dop, int * qflg,
             /*calculate phase of scattered signal depending on its location*/
             phase = -4.*PI*(smptime*(v_dop[r]+range_gates[r][i].velo)+range_gates[r][i].space)/lambda;
             /*record scattered signal as a raw sample*/
-            raw_samples[smpnum] += amplitude*(cos(phase) + I*sin(phase));
+            /* raw_samples[smpnum] += amplitude*(cos(phase) + I*sin(phase)); */
+            raw_samples[smpnum] += amp0[r]*amplitude*(cos(phase) + I*sin(phase));
           }
         }
         /*calculate an ACF from the raw samples*/
@@ -541,11 +543,14 @@ void sim_data(double *t_d, double *t_g, double *t_c, double *v_dop, int * qflg,
 	{
     for(i=0;i<n_lags;i++)
     {
-      if(decayflg) out_acfs[r][i] = 1./(pow(r+1,2))*acfs[r][i]*amp0[r]/(nave*pwrtot/numtot);
-			else out_acfs[r][i] = acfs[r][i]*amp0[r]/(nave*pwrtot/numtot);
+      /* if(decayflg) out_acfs[r][i] = 1./(pow(r+1,2))*acfs[r][i]*amp0[r]/(nave*pwrtot/numtot);
+			else out_acfs[r][i] = acfs[r][i]*amp0[r]/(nave*pwrtot/numtot); */
+	if(decayflg) out_acfs[r][i] = 1./(pow(r+1,2))*acfs[r][i];
+		else out_acfs[r][i] = acfs[r][i];
       if(noise_flg)
       {
-        noise_acfs[r][i] *= noise_lev/(nave*npwrtot/nnumtot);
+        /* noise_acfs[r][i] *= noise_lev/(nave*npwrtot/nnumtot); */
+        noise_acfs[r][i] *= noise_lev;
         out_acfs[r][i] += noise_acfs[r][i];
       }
     }


### PR DESCRIPTION
In the original version, the echoes for all ranges were generated without scaling, i.e. effectively with the same lag 0 power. The dependence of the amplitude on range, amp0[r], has only been applied to the already simulated ACFs, which was also normalised on the average power across all ranges and divided by the number of avaraged pulses sequences. This post-scaling is incorrect with respect to the level of cross-range interference -- it was always the same regardless of amp0. I noticed the problem in 2013 but was able to locat its source only recently. The fix was rather simle: I (a) abandoned normalisation and (b) shifted scaling back into the simulation loop so that echoes from interfering ranges are accumulated with correct weights. Testing showed the expected changes in CRI levels at different ACF lags.