### PR TITLE
Buffer overflow fix for oldfitdlm

### DIFF
--- a/codebase/superdarn/src.dlm/oldfitdlm.1.7/oldfitdlm.c
+++ b/codebase/superdarn/src.dlm/oldfitdlm.1.7/oldfitdlm.c
@@ -50,7 +50,7 @@ void OldFitIDLToFitFp(struct OldFitIDLFp *ifitfp,struct OldFitFp *fitfp) {
   fitfp->etime=ifitfp->etime;
   fitfp->time=ifitfp->time;
   strncpy(fitfp->header,ifitfp->header,80);
-  strncpy(fitfp->date,ifitfp->date,80);
+  strncpy(fitfp->date,ifitfp->date,32);
   strncpy(fitfp->extra,ifitfp->extra,256);
   fitfp->major_rev=ifitfp->major_rev;
   fitfp->minor_rev=ifitfp->minor_rev;
@@ -70,7 +70,7 @@ void OldFitFitFpToIDL(struct OldFitFp *fitfp,struct OldFitIDLFp *ifitfp) {
   ifitfp->etime=fitfp->etime;
   ifitfp->time=fitfp->time;
   strncpy(ifitfp->header,fitfp->header,80);
-  strncpy(ifitfp->date,fitfp->date,80);
+  strncpy(ifitfp->date,fitfp->date,32);
   strncpy(ifitfp->extra,fitfp->extra,256);
   ifitfp->major_rev=fitfp->major_rev;
   ifitfp->minor_rev=fitfp->minor_rev;

--- a/codebase/superdarn/src.idl/lib/legacy.1.6/fitlib.pro
+++ b/codebase/superdarn/src.idl/lib/legacy.1.6/fitlib.pro
@@ -68,7 +68,7 @@ function fitropen, fname
   common fitfp_com, ffp
 
   fileptr = long(0)
-  if (n_params() EQ 0) then name = pickfile() else name = fname
+  if (n_params() EQ 0) then name = dialog_pickfile() else name = fname
   s = strpos(name,".")
   if (s NE -1) then name = strmid(name,0,s)
 

--- a/codebase/superdarn/src.idl/lib/legacy.1.6/istplib.pro
+++ b/codebase/superdarn/src.idl/lib/legacy.1.6/istplib.pro
@@ -204,7 +204,7 @@ function open_istp_cdf,fname,sat=sat,dir=dir,inst=inst,datestr=datestr
     date1 = ' '
     read,date1
     if (strlen(date1) Eq 0) then begin
-      ;fname = pickfile(filter="*.cdf", path=dir)
+      ;fname = dialog_pickfile(filter="*.cdf", path=dir)
       flag = 1
     endif
   endelse

--- a/codebase/superdarn/src.idl/lib/legacy.1.6/rawlib.pro
+++ b/codebase/superdarn/src.idl/lib/legacy.1.6/rawlib.pro
@@ -78,7 +78,7 @@ function rawropen, fname
                       more_badrange, lags, rd_byte
 
   common rawfp_com, rfp
-  if (n_params() EQ 0) then name = pickfile() else name = fname
+  if (n_params() EQ 0) then name = dialog_pickfile() else name = fname
 
   splitpath,fname,path,name,ext
 


### PR DESCRIPTION
This pull request addresses the issue identified in #29 by correcting the size of the date string provided to strncpy (which previously would always result in a buffer overflow).  I had already identified this fix in #29, but I wasn't convinced that it was sufficient since a few other values in the prm structure such as bmazm were odd-looking values like -999.0.  After digging deeper into the code, I realized that bmazm is hardcoded to -999 for .fit files and is only calculated for fitacf files from the radar site information.

The other commit on this pull request addresses several warnings upon IDL startup about undefined calls to 'pickfile' in the legacy fitlib, istplib, and rawlib .pro libraries.  This function was "obsoleted" in IDL 5.0 and replaced by dialog_pickfile (http://northstar-www.dartmouth.edu/doc/idl/html_6.2/Obs_in_50.html).

To test, load the oldfitdlm in IDL and execute something like `fitfp = oldfitopen('/path/somefile.fit')` and then `ret = oldfitread(fitfp,prm,fit)`.  If you don't get kicked out of IDL by a buffer overflow / core dump then you're halfway there.  Next you can compare the contents of the prm and fit structures to the output of `fittofitacf /path/somefile.fit > /path/somefile.fitacf` and then `dmapdump -d /path/somefile.fitacf > /path/somefile.txt`