### PR TITLE
Fixing hour/minute logic discrepancy in test_fitacf.c

### DIFF
--- a/codebase/superdarn/src.bin/tk/testing/test_fitacf.1.0/test_fitacf.c
+++ b/codebase/superdarn/src.bin/tk/testing/test_fitacf.1.0/test_fitacf.c
@@ -208,19 +208,21 @@ int main(int argc,char *argv[]) {
 
   if (vb)
       fprintf(stderr,"%d-%d-%d %d:%d:%d beam=%d\n",prm->time.yr,prm->time.mo,
-	     prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
+        prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
 
   fblk=FitACFMake(site,prm->time.yr);
 
-	if(prm->time.hr >= tgthr && prm->time.mt >= tgtmin && prm->time.sc >= tgtsec && prm->bmnum == tgtbeam && prm->channel != 2)
-	{
-		FitACFT(prm,raw,fblk,fit,1);
-		done=1;
-	}
+    if(prm->time.hr >= tgthr && prm->time.mt >= tgtmin && prm->time.sc >= tgtsec && prm->bmnum == tgtbeam && prm->channel != 2)
+    {
+        fprintf(stdout,"%d  %d  %d  %d  %d  %d  %d  %d\n",prm->stid,prm->time.yr,prm->time.mo,
+            prm->time.dy,prm->time.hr,prm->time.mt,(int)prm->time.sc,prm->bmnum);
+        FitACFT(prm,raw,fblk,fit,1);
+        done=1;
+    }
 
 
   do
-	{
+    {
 
 
     ctime = time((time_t) 0);
@@ -230,21 +232,23 @@ int main(int argc,char *argv[]) {
     RadarParmSetOriginTime(prm,tmstr);
 
     if (old)
-			status=OldRawRead(rawfp,prm,raw);
+        status=OldRawRead(rawfp,prm,raw);
     else
-			status=RawFread(fp,prm,raw);
+        status=RawFread(fp,prm,raw);
 
      if (vb)
       fprintf(stderr,"%d-%d-%d %d:%d:%d beam=%d\n",prm->time.yr,prm->time.mo,
-	     prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
+         prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
 
 
     if(prm->time.hr >= tgthr && prm->time.mt >= tgtmin && prm->time.sc >= tgtsec && prm->bmnum == tgtbeam
-				&& status == 0 && !done && prm->channel != 2)
-		{
-			FitACFT(prm,raw,fblk,fit,1);
-			done = 1;
-		}
+        && status == 0 && !done && prm->channel != 2)
+    {
+        fprintf(stdout,"%d  %d  %d  %d  %d  %d  %d  %d\n",prm->stid,prm->time.yr,prm->time.mo,
+                prm->time.dy,prm->time.hr,prm->time.mt,(int)prm->time.sc,prm->bmnum);
+        FitACFT(prm,raw,fblk,fit,1);
+        done = 1;
+    }
 
 
   } while (status==0 && !done);

--- a/codebase/superdarn/src.bin/tk/testing/test_fitacf.1.0/test_fitacf.c
+++ b/codebase/superdarn/src.bin/tk/testing/test_fitacf.1.0/test_fitacf.c
@@ -206,17 +206,14 @@ int main(int argc,char *argv[]) {
     strcat(command,argv[c]);
   }
 
-
   if (vb)
       fprintf(stderr,"%d-%d-%d %d:%d:%d beam=%d\n",prm->time.yr,prm->time.mo,
 	     prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
 
   fblk=FitACFMake(site,prm->time.yr);
 
-	if(prm->time.hr == tgthr && prm->time.mt == tgtmin && prm->time.sc >= tgtsec && prm->bmnum == tgtbeam && prm->channel != 2)
+	if(prm->time.hr >= tgthr && prm->time.mt >= tgtmin && prm->time.sc >= tgtsec && prm->bmnum == tgtbeam && prm->channel != 2)
 	{
-		fprintf(stdout,"%d  %d  %d  %d  %d  %d  %d  %d\n",prm->stid,prm->time.yr,prm->time.mo,
-									prm->time.dy,prm->time.hr,prm->time.mt,(int)prm->time.sc,prm->bmnum);
 		FitACFT(prm,raw,fblk,fit,1);
 		done=1;
 	}
@@ -242,11 +239,9 @@ int main(int argc,char *argv[]) {
 	     prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
 
 
-    if(prm->time.hr == tgthr && prm->time.mt == tgtmin && prm->time.sc >= tgtsec && prm->bmnum == tgtbeam
+    if(prm->time.hr >= tgthr && prm->time.mt >= tgtmin && prm->time.sc >= tgtsec && prm->bmnum == tgtbeam
 				&& status == 0 && !done && prm->channel != 2)
 		{
-			fprintf(stdout,"%d  %d  %d  %d  %d  %d  %d  %d\n",prm->stid,prm->time.yr,prm->time.mo,
-									prm->time.dy,prm->time.hr,prm->time.mt,(int)prm->time.sc,prm->bmnum);
 			FitACFT(prm,raw,fblk,fit,1);
 			done = 1;
 		}
@@ -258,16 +253,3 @@ int main(int argc,char *argv[]) {
   if (old) OldRawClose(rawfp);
   return 0;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This commit changes the logic used to test the input or 'target' hour and minute against the time.hr and time.mt values in the prm block of the rawacf file(s) to match the logic used by test_fitex2 and test_lmfit. The current method in test_fitacf which searches for the exact hour and minute often causes the routine to miss a record which may be only a few seconds after the desired time. For reference, see:

https://github.com/SuperDARN/rst/blob/develop/codebase/superdarn/src.bin/tk/testing/test_lmfit.1.0/test_lmfit.c#L221
and
https://github.com/SuperDARN/rst/blob/develop/codebase/superdarn/src.bin/tk/testing/test_fitex2.1.0/test_fitex2.c#L223

Practically speaking, this should fix the issue on the VT website where the default options for the ACF Plotting Tools page (http://vt.superdarn.org/tiki-index.php?page=ACF+Plotting+Tools) gives you a broken link.  My only doubt is whether the fprintf to stdout statements that I've removed are actually necessary.  I don't think so after looking at the other testing tools and the make_fit routine but someone else should verify that.