### PR TITLE
Fix fitacf.2.5

### DIFF
--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/badlags_s.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/badlags_s.c
@@ -134,7 +134,7 @@ void FitACFBadlagsStereo(struct FitPrm *ptr, struct FitACFBadSample *bptr) {
     offset=ptr->offset;
     if (ptr->channel==1) offset=-offset;
 
-    if (offset==0) return;
+   /* if (offset==0) return; */
 
 
     while ( offset != 0 && i < (ptr->mppul - 1) && k < maxbad ) {

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/do_fit.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/do_fit.c
@@ -203,7 +203,7 @@ int do_fit(struct FitBlock *iptr,int lag_lim,int goose,
         return -1;
     }
 
-    if (iptr->prm.channel==0) FitACFBadlags(&iptr->prm,&badsmp);
+    if (iptr->prm.offset==0) FitACFBadlags(&iptr->prm,&badsmp);
     else FitACFBadlagsStereo(&iptr->prm,&badsmp);
 
 


### PR DESCRIPTION
These changes fix problems with processing two-channel non-stereo data like the two-frequency mode from Canadian radars, in which different channels are assigned to different frequencies. 