### PR TITLE
Bug fix to makeall. Major version increment was not tracking properly.

### DIFF
--- a/codebase/base/src.bin/build/makeall.1.21/makeall.c
+++ b/codebase/base/src.bin/build/makeall.1.21/makeall.c
@@ -153,7 +153,8 @@ void add_make(char *name,char type) {
 
       /* now compare version numbers */
       if (major<makevmajor[k]) return;
-      if (minor<makevminor[k]) return;
+      if (minor<makevminor[k] && major == makevmajor[k]) return;
+			/* bugfix SGS: 17Feb2017 was returning when major> and minor< */
 
       makevmajor[k]=major;
       makevminor[k]=minor;


### PR DESCRIPTION
This is a one-line change with an addition comment line. It fixes a problem with incrementing major version numbers in the makeall function.