### PR TITLE
Documentation cleanup

### DIFF
--- a/build/doc/sk/bin.local.sk
+++ b/build/doc/sk/bin.local.sk
@@ -45,9 +45,6 @@
 </div>
 
 <div id="tail">
-    <center><p>
-    &copy; Johns Hopkins Applied Physics Laboratory 2010
-    </p></center>
 </div>
 
 </div>

--- a/build/doc/sk/doc.home.local.sk
+++ b/build/doc/sk/doc.home.local.sk
@@ -44,9 +44,6 @@
 </div>
 
 <div id="tail">
-    <center><p>
-    &copy; Johns Hopkins Applied Physics Laboratory 2010
-    </p></center>
 </div>
 
 </div>

--- a/build/doc/sk/doc.index.local.sk
+++ b/build/doc/sk/doc.index.local.sk
@@ -74,9 +74,6 @@
 </div>
 
 <div id="tail">
-    <center><p>
-    &copy; Johns Hopkins Applied Physics Laboratory 2010
-    </p></center>
 </div>
 
 </div>

--- a/build/doc/sk/doc.root.local.sk
+++ b/build/doc/sk/doc.root.local.sk
@@ -13,7 +13,7 @@
 
 
 <div id="main">
-<center>Navigate by using the toolbar above or by clicking on the links below.</center>
+<center>Navigate by clicking on the links below.</center>
 <ul>
 <!--TOP-->
 <!--MAIN-->
@@ -24,9 +24,6 @@
 </div>
 
 <div id="tail">
-    <center><p>
-    &copy; Johns Hopkins Applied Physics Laboratory 2010
-    </p></center>
 </div>
 
 </div>

--- a/build/doc/sk/doc.root.www.sk
+++ b/build/doc/sk/doc.root.www.sk
@@ -14,7 +14,7 @@
 
 <div id="main">
 <br>
-<center>Navigate by using the toolbar above or by clicking on the links below.</center>
+<center>Navigate by clicking on the links below.</center>
 <ul>
 <!--TOP-->
 <!--MAIN-->

--- a/build/doc/sk/doc.section.local.sk
+++ b/build/doc/sk/doc.section.local.sk
@@ -20,7 +20,7 @@
 </div>
 
 <div id="main">
-<center>Navigate by using the toolbar above or by clicking on the links below.</center>
+<center>Navigate by clicking on the links below.</center>
 <ul>
 <!--TOP-->
 <!--MAIN-->
@@ -31,9 +31,6 @@
 </div>
 
 <div id="tail">
-    <center><p>
-    &copy; Johns Hopkins Applied Physics Laboratory 2010
-    </p></center>
 </div>
 
 </div>

--- a/build/doc/sk/doc.section.www.sk
+++ b/build/doc/sk/doc.section.www.sk
@@ -20,7 +20,7 @@
 </div>
 
 <div id="main">
-<center>Navigate by using the toolbar above or by clicking on the links below.</center>
+<center>Navigate by clicking on the links below.</center>
 <ul>
 <!--TOP-->
 <!--MAIN-->

--- a/build/doc/sk/lib.inx.local.sk
+++ b/build/doc/sk/lib.inx.local.sk
@@ -26,7 +26,7 @@
 <div id="main">
 <h2 class="doctitle"><!--LIBRARY--></h2>
 <br>
-<center>Navigate by using the toolbar above or by clicking on the links below.</center>
+<center>Navigate by clicking on the links below.</center>
 <br>
 <h4>Documentation XML Source:<!--XML--></h4>
 <h4>Functions:</h4>
@@ -73,9 +73,6 @@
 </div>
 
 <div id="tail">
-    <center><p>
-    &copy; Johns Hopkins Applied Physics Laboratory 2010
-    </p></center>
 </div>
 
 </div>

--- a/build/doc/sk/lib.inx.www.sk
+++ b/build/doc/sk/lib.inx.www.sk
@@ -24,7 +24,7 @@
 <div id="main">
 <h2 class="doctitle"><!--LIBRARY--></h2>
 <br>
-<center>Navigate by using the toolbar above or by clicking on the links below.</center>
+<center>Navigate by clicking on the links below.</center>
 <br>
 <h4>Documentation XML Source:<!--XML--></h4>
 <h4>Functions:</h4>

--- a/build/doc/sk/lib.local.sk
+++ b/build/doc/sk/lib.local.sk
@@ -47,9 +47,6 @@
 </div>
 
 <div id="tail">
-    <center><p>
-    &copy; Johns Hopkins Applied Physics Laboratory 2010
-    </p></center>
 </div>
 
 </div>
@@ -96,9 +93,6 @@
 </div>
 
 <div id="tail">
-    <center><p>
-    &copy; Johns Hopkins Applied Physics Laboratory 2010
-    </p></center>
 </div>
 </div>
 
@@ -145,9 +139,6 @@
 </div>
 
 <div id="tail">
-    <center><p>
-    &copy; Johns Hopkins Applied Physics Laboratory 2010
-    </p></center>
 </div>
 
 </div>

--- a/build/doc/sk/rfc.inx.local.sk
+++ b/build/doc/sk/rfc.inx.local.sk
@@ -42,9 +42,6 @@
 </div>
 
 <div id="tail">
-    <center><p>
-    &copy; Johns Hopkins Applied Physics Laboratory 2010
-    </p></center>
 </div>
 
 </div>

--- a/build/doc/sk/rfc.local.sk
+++ b/build/doc/sk/rfc.local.sk
@@ -54,9 +54,6 @@
 </div>
 
 <div id="tail">
-    <center><p>
-    &copy; Johns Hopkins Applied Physics Laboratory 2010
-    </p></center>
 </div>
 
 </div>

--- a/build/doc/sk/tutorial.inx.local.sk
+++ b/build/doc/sk/tutorial.inx.local.sk
@@ -51,9 +51,6 @@
 </div>
 
 <div id="tail">
-    <center><p>
-    &copy; Johns Hopkins Applied Physics Laboratory 2010
-    </p></center>
 </div>
 
 </div>

--- a/build/doc/sk/tutorial.local.sk
+++ b/build/doc/sk/tutorial.local.sk
@@ -44,9 +44,6 @@
 
 
 <div id="tail">
-    <center><p>
-    &copy; Johns Hopkins Applied Physics Laboratory 2010
-    </p></center>
 </div>
 
 </div>


### PR DESCRIPTION
This pull request fixes some of the generic text in the html documentation.  Testing should be unnecessary as no functional code has been modified.  A temporary copy of the documentation may be found here:

https://engineering.dartmouth.edu/superdarn/documentation/index.html

Note that a lot of the gridding and map potential documentation is incomplete and is being updated on a separate branch.