### PR TITLE
Modifying igrf_date variable in igrfcall.c to resolve naming conflict

### DIFF
--- a/codebase/analysis/src.lib/igrf/igrf.1.12/src/igrfcall.c
+++ b/codebase/analysis/src.lib/igrf/igrf.1.12/src/igrfcall.c
@@ -41,7 +41,7 @@
 #include "getshc.h"
 #include "shval3.h"
 
-double igrf_date=-1;
+double old_igrf_date=-1;
 
 
 char filmod[256][256];
@@ -81,12 +81,12 @@ int IGRFCall(double date, double flat, double flon,
       fclose(fp);
     }
 
-    if (igrf_date !=date) {
+    if (old_igrf_date !=date) {
       for (i=0;(dtemod[i] !=0) && (dtemod[i]<date);i++);
       if (i==0) return -1;
       i--;
 
-      igrf_date=date;
+      old_igrf_date=date;
       envstr=getenv("IGRF_PATH");
       
       sprintf(file1,"%s/%s",envstr,filmod[i]);


### PR DESCRIPTION
This pull request addresses a naming conflict between the igrf_date variables in igrfcall.c and igrflib.c (of the IGRF_v2 library).  This commit is necessary for any future attempts to link both the old and new IGRF libraries for the same binary.