### PR TITLE
installation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ For macOS it is also available through macports, as are all listed dependencies
 
 
 1. Upon cloning the repository (with git clone or downloading zip file), make sure the RST
-   environment variables are properly set.   In ~/rst/.profile.bash:
+   environment variables are properly set.   In `~/rst/.profile.bash`:
 
    OSTYPE="linux" for any linux operating system or "darwin" for macOS
    SYSTEM="linux" or "darwin" as appropriate
 
-   In ~/rst/.profile/base.bash, check to make sure these paths are appropriate:
+   In `~/rst/.profile/base.bash`, check to make sure these paths are appropriate:
 
-   XPATH, NETCDF_PATH, CDF_PATH
+   `XPATH, NETCDF_PATH, CDF_PATH`
 
-   If you have IDL, check to see that `IDL_IPATH` in ~/rst/.profile/idl.bash is correct.
+   If you have IDL, check to see that `IDL_IPATH` in `~/rst/.profile/idl.bash` is correct.
    (Note: for users without access to IDL, modifying the `IDL_IPATH` environment variable is
    not required).
 
 2. Load the RST environment variables.  For example, this is accomplished in linux by modifying
-   the ~/.bashrc file by adding:
+   the `~/.bashrc` file by adding:
 
         # bash profile for rst
         export RSTPATH="INSTALL LOCATION"/rst
@@ -48,29 +48,32 @@ For macOS it is also available through macports, as are all listed dependencies
    where the INSTALL LOCATION is the path with the RST repository that has been copied to your
    computer.  In order to load the environment variables you just setup, you'll need to close 
    your current terminal and open a new terminal, or from the command line type:
-
-   	source ~/.bashrc
+   
+       source ~/.bashrc
 
 3. Change directory to `$RSTPATH/build/script` and run `make.build` from the command line.
    This runs a helper script that sets up other compiling code.
 
 4. In the same directory run `make.code superdarn rst` to compile all of the code.
    This runs a script to find all of the source codes and compile them into binaries.
-   A log of this compilation is stored in $RSTPATH/log.
+   A log of this compilation is stored in `$RSTPATH/log`.
 
    4a.	 If you don't have IDL and the IDL skip in make.code fails, you will see an error
    	 upon the inability to locate `idl_export.h`.  If this happens:
 
+	 ```
 	 cd $RSTPATH/codebase/superdarn/src.lib/tk
 	 tar -P -czuf idl.tar.gz idl
 	 rm -rf idl
 	 cd $RSTPATH/build/script
 	 make.code superdarn rst
+	 ```
 
    4b.	 If the order of make.code is executed incorrectly, you will see an error upon
    	 the inability to locate a header file (i.e. `sza.h`).  If this happens (using
 	 `sza.h` as an example):
 
+	 ```
 	 find $RSTPATH -name "sza.h"
 	 >> $RSTPATH/codebase/imagery/src.lib/sza.1.9/include/sza.h
 	 cd $RSTPATH/codebase/imagery/src.lib/sza.1.9/src
@@ -78,10 +81,11 @@ For macOS it is also available through macports, as are all listed dependencies
 	 make
 	 cd $RSTPATH/build/script
 	 make.code superdarn rst
+	 ```
 
 5. To compile the html documentation, run `make.doc.rfc codebase superdarn` and
    `make.doc superdarn rst` from the command line. You may need to modify the `URLBASE`
-   environment variable in ~/rst/.profile/rst.bash for the links in the html pages to
+   environment variable in `$RSTPATH/.profile/rst.bash` for the links in the html pages to
    function correctly.  Temporary documentation is available at:
 
    http://superdarn.thayer.dartmouth.edu/documentation/index.html

--- a/README.md
+++ b/README.md
@@ -3,29 +3,38 @@ Radar Software Toolkit
 
 In addition to this code, you will need the following packages:
 
-Debian 8.7 | Mint 18.1 | OpenSUSE 42.2 | Ubuntu 16.04
----------- | --------- | ------------- | ------------
-gcc | libc6-dev | gcc | libhdf5-serial-dev
-libhdf5-serial-dev | libncurses5-dev | hdf5-devel | libncurses-dev
-libnetcdf-dev | libnetcdf-dev | libpng16-devel | libnetcdf-dev
-libncurses | libpng16-dev | libX11-devel | libpng12-dev
-libpng12-dev | libx11-dev | libXext6 | libx11-dev
-libx11-dev | libxext-dev | libXext-devel | libxext-dev
-libxext-dev | | netcdf | netpbm
-netpbm | | netcdf-devel |
- | | | ncurses-devel |
- | | | zlib-devel |
+Debian 8.7 | Mint 18.1 | OpenSUSE 42.2 | Ubuntu 16.04 | macOS 10.12.4
+---------- | --------- | ------------- | ------------ | --------------
+gcc | libc6-dev | gcc | libhdf5-serial-dev | libhdf5
+libhdf5-serial-dev | libncurses5-dev | hdf5-devel | libncurses-dev | libnetcdf
+libnetcdf-dev | libnetcdf-dev | libpng16-devel | libnetcdf-dev | libcurses
+libncurses | libpng16-dev | libX11-devel | libpng12-dev | libpng16
+libpng12-dev | libx11-dev | libXext6 | libx11-dev | libx11
+libx11-dev | libxext-dev | libXext-devel | libxext-dev | cdf
+libxext-dev | | netcdf | netpbm | netpdm (10.77.03_2+x11)
+netpbm | | netcdf-devel | |
+ | | | ncurses-devel | |
+ | | | zlib-devel | |
 
 You will also need the CDF (Common Data Format) library which can be downloaded from NASA.
 You can find the latest release at: http://cdf.gsfc.nasa.gov/
+For macOS it is also available through macports, as are all listed dependencies
 
 
 ## Install notes:
 
 
 1. Upon cloning the repository (with git clone or downloading zip file), make sure the RST
-   environment variables are properly set.  In particular, make sure `CDF_PATH` in
-   ~/rst/.profile/base.bash and `IDL_IPATH` in ~/rst/.profile/idl.bash are correct.
+   environment variables are properly set.   In ~/rst/.profile.bash:
+
+   OSTYPE="linux" for any linux operating system or "darwin" for macOS
+   SYSTEM="linux" or "darwin" as appropriate
+
+   In ~/rst/.profile/base.bash, check to make sure these paths are appropriate:
+
+   XPATH, NETCDF_PATH, CDF_PATH
+
+   If you have IDL, check to see that `IDL_IPATH` in ~/rst/.profile/idl.bash is correct.
    (Note: for users without access to IDL, modifying the `IDL_IPATH` environment variable is
    not required).
 
@@ -38,20 +47,44 @@ You can find the latest release at: http://cdf.gsfc.nasa.gov/
 
    where the INSTALL LOCATION is the path with the RST repository that has been copied to your
    computer.  In order to load the environment variables you just setup, you'll need to close 
-   your current terminal and open a new terminal.
+   your current terminal and open a new terminal, or from the command line type:
 
-3. Run `make.build` from the command line.  This runs a helper script that sets up other 
-   compiling code.
+   	source ~/.bashrc
 
-4. Run `make.code superdarn rst` to compile all of the code.  This runs a script to find
-   all of the source codes and compile them into binaries.  A log of this compilation is
-   stored in ~/rst/log.  The source code for make.build and make.code can be found in
-   ~/rst/build/script/
+3. Change directory to `$RSTPATH/build/script` and run `make.build` from the command line.
+   This runs a helper script that sets up other compiling code.
+
+4. In the same directory run `make.code superdarn rst` to compile all of the code.
+   This runs a script to find all of the source codes and compile them into binaries.
+   A log of this compilation is stored in $RSTPATH/log.
+
+   4a.	 If you don't have IDL and the IDL skip in make.code fails, you will see an error
+   	 upon the inability to locate `idl_export.h`.  If this happens:
+
+	 cd $RSTPATH/codebase/superdarn/src.lib/tk
+	 tar -P -czuf idl.tar.gz idl
+	 rm -rf idl
+	 cd $RSTPATH/build/script
+	 make.code superdarn rst
+
+   4b.	 If the order of make.code is executed incorrectly, you will see an error upon
+   	 the inability to locate a header file (i.e. `sza.h`).  If this happens (using
+	 `sza.h` as an example):
+
+	 find $RSTPATH -name "sza.h"
+	 >> $RSTPATH/codebase/imagery/src.lib/sza.1.9/include/sza.h
+	 cd $RSTPATH/codebase/imagery/src.lib/sza.1.9/src
+	 make clean
+	 make
+	 cd $RSTPATH/build/script
+	 make.code superdarn rst
 
 5. To compile the html documentation, run `make.doc.rfc codebase superdarn` and
    `make.doc superdarn rst` from the command line. You may need to modify the `URLBASE`
    environment variable in ~/rst/.profile/rst.bash for the links in the html pages to
-   function correctly.
+   function correctly.  Temporary documentation is available at:
+
+   http://superdarn.thayer.dartmouth.edu/documentation/index.html
 
 
 ### Historical Version Log

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ For macOS it is also available through macports, as are all listed dependencies
 1. Upon cloning the repository (with git clone or downloading zip file), make sure the RST
    environment variables are properly set.   In `~/rst/.profile.bash`:
 
-   OSTYPE="linux" for any linux operating system or "darwin" for macOS
-   SYSTEM="linux" or "darwin" as appropriate
+       OSTYPE="linux" for any linux operating system or "darwin" for macOS
+       SYSTEM="linux" or "darwin" as appropriate
 
    In `~/rst/.profile/base.bash`, check to make sure these paths are appropriate:
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For macOS it is also available through macports, as are all listed dependencies
    
        source ~/.bashrc
 
-3. Change directory to `$RSTPATH/build/script` and run `make.build` from the command line.
+3. Run `make.build` from the command line.  You may need to change directory to `$RSTPATH/build/script`.
    This runs a helper script that sets up other compiling code.
 
 4. In the same directory run `make.code superdarn rst` to compile all of the code.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ libnetcdf-dev | libnetcdf-dev | libpng16-devel | libnetcdf-dev | libcurses
 libncurses | libpng16-dev | libX11-devel | libpng12-dev | libpng16
 libpng12-dev | libx11-dev | libXext6 | libx11-dev | libx11
 libx11-dev | libxext-dev | libXext-devel | libxext-dev | cdf
-libxext-dev | | netcdf | netpbm | netpdm (10.77.03_2+x11)
+libxext-dev | | netcdf | netpbm | netpbm (10.77.03_2+x11)
 netpbm | | netcdf-devel | |
  | | | ncurses-devel | |
  | | | zlib-devel | |

--- a/build/make/makebin.darwin
+++ b/build/make/makebin.darwin
@@ -12,7 +12,7 @@ CFLAGS = -Wall -O3 -ansi -D_GNU_SOURCE -D_DARWIN -I/opt/local/include
 ifdef XPATH
   ifdef XLIB
     CFLAGS += -D_XLIB_
-    XLIBS=-L/usr/X11R6/lib -lX11 -lXext
+    XLIBS=-L$(XPATH)/lib -lX11 -lXext
   endif
 else 
    XLIB=

--- a/build/make/makebin.linux
+++ b/build/make/makebin.linux
@@ -12,7 +12,7 @@ CFLAGS+=-fPIC -Wall -O3 -ansi -D_GNU_SOURCE -D_LINUX
 ifdef XPATH
   ifdef XLIB
     CFLAGS += -D_XLIB_
-    XLIBS=-L/usr/X11R6/lib -lX11 -lXext
+    XLIBS=-L$(XPATH)/lib -lX11 -lXext
   endif
 else 
     XLIB=


### PR DESCRIPTION
Updated makebin.* files to use XPATH environment variable instead of
hardcoding X11 library directory

Updated README.md to include macOS dependencies, list of all
environment variables that need to be updated, and solutions to
problems encountered during macOS sierra installation.