### PR TITLE
Improved automatic detection of whether to compile with/without IDL

### DIFF
--- a/build/script/make.code
+++ b/build/script/make.code
@@ -132,7 +132,8 @@ fi
 
 
 # This modification allows for automatic compilation for systems without IDL
-if [ ! -n "${DLMPATH}" ]; then
+if [ ! -r ${IDL_IPATH}/idl_export.h ]; then
+  echo "Failed to locate idl_export.h - will not compile IDL libraries or DLMs"
   if [ -d ${RSTPATH}/codebase/superdarn/src.lib/tk/idl ]; then
     currentdir=(`pwd`)
     cd ${RSTPATH}/codebase/superdarn/src.lib/tk
@@ -160,24 +161,24 @@ mkdir -p ${LOGPATH}
 makemodule hdr ${BUILD}/script/build.txt
 makemodule lib ${BUILD}/script/build.txt
 makemodule bin ${BUILD}/script/build.txt
-if [ -n "${DLMPATH}" ]
+if [ -r ${IDL_IPATH}/idl_export.h ]
 then 
-    makemodule dlm ${BUILD}/script/build.txt
+  makemodule dlm ${BUILD}/script/build.txt
 
-    mkdir -p ${RSTPATH}/idl
-    mkdir -p ${RSTPATH}/idl/lib
-    mkdir -p ${RSTPATH}/idl/app
+  mkdir -p ${RSTPATH}/idl
+  mkdir -p ${RSTPATH}/idl/lib
+  mkdir -p ${RSTPATH}/idl/app
 
-    cd ${RSTPATH}/idl/lib
-    ln -svf ../../codebase/analysis/src.idl/lib analysis
-    ln -svf ../../codebase/general/src.idl/lib general
-    ln -svf ../../codebase/superdarn/src.idl/lib superdarn
+  cd ${RSTPATH}/idl/lib
+  if ! [ -L analysis ]; then ln -svf ../../codebase/analysis/src.idl/lib analysis; fi
+  if ! [ -L general ]; then ln -svf ../../codebase/general/src.idl/lib general; fi
+  if ! [ -L superdarn ]; then  ln -svf ../../codebase/superdarn/src.idl/lib superdarn; fi
 
-    cd ${RSTPATH}/idl/app
-    ln -svf ../../codebase/superdarn/src.idl/app superdarn
+  cd ${RSTPATH}/idl/app
+  if ! [ -L superdarn ]; then ln -svf ../../codebase/superdarn/src.idl/app superdarn; fi
 
-    cd ${RSTPATH}/idl
-    ln -svf ../codebase/superdarn/src.idl/startup/startup.pro startup.pro
+  cd ${RSTPATH}/idl
+  if ! [ -L startup.pro ]; then ln -svf ../codebase/superdarn/src.idl/startup/startup.pro startup.pro; fi
 fi
 exit 0
 


### PR DESCRIPTION
This pull request modifies the make.code script to test for the presence of the idl_export.h within the $IDL_IPATH directory rather than testing if the $DLMPATH environment variable is set (as was implemented in a previous pull request).  This has the advantage of not requiring any additional steps for users to compile the RST if they don't have access to IDL.

A change has also been made to the way the symbolic links are created within the idl/ directory.  There was a small bug in the previous version where a dead link would be created within the codebase/superdarn/src.idl/app directory if you tried compiling multiple times.  This is now corrected by first testing whether the symbolic links have already been created during a previous compilation of the RST.

I've tested and confirmed that compilation still works without IDL on Debian 8.7.1, OpenSUSE 42.2, Mint 18.1, and Ubuntu 16.04.2 virtual machines on my laptop.  I've also verified that the symbolic links are now properly handled after multiple compilations on my desktop (Ubuntu 16.04) which has access to IDL.