### PR TITLE
Fixing issues with normalising CRI (second try)

### DIFF
--- a/codebase/superdarn/src.lib/tk/sim_data.1.0/src/sim_data.c
+++ b/codebase/superdarn/src.lib/tk/sim_data.1.0/src/sim_data.c
@@ -393,7 +393,8 @@ void sim_data(double *t_d, double *t_g, double *t_c, double *v_dop, int * qflg,
             /*calculate phase of scattered signal depending on its location*/
             phase = -4.*PI*(smptime*(v_dop[r]+range_gates[r][i].velo)+range_gates[r][i].space)/lambda;
             /*record scattered signal as a raw sample*/
-            raw_samples[smpnum] += amplitude*(cos(phase) + I*sin(phase));
+            /* raw_samples[smpnum] += amplitude*(cos(phase) + I*sin(phase)); */
+            raw_samples[smpnum] += amp0[r]*amplitude*(cos(phase) + I*sin(phase));
           }
         }
 
@@ -457,7 +458,8 @@ void sim_data(double *t_d, double *t_g, double *t_c, double *v_dop, int * qflg,
             /*calculate phase of scattered signal depending on its location*/
             phase = -4.*PI*(smptime*(v_dop[r]+range_gates[r][i].velo)+range_gates[r][i].space)/lambda;
             /*record scattered signal as a raw sample*/
-            raw_samples[smpnum] += amplitude*(cos(phase) + I*sin(phase));
+            /* raw_samples[smpnum] += amplitude*(cos(phase) + I*sin(phase)); */
+            raw_samples[smpnum] += amp0[r]*amplitude*(cos(phase) + I*sin(phase));
           }
         }
         /*calculate an ACF from the raw samples*/
@@ -541,11 +543,14 @@ void sim_data(double *t_d, double *t_g, double *t_c, double *v_dop, int * qflg,
 	{
     for(i=0;i<n_lags;i++)
     {
-      if(decayflg) out_acfs[r][i] = 1./(pow(r+1,2))*acfs[r][i]*amp0[r]/(nave*pwrtot/numtot);
-			else out_acfs[r][i] = acfs[r][i]*amp0[r]/(nave*pwrtot/numtot);
+      /* if(decayflg) out_acfs[r][i] = 1./(pow(r+1,2))*acfs[r][i]*amp0[r]/(nave*pwrtot/numtot);
+			else out_acfs[r][i] = acfs[r][i]*amp0[r]/(nave*pwrtot/numtot); */
+	if(decayflg) out_acfs[r][i] = 1./(pow(r+1,2))*acfs[r][i];
+		else out_acfs[r][i] = acfs[r][i];
       if(noise_flg)
       {
-        noise_acfs[r][i] *= noise_lev/(nave*npwrtot/nnumtot);
+        /* noise_acfs[r][i] *= noise_lev/(nave*npwrtot/nnumtot); */
+        noise_acfs[r][i] *= noise_lev;
         out_acfs[r][i] += noise_acfs[r][i];
       }
     }


### PR DESCRIPTION
In the original version, the echoes for all ranges were generated without scaling, i.e. effectively with the same lag 0 power. The dependence of the amplitude on range, amp0[r], has only been applied to the already simulated ACFs, which was also normalised on the average power across all ranges and divided by the number of avaraged pulses sequences. This post-scaling is incorrect with respect to the level of cross-range interference -- it was always the same regardless of amp0. I noticed the problem in 2013 but was able to locat its source only recently. The fix was rather simle: I (a) abandoned normalisation and (b) shifted scaling back into the simulation loop so that echoes from interfering ranges are accumulated with correct weights. Testing showed the expected changes in CRI levels at different ACF lags.