### PR TITLE
Abandoning negative velocity error values

### DIFF
--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fit_acf.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fit_acf.c
@@ -321,8 +321,8 @@ int fit_acf (struct complex *acf,int range,
 
         if (fabs(omega_high - omega_low) >= 2*ptr->v_err) {
             ptr->v = omega_base;
-            ptr->v_err = - ptr->v_err;
-        }
+        
+         }
     }
 
 


### PR DESCRIPTION
The negative values of the velocity erros were designed as an indicator that the piece-wise esitmate of the phase slope by `omega_guess` failed due to lack of the consecutive "good" lags (in this case the phase fit is still performed). The above sign change might be useful for testing purposes but it might cause lots of confusion while using fitting errors in generating electric field distribution, and I decided to abandon the negative error values.