### PR TITLE
Adding historical RST version log info to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,35 @@ You can find the latest release at: http://cdf.gsfc.nasa.gov/
    stored in ~/rst/log.  The source code for make.build and make.code can be found in
    ~/rst/build/script/
 
+
+### Historical Version Log
+
+
+- 3.3   -  Final bug fixes and updates of the 3.x series
+- 3.2   -  First release with DLM support
+- 3.1   -  First release of ROS 3
+- 2.11  -  added support for I&Q sample analysis
+- 2.10  -  bug fixes to the fitacfex library and rnk hardware.dat
+- 2.09  -  fixed known errors in the documentation - gold release
+- 2.08  -  further bug fixes, fitacfex and documentation system
+           included. 
+- 2.07  -  introduced fitacf version 2.0 and numerous bug fixes
+- 2.06  -  introduction of the origin flag and the beam azimuth parameter
+           together with numerous bug fixes
+- 2.05  -  modification to deal with arbitrary numbers of radar beams
+- 2.04  -  bug fixes from the deployment of the Radar Operating System
+- 2.03  -  added ksh enviroment as an option plus more bug fixes
+- 2.02  -  more bug fixes and more XML documentation completed.
+- 2.01  -  various bug fixes and improvements to the IDL libraries
+- 2.00  -  code adopted as official release.
+- 1.07  -  numerous bug fixes.
+- 1.06  -  completed IDL interfaces for grid and map data, incorporated help
+           and error messages derived from XML documentation.
+- 1.05  -  adopted the DataMap format for grid and map data, incorporated
+           outline documentation and fixed a lot of bugs.
+- 1.04  -  general bug fixes, addition of Mac OS X support
+- 1.03  -  implemented the legacy IDL interfaces and incorporated the
+           data tables into this release
+- 1.02  -  incorporated the IDL interfaces and fixed a lot of bugs
+- 1.01  -  initial revision of the code.
+

--- a/README.md
+++ b/README.md
@@ -52,31 +52,31 @@ You can find the latest release at: http://cdf.gsfc.nasa.gov/
 ### Historical Version Log
 
 
-- 3.3   -  Final bug fixes and updates of the 3.x series
-- 3.2   -  First release with DLM support
-- 3.1   -  First release of ROS 3
-- 2.11  -  added support for I&Q sample analysis
-- 2.10  -  bug fixes to the fitacfex library and rnk hardware.dat
-- 2.09  -  fixed known errors in the documentation - gold release
+- 3.3   -  Final bug fixes and updates of the 3.x series (Aug 2011)
+- 3.2   -  First release with DLM support (Nov 2010)
+- 3.1   -  First release of ROS 3 (Jun 2010)
+- 2.11  -  added support for I&Q sample analysis (Mar 2008)
+- 2.10  -  bug fixes to the fitacfex library and rnk hardware.dat (Jun 2007)
+- 2.09  -  fixed known errors in the documentation - gold release (Mar 2007)
 - 2.08  -  further bug fixes, fitacfex and documentation system
            included. 
 - 2.07  -  introduced fitacf version 2.0 and numerous bug fixes
 - 2.06  -  introduction of the origin flag and the beam azimuth parameter
            together with numerous bug fixes
-- 2.05  -  modification to deal with arbitrary numbers of radar beams
-- 2.04  -  bug fixes from the deployment of the Radar Operating System
+- 2.05  -  modification to deal with arbitrary numbers of radar beams (Apr 2006)
+- 2.04  -  bug fixes from the deployment of the Radar Operating System (Feb 2006)
 - 2.03  -  added ksh enviroment as an option plus more bug fixes
 - 2.02  -  more bug fixes and more XML documentation completed.
-- 2.01  -  various bug fixes and improvements to the IDL libraries
-- 2.00  -  code adopted as official release.
+- 2.01  -  various bug fixes and improvements to the IDL libraries (Jul 2005)
+- 2.00  -  code adopted as official release. (Apr 2005)
 - 1.07  -  numerous bug fixes.
 - 1.06  -  completed IDL interfaces for grid and map data, incorporated help
-           and error messages derived from XML documentation.
+           and error messages derived from XML documentation. (Nov 2004)
 - 1.05  -  adopted the DataMap format for grid and map data, incorporated
-           outline documentation and fixed a lot of bugs.
-- 1.04  -  general bug fixes, addition of Mac OS X support
+           outline documentation and fixed a lot of bugs. (Oct 2004)
+- 1.04  -  general bug fixes, addition of Mac OS X support (Sep 2004)
 - 1.03  -  implemented the legacy IDL interfaces and incorporated the
-           data tables into this release
-- 1.02  -  incorporated the IDL interfaces and fixed a lot of bugs
+           data tables into this release (Aug 2004)
+- 1.02  -  incorporated the IDL interfaces and fixed a lot of bugs (Aug 2004)
 - 1.01  -  initial revision of the code.
 


### PR DESCRIPTION
This pull request adds historical Version Log information to the bottom of the README.md file.  This was pulled from previous releases of the RST and will help us retain information about development milestones from the pre-VTRST3.5 era.