### PR TITLE
Compile without IDL access by removing DLMPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ your computer.
    In order to load the environment variables you just setup, you'll need to close your current terminal and
    open a new terminal.
 
+   Note: to compile without any IDL dependencies, comment out the DLMPATH entry in ~/rst/.profile/idl.bash
+
 2. Run `make.build` from the command line.  This runs a helper script that sets up other 
 compiling code.  The source code for make.build can be found in ~/rst/build/script/
 

--- a/build/script/make.code
+++ b/build/script/make.code
@@ -168,6 +168,30 @@ cp -vp *.a ${LIBPATH}
 # Get back to the old directory that we were in before
 cd ${currentdir}
 
+# This modification allows for automatic compilation for systems without IDL
+if [ ! -n "${DLMPATH}" ]; then
+  if [ -d ${RSTPATH}/codebase/superdarn/src.lib/tk/idl ]; then
+    currentdir=(`pwd`)
+    cd ${RSTPATH}/codebase/superdarn/src.lib/tk
+    tar -P -czvf idl.tar.gz idl
+    rm -R idl
+    cd ${currentdir}
+  fi
+else
+  if [ ! -d ${RSTPATH}/codebase/superdarn/src.lib/tk/idl ]; then
+    if [ -a ${RSTPATH}/codebase/superdarn/src.lib/tk/idl.tar.gz ]; then
+      currentdir=(`pwd`)
+      cd ${RSTPATH}/codebase/superdarn/src.lib/tk
+      tar -xzvf idl.tar.gz
+      rm idl.tar.gz
+      cd ${currentdir}
+    else
+      echo "Failed to locate IDL libraries for DLMs"
+      exit 1
+    fi
+  fi
+fi
+
 mkdir -p ${LOGPATH}
 makemodule hdr ${pkgdir}/build.txt
 makemodule lib ${pkgdir}/build.txt


### PR DESCRIPTION
This pull request modifies make.code to allow automatic compilation/recompilation without access to IDL by checking the length of the DLMPATH environment variable.  This way, users can compile the RST with or without IDL by modifying a single line in idl.bash (or idl.tcsh).