### PR TITLE
Fixing some final documentation bugs

### DIFF
--- a/codebase/base/src.lib/graphic/fbuffer.1.18/doc/fbuffer.doc.xml
+++ b/codebase/base/src.lib/graphic/fbuffer.1.18/doc/fbuffer.doc.xml
@@ -7,7 +7,7 @@
 <name>FrameBufferBezier</name>
 <location>src.lib/graphic/fbuffer</location>
 <header>base/rfbuffer.h</header>
-<syntax>int FrameBufferBezier(<sn href="structFrameBuffer.html">struct FrameBuffer</sn> *ptr, int x1,int y1,int x2,int y2, int x3,int y3,int x4,int y4,float step, unsigned int color,unsigned char m,int width, <sn href="structFrameBufferDash.html">struct FrameBufferDash</sn> *dash, <sn href="strucFrameBufferClip.html">struct FrameBufferClip</sn> *clip);</syntax>
+<syntax>int FrameBufferBezier(<sn href="structFrameBuffer.html">struct FrameBuffer</sn> *ptr, int x1,int y1,int x2,int y2, int x3,int y3,int x4,int y4,float step, unsigned int color,unsigned char m,int width, <sn href="structFrameBufferDash.html">struct FrameBufferDash</sn> *dash, <sn href="structFrameBufferClip.html">struct FrameBufferClip</sn> *clip);</syntax>
 
 
 <description><p>The <fn href="FrameBufferBezier.html">FrameBufferBezier</fn> function plots a bezier curve.</p>
@@ -76,7 +76,7 @@
 <location>src.lib/graphic/fbuffer</location>
 <header>base/rfbuffer.h</header>
 <syntax><sn href="structFrameBuffer.html">struct FrameBuffer</sn> *FrameBufferCopy(<sn href="structFrameBuffer.html">struct FrameBuffer</sn> *src);</syntax>
-<description><p>The <fn href="FrameBufferCopyr.html">FrameBufferCopy</fn> function copies a frame buffer.</p>
+<description><p>The <fn href="FrameBufferCopy.html">FrameBufferCopy</fn> function copies a frame buffer.</p>
 <p>The argument <ar>src</ar> is a pointer to the frame buffer to copy.</p> 
 </description>
 
@@ -524,9 +524,7 @@ int pixel(int wdt,int hgt,char *img,char *msk, int x,int y,int depth,int off,int
 <p>The red, green, blue and alpha components of the color to use for the point are given by the arguments <ar>r</ar>, <ar>g</ar>, <ar>b</ar> and <ar>a</ar>.
 </p>
 
-<p>The <ar>data</ar> argument of the <fn href="FrameBufferSetUser.html">FrameBufferSetUser</fn> function is passed directly as the <ar>dptr</ar> argument and allows extra parameters to be passed to the function.
-
-</description>
+<p>The <ar>data</ar> argument of the <fn href="FrameBufferSetUser.html">FrameBufferSetUser</fn> function is passed directly as the <ar>dptr</ar> argument and allows extra parameters to be passed to the function.</p>
 
 
 </description>
@@ -579,7 +577,7 @@ int pixel(int wdt,int hgt,char *img,char *msk, int x,int y,int depth,int off,int
 <header>base/rfbuffer.h</header>
 <syntax>int FrameBufferXMLEnd(char *name,char *buf,int sze,void *data);</syntax>
 <description><p>The <fn href="FrameBufferXMLEnd.html">FrameBufferXMLEnd</fn> function is a parser function that is used by the XML parser to read frame buffer images stored in XML format.</p>
-<p>The function is called by the XML parser when an end tag is encountered in the XML document. The function expects the argument <ar>data</ar> to be a pointer to a structure of type <sn href="structFrameBufferXML">struct FrameBufferXML</sn>.</p>
+<p>The function is called by the XML parser when an end tag is encountered in the XML document. The function expects the argument <ar>data</ar> to be a pointer to a structure of type <sn href="structFrameBufferXML.html">struct FrameBufferXML</sn>.</p>
 </description>
 
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
@@ -594,7 +592,7 @@ int pixel(int wdt,int hgt,char *img,char *msk, int x,int y,int depth,int off,int
 
 
 <description><p>The <fn href="FrameBufferXMLStart.html">FrameBufferXMLStart</fn> function is a parser function that is used by the XML parser to read frame buffer images stored in XML format.</p>
-<p>The function is called by the XML parser when a new tag is encountered in the XML document. The function expects the argument <ar>data</ar> to be a pointer to a structure of type <sn href="structFrameBufferXML">struct FrameBufferXML</sn>.</p>
+<p>The function is called by the XML parser when a new tag is encountered in the XML document. The function expects the argument <ar>data</ar> to be a pointer to a structure of type <sn href="structFrameBufferXML.html">struct FrameBufferXML</sn>.</p>
 </description>
 
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
@@ -802,7 +800,7 @@ int pixel(int wdt,int hgt,char *img,char *msk, int x,int y,int depth,int off,int
       <description>None.</description>
     </member>
     <member>
-      <proto><sn href="&root;/src.lib/xml/xml/structXMLdata.html">struct XMLdata</sn> *xml;</proto>
+      <proto><sn href="&root;/base/src.lib/xml/xml/structXMLdata.html">struct XMLdata</sn> *xml;</proto>
       <description>None.</description>
     </member>
     <member>
@@ -819,7 +817,7 @@ int pixel(int wdt,int hgt,char *img,char *msk, int x,int y,int depth,int off,int
  <header>base/rfbuffer.h</header>
  <struct>  
     <member>
-      <proto><sn href="&root;/src.lib/xml/xml/structXMLdata.html">struct XMLdata</sn> *xml;</proto>
+      <proto><sn href="&root;/base/src.lib/xml/xml/structXMLdata.html">struct XMLdata</sn> *xml;</proto>
       <description>None.</description>
     </member>
     <member>

--- a/codebase/base/src.lib/graphic/fontdb.1.9/doc/fontdb.doc.xml
+++ b/codebase/base/src.lib/graphic/fontdb.1.9/doc/fontdb.doc.xml
@@ -8,8 +8,7 @@
 <name>FrameBufferFontDBFind</name>
 <location>src.lib/graphic/fontdb</location>
 <header>base/fontdb.h</header>
-<syntax><sn href="&root;/src.lib/graphic/fbuffer/structFrameBufferFont.html">struct FrameBufferFont</sn> *FrameBufferFontDBFind(<sn href="structFrameBufferFontDB.html">struct FrameBufferFontDB</sn> *ptr,char *name,int sze);</syntax>
-
+<syntax><sn href="structFrameBufferFontDB.html">struct FrameBufferFontDB</sn> *FrameBufferFontDBFind(<sn href="structFrameBufferFontDB.html">struct FrameBufferFontDB</sn> *ptr,char *name,int sze);</syntax>
 <description><p>The <fn href="FrameBufferFontDBFind.html">FrameBufferFontDBFind</fn> function attempts to locate a bitmap font in a font database.</p>
 <p>The structure containing the font database is pointed to by the argument <ar>ptr</ar>.</p>
 <p>The name of the font to search for is given by the zero terminated string pointed to by the argument <ar>name</ar> and the size of the font is given by the argument <ar>sze</ar>.</p>
@@ -18,8 +17,8 @@
 <errors>On error a <code>NULL</code> pointer is returned.</errors>
 <example type="image">FrameBufferFontDBFind</example>
 <example type="source">FrameBufferFontDBFind.c</example>
-
 </function>
+
 <function>
 <name>FrameBufferFontDBFree</name>
 <location>src.lib/graphic/fontdb</location>
@@ -28,71 +27,68 @@
 <description><p>The <fn href="FrameBufferFontDBFree.html">FrameBufferFontDBFree</fn> function releases memory allocated to store a font database.</p>
 <p>The structure containing the font database is pointed to by the argument <ar>ptr</ar>.</p>
 </description>
-
 <example type="image">FrameBufferFontDBFree</example>
 <example type="source">FrameBufferFontDBFree.c</example>
-
-
 </function>
+
 <function>
 <name>FrameBufferFontDBLoad</name>
 <location>src.lib/graphic/fontdb</location>
 <header>base/fontdb.h</header>
 <syntax><sn href="structFrameBufferFontDB.html">struct FrameBufferFontDB</sn> *FrameBufferFontDBLoad(FILE *fp);</syntax>
-
 <description><p>The <fn href="FrameBufferFontDBLoad.html">FrameBufferFontDBLoad</fn> function loads a font database from an open stream into memory.</p>
 <p>The database is read from the open stream pointed to by the argument <ar>fp</ar>.</p>
 </description>
-
 <returns>Returns a pointer to the structure containing the database on success. On error a <code>NULL</code> pointer is returned.</returns>
 <errors>On error a <code>NULL</code> pointer is returned.</errors>
-
 <example type="image">FrameBufferFontDBLoad</example>
 <example type="source">FrameBufferFontDBLoad.c</example>
-
-
 </function>
 
+
+
 <structure>
- <name>FrameBufferFontDB</name>
- <location>src.lib/graphic/fontdb</location>
- <header>base/fontdb.h</header>
- <struct>
+  <name>FrameBufferFontDB</name>
+  <location>src.lib/graphic/fontdb</location>
+  <header>base/fontdb.h</header>
+  <struct>
+
     <member>
       <proto>char *path;</proto>
       <description>Pathname of the directory containing the font files.</description>
     </member>
+
     <member>
       <proto>char *buf;</proto>
       <description>Internal buffer used to deproto the database.</description>
     </member>
+
     <member>
       <proto>int flg;</proto>
       <description>Internal flag used to deproto the database.</description>
     </member>
+
     <member>
       <proto>int num;</proto>
       <description>Number of fonts in the datbase.</description>
     </member>
+
     <member>
-      <proto><sn href="&root;/src.lib/graphic/fbuffer/structFrameBufferFont.html">struct FrameBufferFont</sn> **font;</proto>
+      <proto><sn href="&root;/base/src.lib/graphic/fbuffer/structFrameBufferFont.html">struct FrameBufferFont</sn> **font;</proto>
       <description>Pointer to an array of strcutures containing the bit map fonts.</description>
     </member>
+
     <member>
-      <proto><sn href="&root;/src.lib/graphic/fbuffer/structFrameBufferFont.html">struct FrameBufferFont</sn> *dfont;</proto>
+      <proto><sn href="&root;/base/src.lib/graphic/fbuffer/structFrameBufferFont.html">struct FrameBufferFont</sn> *dfont;</proto>
       <description>Default font to use if no match is found.</description>
     </member>
 
+   </struct>
 
-
- </struct>
-
-
-<description><p>The <sn href="structFrameBufferFontDB.html">struct FrameBufferFontDB</sn> structure stores a font database.</p>
-</description>
+  <description>
+  <p>The <sn href="structFrameBufferFontDB.html">struct FrameBufferFontDB</sn> structure stores a font database.</p>
+  </description>
 
 </structure>
-
-
 
 </library>

--- a/codebase/base/src.lib/graphic/imagedb.1.4/doc/imagedb.doc.xml
+++ b/codebase/base/src.lib/graphic/imagedb.1.4/doc/imagedb.doc.xml
@@ -7,7 +7,7 @@
 <name>FrameBufferDBAdd</name>
 <location>src.lib/graphic/imagedb</location>
 <header>base/imagedb.h</header>
-<syntax>int FrameBufferDBAdd(<sn href="structFrameBufferDB.html">struct FrameBufferDB</sn> *ptr,<sn href="&root;/src.lib/graphic/fbuffer/structFrameBuffer.html">struct FrameBuffer</sn> *img);</syntax>
+<syntax>int FrameBufferDBAdd(<sn href="structFrameBufferDB.html">struct FrameBufferDB</sn> *ptr,<sn href="&root;/base/src.lib/graphic/fbuffer/structFrameBuffer.html">struct FrameBuffer</sn> *img);</syntax>
 
 <description><p>The <fn href="FrameBufferDBAdd.html">FrameBufferDBAdd</fn> function addd a frame buffer or bitmap to a frame buffer database.</p>
 <p>The structure containing the frame buffer database is pointed to by the argument <ar>ptr</ar>.</p>
@@ -24,7 +24,7 @@
 <name>FrameBufferDBFind</name>
 <location>src.lib/graphic/imagedb</location>
 <header>base/imagedb.h</header>
-<syntax><sn href="&root;/src.lib/graphic/fbuffer/structFrameBuffer.html">struct FrameBuffer</sn> *FrameBufferDBFind(<sn href="structFrameBufferDB.html">struct FrameBufferDB</sn> *ptr,char *name);</syntax>
+<syntax><sn href="&root;/base/src.lib/graphic/fbuffer/structFrameBuffer.html">struct FrameBuffer</sn> *FrameBufferDBFind(<sn href="structFrameBufferDB.html">struct FrameBufferDB</sn> *ptr,char *name);</syntax>
 
 <description><p>The <fn href="FrameBufferDBFind.html">FrameBufferDBFind</fn> function attempts to locate a frame buffer or bitmap in a frame buffer database.</p>
 <p>The structure containing the frame buffer database is pointed to by the argument <ar>ptr</ar>.</p>

--- a/codebase/base/src.lib/graphic/ps.1.9/doc/ps.doc.xml
+++ b/codebase/base/src.lib/graphic/ps.1.9/doc/ps.doc.xml
@@ -123,7 +123,7 @@
 <name>PostScriptImage</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
-<syntax>int PostScriptImage(<sn href="structPostScript.html">struct PostScript</sn> *ptr, <sn href="structPostScriptMatrix.html">struct PostScriptMatrix</sn> *matrix,<sn href="&root;/graphic/fbuffer/structFrameBuffer.html">struct FrameBuffer</sn> *img, unsigned char mask, float x,float y, <sn href="structPostScriptClip.html">struct PostScriptClip</sn> *clip);</syntax>
+<syntax>int PostScriptImage(<sn href="structPostScript.html">struct PostScript</sn> *ptr, <sn href="structPostScriptMatrix.html">struct PostScriptMatrix</sn> *matrix,<sn href="&root;/base/src.lib/graphic/fbuffer/structFrameBuffer.html">struct FrameBuffer</sn> *img, unsigned char mask, float x,float y, <sn href="structPostScriptClip.html">struct PostScriptClip</sn> *clip);</syntax>
 <description><p>The <fn href="PostScriptImage.html">PostScriptImage</fn> function plots a bitmap image.</p>
 <p>The argument <ar>ptr</ar> is a pointer to the PostScript control structure. The argument <ar>matrix</ar> is an optional transformation matrix that can be applied to the bitmap. If this is set to a <code>NULL</code> pointer then no transformation is applied.</p>
 <p>The bitmap image is pointed to by the argument <ar>img</ar>.</p>

--- a/codebase/base/src.lib/graphic/ps.1.9/doc/ps.doc.xml
+++ b/codebase/base/src.lib/graphic/ps.1.9/doc/ps.doc.xml
@@ -1,32 +1,26 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-
 <library>
 <project>base</project>
 <name>rps</name>
 <location>src.lib/graphic/ps</location>
+
 <function>
 <name>PostScriptBezier</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>int PostScriptBezier(<sn href="structPostScript.html">struct PostScript</sn> *ptr, float x1,float y1,float x2,float y2,float x3,float y3, float x4,float y4, unsigned int color,float width, <sn href="structPostScriptDash.html">struct PostScriptDash</sn> *dash,<sn href="structPostScriptClip.html">struct PostScriptClip</sn> *clip);</syntax>
-
 <description><p>The <fn href="PostScriptBezier.html">PostScriptBezier</fn> function plots a bezier curve.</p>
 <p>The argument <ar>ptr</ar> is a pointer to the <code>PostScript</code> control structure.</p> 
 <p>The coordinates of the four points that define the bezier curve are given by the arguments
 <ar>x1</ar>, <ar>y1</ar>,<ar>x2</ar>, <ar>y2</ar>,<ar>x2</ar>, <ar>y3</ar>, and <ar>x4</ar>, <ar>y4</ar>. The two end points are defined by <ar>x1</ar>, <ar>y1</ar> and <ar>x4</ar>,<ar>y4</ar>. The other two coordinates are the control points.</p>
-
 <p>The color used to plot the curve is given by the <ar>color</ar> which is a 24-bit number that represents the red,green and blue components of the color as 8-bit numbers. The red channel occupies the most significant bits and the blue channel occupies the least significant bits.</p>
 <p>The width of the line used to plot the curve is controlled using the argument <ar>width</ar>, a value of zero will plot a hairline. The dot-dash pattern is given by <ar>dash</ar>. If this is set to a <code>NULL</code> pointer, a solid line is plotted.</p>
 <p>The clipping polygon is given by the argument <ar>clip</ar>. If this is set to a <code>NULL</code> pointer, no clipping is performed.</p>
-
 </description>
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptBezier</example>
 <example type="source">PostScriptBezier.c</example>
-
-
 </function>
 
 <function>
@@ -34,59 +28,45 @@
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>unsigned int PostScriptColor(int r,int g,int b);</syntax>
-
 <description><p>The <fn href="PostScriptColor.html">PostScriptColor</fn> function creates an integer representation of a color.</p>
 <p>The red, green, and blue component of the color are given by the arguments <ar>r</ar>, <ar>g</ar>, and <ar>b</ar>. The values of these arguments range from zero to (255).</p>
 </description>
 <returns>Returns an integer representation of the color on success. On error, (-1) is returned.</returns>
 <errors>On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptColor</example>
 <example type="source">PostScriptColor.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptEllipse</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>int PostScriptEllipse(<sn href="structPostScript.html">struct PostScript</sn> *ptr, <sn href="structPostScriptMatrix.html">struct PostScriptMatrix</sn> *matrix, float x,float y,float w,float h, int fill,unsigned int color, float width, <sn href="structPostScriptDash.html">struct PostScriptDash</sn> *dash,<sn href="structPostScriptClip.html">struct PostScriptClip</sn> *clip);</syntax>
-
 <description><p>The <fn href="PostScriptEllipse.html">PostScriptEllipse</fn> function plots an ellipse.</p>
 <p>The argument <ar>ptr</ar> is a pointer to the <code>PostScript</code> control structure. The argument <ar>matrix</ar> is an optional transformation matrix that can be applied to the ellipse. If this is set to a <code>NULL</code> pointer then no transformation is applied. The position of the center of the ellipse is given by the arguments <ar>x</ar>, and <ar>y</ar>. The horizontal and vertical radii are given by the arguments <ar>w</ar> and <ar>h</ar>.</p>
 <p>If the argument <ar>fill</ar> is set to a non-zero value then the ellipse will be plotted as a solid shape, not an outline.</p>
 <p>The color used to plot the rectangle is given by the <ar>color</ar> which is a 24-bit number that represents the red,green and blue components of the color as 8-bit number. The red channel occupies the most significant bits and the blue channel occupies the least significant bits.</p>
 <p>The width of the line used to plot the ellipse is controlled using the argument <ar>width</ar>, a value of zero will plot a hairline. The dot-dash pattern used to plot the ellipse is given by <ar>dash</ar>. If this is set to a <code>NULL</code> pointer, a solid line is plotted.</p>
 <p>The clipping polygon is given by the argument <ar>clip</ar>. If this is set to a <code>NULL</code> pointer, no clipping is performed.</p>
-
-
 </description>
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptEllipse</example>
 <example type="source">PostScriptEllipse.c</example>
-
-
 </function>
-
 
 <function>
 <name>PostScriptEndDocument</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>int PostScriptEndDocument(<sn href="structPostScript.html">struct PostScript</sn> *ptr);</syntax>
-
 <description><p>The <fn href="PostScriptEndDocument.html">PostScriptEndDocument</fn> function ends an PostScript document. No further plotting can take place once this function is called</p>
 <p>The argument <ar>ptr</ar> is a pointer to the PostScript control structure.</p>
 </description>
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptEndDocument</example>
 <example type="source">PostScriptEndDocument.c</example>
-
-
 </function>
 
 <function>
@@ -94,70 +74,56 @@
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>int PostScriptEndPlot(<sn href="structPostScript.html">struct PostScript</sn> *ptr);</syntax>
-
 <description><p>The <fn href="PostScriptEndPlot.html">PostScriptEndPlot</fn> function ends a PostScript plot by closing the page. Plotting can be continued on a new page by called <fn href="PostScriptMakePlot.html">PostScriptMakePlot</fn></p>
 <p>The argument <ar>ptr</ar> is a pointer to the PostScript control structure.</p>
 </description>
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptEndPlot</example>
 <example type="source">PostScriptEndPlot.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptFree</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>void PostScriptFree(<sn href="structPostScript.html">struct PostScript</sn> *ptr);</syntax>
-
 <description><p>The <fn href="PostScriptFree.html">PostScriptFree</fn> function releases memory allocated for an PostScript control structure.</p>
 <p>The argument ptr is a pointer to the PostScript control structure.</p>
 </description>
-
 <example type="postscript">PostScriptFree</example>
 <example type="source">PostScriptFree.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptFreeClip</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>void PostScriptFreeClip(<sn href="structPostScriptClip.html">struct PostScriptClip</sn> *ptr);</syntax>
-
 <description><p>The <fn href="PostScriptFreeClip.html">PostScriptFreeClip</fn> function releases memory allocated for an PostScript clipping polygon.</p>
 <p>The argument <ar>ptr</ar> is a pointer to the PostScript clipping polygon.</p>
 </description>
-
 <example type="postscript">PostScriptFreeClip</example>
 <example type="source">PostScriptFreeClip.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptFreeDash</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>void PostScriptFreeDash(<sn href="structPostScriptDash.html">struct PostScriptDash</sn> *ptr);</syntax>
-
 <description><p>The <fn href="PostScriptFreeDash.html">PostScriptFreeDash</fn> function releases memory allocated for an PostScript dash pattern.</p>
 <p>The argument <ar>ptr</ar> is a pointer to the PostScript dash pattern.</p>
 </description>
-
 <example type="postscript">PostScriptFreeDash</example>
 <example type="source">PostScriptFreeDash.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptImage</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
-<syntax>int PostScriptImage(<sn href="structPostScript.html">struct PostScript</sn> *ptr, <sn href="structPostScriptMatrix.html">struct PostScriptMatrix</sn> *matrix,<sn href="struct&root;/src.lib/graphic/fbuffer/FrameBuffer.html">struct FrameBuffer</sn> *img, unsigned char mask, float x,float y, <sn href="structPostScriptClip.html">struct PostScriptClip</sn> *clip);</syntax>
-
-
+<syntax>int PostScriptImage(<sn href="structPostScript.html">struct PostScript</sn> *ptr, <sn href="structPostScriptMatrix.html">struct PostScriptMatrix</sn> *matrix,<sn href="&root;/graphic/fbuffer/structFrameBuffer.html">struct FrameBuffer</sn> *img, unsigned char mask, float x,float y, <sn href="structPostScriptClip.html">struct PostScriptClip</sn> *clip);</syntax>
 <description><p>The <fn href="PostScriptImage.html">PostScriptImage</fn> function plots a bitmap image.</p>
 <p>The argument <ar>ptr</ar> is a pointer to the PostScript control structure. The argument <ar>matrix</ar> is an optional transformation matrix that can be applied to the bitmap. If this is set to a <code>NULL</code> pointer then no transformation is applied.</p>
 <p>The bitmap image is pointed to by the argument <ar>img</ar>.</p>
@@ -165,21 +131,17 @@
 <p>The position of the top-left hand corner of the bitmap is given by the arguments <ar>x</ar>, and <ar>y</ar>.</p>
 <p>The clipping polygon is given by the argument <ar>clip</ar>. If this is set to a <code>NULL</code> pointer, no clipping is performed.</p>  
 </description>
-
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptImage</example>
 <example type="source">PostScriptImage.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptLine</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>int PostScriptLine(<sn href="structPostScript.html">struct PostScript</sn> *ptr, float ax,float ay,float bx,float by, unsigned int color,float width, <sn href="structPostScriptDash.html">struct PostScriptDash</sn> *dash, <sn href="structPostScriptClip.html">struct PostScriptClip</sn> *clip);</syntax>
-
 <description><p>The <fn href="PostScriptLine.html">PostScriptLine</fn> function plots a straight line segment.</p>
 <p>The argument <ar>ptr</ar> is a pointer to the PostScript control structure.</p> 
 <p>The coordinates of the two points that define the line are given by the arguments <ar>ax</ar>, <ar>ay</ar>, and <ar>bx</ar>, <ar>by</ar>.</p>
@@ -187,58 +149,46 @@
 <p>The width of the line is controlled using the argument <ar>width</ar>, a value of zero will plot a hairline. The dot-dash pattern is given by <ar>dash</ar>. If this is set to a <code>NULL</code> pointer, a solid line is plotted.</p>
 <p>The clipping polygon is given by the argument <ar>clip</ar>. If this is set to a <code>NULL</code> pointer, no clipping is performed.</p>  
 </description>
-
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptLine</example>
 <example type="source">PostScriptLine.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptMake</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax><sn href="structPostScript.html">struct PostScript</sn> *PostScriptMake();</syntax>
-
 <description><p>The <fn href="PostScriptMake.html">PostScriptMake</fn> function initializes an  PostScript control structure.</p>
 </description>
 <returns>Returns a pointer to the control structure on success. On error, a <code>NULL</code> pointer is returned.</returns>
 <errors>On error, a <code>NULL</code> pointer is returned.</errors>
-
 <example type="postscript">PostScriptMake</example>
 <example type="source">PostScriptMake.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptMakeClip</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax><sn href="structPostScriptClip.html">struct PostScriptClip</sn> *PostScriptMakeClip(float x,float y,float wdt, float hgt,  int num,float *px, float *py,int *t);</syntax>
-
-
 <description><p>The <fn href="PostScriptMakeClip.html">PostScriptMakeClip</fn> function creates a clipping polygon.</p>
 <p>The arguments <ar>x</ar> and <ar>y</ar> are applied as an offset to each vertex in the clipping polygon. The polygon is expected to lie with the rectangle whose size is given by the arguments <ar>wdt</ar> and <ar>hgt</ar>.</p>
 <p>The number of vertices of the clipping polygon is given by the argument <ar>num</ar>. The arrays containing the X and Y coordinates of each vertex are pointed to by the arguments <ar>px</ar> and <ar>y</ar>.</p>
 <p>A polygon can be constructed from straight line segments or bezier curves. The array pointed to by the argument <ar>t</ar> determines what kind of line segment is used to join to a vertex. If the corresponding entry in the array equals zero, then the segment between the current point and the next point is a straight line; if the entry is (1) then the connecting segment is a bezier curve and the next two vertices are the control points, the curve connects to the third point.</p> 
 </description>
-
 <returns>Returns a pointer to the structure containing the clipping polygon on success. On error, a <code>NULL</code> pointer is returned.</returns>
 <errors>On error, a <code>NULL</code> pointer is returned.</errors>
-
 <example type="postscript">PostScriptMakeClip</example>
 <example type="source">PostScriptMakeClip.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptMakeDash</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax><sn href="structPostScriptDash.html">struct PostScriptDash</sn> *PostScriptMakeDash(float *p,float phase,int sze);</syntax>
-
 <description><p>The <fn href="PostScriptMakeDash.html">PostScriptMakeDash</fn> function makes a dash pattern for an PostScript plot.</p>
 <p>The array pointed to by the argument <ar>p</ar> is interpreted as distances along the line that alternately specify dashes and gaps. The argument <ar>sze</ar> give the number of elements in the array.</p>
 <p>When a dashed line is plotted an element is read from the array and a dash of length equal to that value is drawn. A gap equal to the value of the next element is then left and the process is repeated until the end of the line is reached, cycling through the array as necessary.</p>
@@ -246,91 +196,67 @@
 </description>
 <returns>Returns a pointer to the dash structure on success. On error, a <code>NULL</code> pointer is returned.</returns>
 <errors>On error, a <code>NULL</code> pointer is returned.</errors>
-
 <example type="postscript">PostScriptMakeDash</example>
 <example type="source">PostScriptMakeDash.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptMakeDashString</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax><sn href="structPostScriptDash.html">struct PostScriptDash</sn> *PostScriptMakeDashString(char *str);</syntax>
-
-
 <description><p>The <fn href="PostScriptMakeDashString.html">PostScriptMakeDashString</fn> function makes a dash pattern for an PostScript plot from a text string.</p>
 <p>The argument <ar>str</ar> is the zero terminated string of space separated numbers that defines the dash pattern.</p>
 <p>The first number in the string is a phase offset. The subsequent numbers are interpreted as distances along the line that alternately specify dashes and gaps.</p>
 <p>When a dashed line is plotted an element is read from the array and a dash of length equal to that value is drawn. A gap equal to the value of the next element is then left and the process is repeated until the end of the line is reached, cycling through the array as necessary.</p>
 <p>The phase specifies the initial element to use from the array.</p>
 </description>
-
 <returns>Returns a pointer to the dash structure on success. On error, a <code>NULL</code> pointer is returned.</returns>
 <errors>On error, a <code>NULL</code> pointer is returned.</errors>
-
 <example type="postscript">PostScriptMakeDashString</example>
 <example type="source">PostScriptMakeDashString.c</example>
-
-
 </function>
-
-
 
 <function>
 <name>PostScriptMakeDocument</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>int PostScriptMakePlot(<sn href="structPostScript.html">struct PostScript</sn> *ptr, float x,float y,float wdt,float hgt, int land);</syntax>
-
-
 <description><p>The <fn href="PostScriptMakeDocument.html">PostScriptMakeDocument</fn> function creates a PostScript document.</p>
 <p>The offset from the edge of the page is given by the arguments <ar>x</ar> and <ar>y</ar>. The size of the plot is given by the arguments <ar>wdt</ar> and <ar>hgt</ar>.</p>
 <p>If the argument <ar>land</ar> has a non-zero value then the PostScript plot is rotated ninety degrees to form a landscape plot.</p>
 </description>
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptMakeDocument</example>
 <example type="source">PostScriptMakeDocument.c</example>
-
-
 </function>
-
 
 <function>
 <name>PostScriptMakePlot</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>int PostScriptMakePlot(<sn href="structPostScript.html">struct PostScript</sn> *ptr);</syntax>
-
-
 <description><p>The <fn href="PostScriptMakePlot.html">PostScriptMakePlot</fn> function creates a PostScript plot by starting a new page.</p>
 </description>
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptMakePlot</example>
 <example type="source">PostScriptMakePlot.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptMatrixString</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax><sn href="structPostScriptMatrix.html">struct PostScriptMatrix</sn> *PostScriptMatrixString(char *str);</syntax>
-
 <description><p>The <fn href="PostScriptMatrixString.html">PostScriptMatrixString</fn> function creates a transformation matrix from a text string.</p>
 <p>The argument <ar>str</ar> is the zero terminated string of space separated numbers that defines the matrix. The first number gives the top-left value, the second, the top-right value, the third, the bottom-left value, and the fourth gives the bottom right value.</p>
 </description>
 <returns>Returns a pointer to the matrix structure on success. On error, a <code>NULL</code> pointer is returned.</returns>
 <errors>On error, a <code>NULL</code> pointer is returned.</errors>
-
 <example type="postscript">PostScriptMatrixString</example>
 <example type="source">PostScriptMatrixString.c</example>
-
-
 </function>
 
 <function>
@@ -338,8 +264,6 @@
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>int PostScriptPolygon(<sn href="structPostScript.html">struct PostScript</sn> *ptr, <sn href="structPostScriptMatrix.html">struct PostScriptMatrix</sn> *matrix, float x,float y, int num,float *px,float *py,int *t,int fill, unsigned int color,float width, <sn href="structPostScriptDash.html">struct PostScriptDash</sn> *dash,<sn href="structPostScriptClip.html">struct PostScriptClip</sn> *clip);</syntax>
-
-
 <description><p>The <fn href="PostScriptPolygon.html">PosctScriptPolygon</fn> function plots a polygon.</p>
 <p>The argument <ar>ptr</ar> is a pointer to the PostScript control structure . The argument <ar>matrix</ar> is an optional transformation matrix that can be applied to the polygon. If this is set to a <code>NULL</code> pointer then no transformation is applied. The position at which the polygon is plotted is given by the arguments <ar>x</ar>, and <ar>y</ar>.</p>
 <p>The number of vertices of the polygon is given by the argument <ar>num</ar>. The arrays containing the X and Y coordinates of each vertex are pointed to by the arguments <ar>x</ar> and <ar>y</ar>.</p>
@@ -351,18 +275,15 @@
 </description>
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>Returns zero on success. On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptPolygon</example>
 <example type="source">PostScriptPolygon.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptRectangle</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>int PostScriptRectangle(<sn href="structPostScript.html">struct PostScript</sn> *ptr, <sn href="structPostScriptMatrix.html">struct PostScriptMatrix</sn> *matrix, float x,float y,float w,float h,int fill,unsigned int color, float width, <sn href="structPostScriptDash.html">struct PostScriptDash</sn> *dash,<sn href="structPostScriptClip.html">struct PostScriptClip</sn> *clip);</syntax>
-
 <description><p>The <fn href="PostScriptRectangle.html">PostScriptRectangle</fn> function plots a rectangle.</p>
 <p>The argument <ar>ptr</ar> is a pointer to the PostScript control structure. The argument <ar>matrix</ar> is an optional transformation matrix that can be applied to the rectangle. If this is set to a <code>NULL</code> pointer then no transformation is applied. The position at which the rectangle is plotted is given by the arguments <ar>x</ar>, and <ar>y</ar>. The width and height of the rectangle are given by the arguments <ar>w</ar> and <ar>h</ar>.</p>
 <p>If the argument <ar>fill</ar> is set to a non-zero value then the rectangle will be plotted as a solid shape, not an outline.</p>
@@ -372,60 +293,43 @@
 </description>
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>Returns zero on success. On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptRectangle</example>
 <example type="source">PostScriptRectangle.c</example>
-
-
-
-
 </function>
+
 <function>
 <name>PostScriptRotateMatrix</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>int PostScriptRotateMatrix(<sn href="structPostScriptMatrix.html">struct PostScriptMatrix</sn> *ptr, float angle);</syntax>
-
 <description><p>The <fn href="PostScriptRotateMatrix.html">PostScriptRotateMatrix</fn> function rotates a transformation matrix.</p>
 <p>The matrix to rotate is pointed to by the argument  <ar>ptr</ar>. The angle in degrees to rotate the matrix is given by the argument <ar>angle</ar>.</p>
 </description>
-
-
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptRotateMatrix</example>
 <example type="source">PostScriptRotateMatrix.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptScaleMatrix</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
-<syntax>int PostScriptScaleMatrix(<sn href="structPostScriptScaleMatrix.html">struct PostScriptScaleMatrix</sn> *ptr, float xscale,float yscale);</syntax>
-
-
-<description><p>The <fn href="PostScriptRotateMatrix.html">PostScriptRotateMatrix</fn> function scales a transformation matrix.</p>
+<syntax>int PostScriptScaleMatrix(<sn href="structPostScriptMatrix.html">struct PostScriptMatrix</sn> *ptr, float xscale,float yscale);</syntax>
+<description><p>The <fn href="PostScriptScaleMatrix.html">PostScriptScaleMatrix</fn> function scales a transformation matrix.</p>
 <p>The matrix to scale is pointed to by the argument  <ar>ptr</ar>. The X and Y scale factors are given by the arguments <ar>xscale</ar> and <ar>yscale</ar>.</p>
 </description>
-
-
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptScaleMatrix</example>
 <example type="source">PostScriptScaleMatrix.c</example>
-
-
 </function>
+
 <function>
 <name>PostScriptSetText</name>
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>int PostScriptSetText(<sn href="structPostScript.html">struct PostScript</sn> *ptr, int (*text)(char *,int,void *),void *data);</syntax>
-
-
 <description><p>The <fn href="PostScriptSetText.html">PostScriptSetText</fn> function sets the text stream handler in the  <code>PostScript</code> control structure.</p>
 <p>The argument <ar>ptr</ar> is a pointer to the PostScript control structure.</p>
 <p>The argument <ar>text</ar> is a pointer to a function of the form:</p>
@@ -435,19 +339,11 @@ int (*text) (char *buffer,int size,void *dptr);
 <p>This function is called each time PostScript commands are sent to the text stream.</p>
 <p>The argument <ar>buffer</ar> is a pointer to a buffer containing the text of the command and the argument <ar>size</ar> indicates the size of the buffer.</p>
 <p>The <ar>data</ar> argument of the <fn href="PostScriptSetText.html">PostScriptSetText</fn> function  is passed directly as the <ar>dptr</ar> argument and allows extra parameters to be passed to the function.</p>
-
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>On error, (-1) is returned.</errors>
-
-
 <example type="postscript">PostScriptSetText</example>
 <example type="source">PostScriptSetText.c</example>
-
-
 </description>
-
-
-
 </function>
 
 <function>
@@ -455,9 +351,6 @@ int (*text) (char *buffer,int size,void *dptr);
 <location>src.lib/graphic/ps</location>
 <header>base/rps.h</header>
 <syntax>int PostScriptText(<sn href="structPostScript.html">struct PostScript</sn> *ptr, <sn href="structPostScriptMatrix.html">struct PostScriptMatrix</sn> *matrix, char *fname,float fsize, float x,float y,int num,char *txt, unsigned int color, <sn href="structPostScriptClip.html">struct PostScriptClip</sn> *clip);</syntax>
-
-
-
 <description><p>The <fn href="PostScriptText.html">PostScriptText</fn> function plots text.</p>
 <p>The argument <ar>ptr</ar> is a pointer to the PostScript control structure. The argument <ar>matrix</ar> is an optional transformation matrix that can be applied to the rectangle. If this is set to a <code>NULL</code> pointer then no transformation is applied.</p>
 <p>The zero terminated string pointed to by the argument <ar>fname</ar> gives thhe name of the font. The size of the font is given by the argument <ar>fsize</ar>.</p>
@@ -466,74 +359,84 @@ int (*text) (char *buffer,int size,void *dptr);
 <p>The color used to plot the text is given by the <ar>color</ar> which is a 24-bit number that represents the red,green and blue components of the color as 8-bit number. The red channel occupies the most significant bits and the blue channel occupies the least significant bits.</p>
 <p>The clipping polygon is given by the argument <ar>clip</ar>. If this is set to a <code>NULL</code> pointer, no clipping is performed.</p>  
 </description>
-
 <returns>Returns zero on success. On error, (-1) is returned.</returns>
 <errors>On error, (-1) is returned.</errors>
-
 <example type="postscript">PostScriptText</example>
 <example type="source">PostScriptText.c</example>
-
-
 </function>
 
 
 <structure>
- <name>PostScript</name>
- <location>src.lib/graphic/ps</location>
- <header>base/rps.h</header>
- <struct>
+  <name>PostScript</name>
+  <location>src.lib/graphic/ps</location>
+  <header>base/rps.h</header>
+  <struct>
+
     <member>
       <proto>int cnt;</proto>
       <description>Counter indicating the number of strokes in the current path.</description>
     </member>
+
     <member>
       <proto>float x;</proto>
       <description>Offset from left edge of the page.</description>
     </member>
+
     <member>
       <proto>float y;</proto>
       <description>Offset from the top of the page.</description>
     </member>
+
     <member>
       <proto>float wdt;</proto>
       <description>Width of the plot.</description>
     </member>
+
     <member>
       <proto>float hgt;</proto>
       <description>Height of the plot.</description>
     </member>
+
     <member>
       <proto>int land;</proto>
       <description>Flag indicating whether the plot is landscape or portrait. A non-zero value indicates landscape</description>
     </member>
+
     <member>
       <proto>int pagenum;</proto>
       <description>Page number.</description>
     </member>
+
     <member>
       <proto>float width;</proto>
       <description>Width of the current stroke.</description>
     </member>
+
     <member>
       <proto>unsigned int color;</proto>
       <description>Color of the current stroke.</description>
     </member>
+
     <member>
       <proto><sn href="structPostScriptDash.html">struct PostScriptDash</sn> *dash;</proto>
       <description>Dash pattern of the current stroke.</description>
     </member>
+
     <member>
       <proto><sn href="structPostScriptClip.html">struct PostScriptClip</sn> *clip;</proto>
       <description>Clipping polygon of the current stroke.</description>
     </member>
+
     <member>
       <proto>float px;</proto>
       <description>X coordinate of the current stroke.</description>
     </member>
+
     <member>
       <proto>float py;</proto>
       <description>Y coordinate of the current stroke.</description>
     </member>
+
     <member>
       <struct>
          <member>
@@ -548,101 +451,116 @@ int (*text) (char *buffer,int size,void *dptr);
        <proto>text;</proto>
        <description>Text stream handler.</description>
     </member>
+
   </struct>
 
-<description>
-<p>The <sn href="structPostScript.html">struct PostScript</sn> structure stores a control structure for an PostScript plot.</p>
-</description>
+  <description>
+  <p>The <sn href="structPostScript.html">struct PostScript</sn> structure stores a control structure for an PostScript plot.</p>
+  </description>
 
 </structure>
 
 
+
 <structure>
- <name>PostScriptClip</name>
- <location>src.lib/graphic/ps</location>
- <header>base/rps.h</header>
- <struct>
+  <name>PostScriptClip</name>
+  <location>src.lib/graphic/ps</location>
+  <header>base/rps.h</header>
+  <struct>
+
     <member>
       <proto>int num;</proto>
       <description>Number of vertices in the clipping polygon.</description>
     </member>
+
     <member>
       <proto>float *px;</proto>
       <description>Pointer to an array containing the X coordinate of each vertex.</description>
     </member>
+
     <member>
       <proto>float *py;</proto>
       <description>Pointer to an array containing the Y coordinate of each vertex.</description>
     </member>
+
     <member>
       <proto>int *t;</proto>
       <description>Pointer to an array containing the type proto for the line segment joined to each vertex.</description>
     </member>
- </struct>
 
-<description>
-<p>The <sn href="structPostScriptClip.html">struct PostScriptClip</sn> structure stores a clipping polygon for an PostScript plot.</p>
-</description>
+  </struct>
 
+  <description>
+  <p>The <sn href="structPostScriptClip.html">struct PostScriptClip</sn> structure stores a clipping polygon for an PostScript plot.</p>
+  </description>
 
 </structure>
 
+
+
 <structure>
- <name>PostScriptDash</name>
- <location>src.lib/graphic/ps</location>
- <header>base/rps.h</header>
- <struct>
+  <name>PostScriptDash</name>
+  <location>src.lib/graphic/ps</location>
+  <header>base/rps.h</header>
+  <struct>
+
     <member>
       <proto>float *p;</proto>
       <description>Pointer to an array of line segment lengths.</description>
     </member>
+
     <member>
       <proto>int sze;</proto>
       <description>Number of entries in the array of line segment lengths.</description>
     </member>
+
     <member>
       <proto>float phase;</proto>
       <description>Current position in the array of line segment lengths.</description>
     </member>
- </struct>
 
-<description>
-<p>The <sn href="structPostScriptDash.html">struct PostScriptDash</sn> structure stores a dash pattern for an PostScript plot.</p>
-</description>
+  </struct>
 
+  <description>
+  <p>The <sn href="structPostScriptDash.html">struct PostScriptDash</sn> structure stores a dash pattern for an PostScript plot.</p>
+  </description>
 
 </structure>
 
+
+
 <structure>
- <name>PostScriptMatrix</name>
- <location>src.lib/graphic/ps</location>
- <header>base/rps.h</header>
- <struct>
+  <name>PostScriptMatrix</name>
+  <location>src.lib/graphic/ps</location>
+  <header>base/rps.h</header>
+  <struct>
+
     <member>
       <proto>float a;</proto>
       <description>Top-left matrix cell.</description>
     </member>
+
     <member>
       <proto>float b;</proto>
       <description>Top-right matrix cell.</description>
     </member>
+
     <member>
       <proto>float c;</proto>
       <description>Bottom-left matrix cell.</description>
     </member>
+
     <member>
       <proto>float d;</proto>
       <description>Bottom-right matrix cell.</description>
     </member>
+
   </struct>
 
-<description>
-<p>The <sn href="structPostScriptMatrix.html">struct PostScriptMatrix</sn> structure stores a transformation matrix for an PostScript plot.</p>
-</description>
-
-
+  <description>
+  <p>The <sn href="structPostScriptMatrix.html">struct PostScriptMatrix</sn> structure stores a transformation matrix for an PostScript plot.</p>
+  </description>
 
 </structure>
-
 
 </library>

--- a/codebase/base/src.lib/graphic/xwin.1.5/doc/xwin.doc.xml
+++ b/codebase/base/src.lib/graphic/xwin.1.5/doc/xwin.doc.xml
@@ -40,9 +40,9 @@
 <name>XwinFrameBufferToXimage</name>
 <location>src.lib/graphic/xwin</location>
 <header>base/xwin.h</header>
-<syntax>int XwinFrameBufferToXimage(<sn href="&root;/src.lib/graphic/fbuffer/structFrameBuffer.html">struct FrameBuffer *fb</sn>,XImage *xi);</syntax>
+<syntax>int XwinFrameBufferToXimage(<sn href="&root;/base/src.lib/graphic/fbuffer/structFrameBuffer.html">struct FrameBuffer *fb</sn>,XImage *xi);</syntax>
 
-<description><p>The <fn href="XwinFrameBufferRoXimage.html">XwinFrameBufferToXimage</fn> function copies a frame buffer to an Ximage structure.</p>
+<description><p>The <fn href="XwinFrameBufferToXimage.html">XwinFrameBufferToXimage</fn> function copies a frame buffer to an Ximage structure.</p>
 <p>The frame buffer structure is pointed to be the argument <ar>fb</ar> and the Ximage structure is pointed to by the argument <ar>xi</ar>.</p>
 </description>
 
@@ -54,7 +54,7 @@
 <name>XwinFrameBufferWindow</name>
 <location>src.lib/graphic/xwin</location>
 <header>base/xwin.h</header>
-<syntax>int XwinFrameBufferWindow(<sn href="&root;/src.lib/graphic/fbuffer/structFrameBuffer.html">struct FrameBuffer *fb</sn>,<sn href="structXwinWindow.html">struct XwinWindow</sn> *wp);</syntax>
+<syntax>int XwinFrameBufferWindow(<sn href="&root;/base/src.lib/graphic/fbuffer/structFrameBuffer.html">struct FrameBuffer *fb</sn>,<sn href="structXwinWindow.html">struct XwinWindow</sn> *wp);</syntax>
 
 
 <description><p>The <fn href="XwinFrameBufferWindow.html">XwinFrameBufferWindow</fn> function copies a frame buffer to an X window.</p>
@@ -193,7 +193,7 @@ On error, a <code>NULL</code> pointer is returned and the location pointed to by
       <description>Zero terminated string giving the program name.</description>
     </member>
     <member>
-      <proto><sn href="structstructXwinDisplay.html">struct XwinDisplay</sn> *dp;</proto>
+      <proto><sn href="structXwinDisplay.html">struct XwinDisplay</sn> *dp;</proto>
       <description>Control structure for the display the window is connected to.</description>
     </member>
     <member>

--- a/codebase/general/src.lib/dmap.1.25/doc/dmap.doc.xml
+++ b/codebase/general/src.lib/dmap.1.25/doc/dmap.doc.xml
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<library>
+<project>general</project>
+<name>dmap</name>
+<location>src.lib/dmap</location>
+
+<function>
+<name>DataMapAddArray</name>
+<location>src.lib/dmap</location>
+<header>general/dmap.h</header>
+<syntax>int DataMapAddArray(<sn href="structDataMap.html">struct DataMap</sn> *ptr, char *name,int type,int dim, int32 *rng,void *data);</syntax>
+<description><p>The <fn href="DataMapAddArray.html">DataMapAddArray</fn> function adds an array variable to a <code>DataMap</code> data structure.</p>
+<p>The data structure is pointed to by the argument <ar>ptr</ar>. The name of the array variable to add is given by the zero terminated string pointed to by the argument <ar>name</ar>.</p>
+<p>The scalar type is given by the argument <ar>type</ar>. Possible values are:</p>
+<center><table>
+<tr><td><pre>DATACHAR</pre></td><td>A single character of type <code>char</code>.</td></tr>
+<tr><td><pre>DATASHORT</pre></td><td>A 16-bit short integer of type <code>int16</code>.</td></tr>
+<tr><td><pre>DATAINT</pre></td><td>A 32-bit integer integer of type <code>int32</code>.</td></tr>
+<tr><td><pre>DATAFLOAT</pre></td><td>A single precision floating point number of type <code>float</code>.</td></tr>
+<tr><td><pre>DATADOUBLE</pre></td><td>A double precision floating point number of type <code>double</code>.</td></tr>
+<tr><td><pre>DATASTRING</pre></td><td>A pointer to a zero terminated text string of type <code>char *</code>.</td></tr>
+</table>
+</center>
+<p>The number of dimensions of the array are given by the argument <ar>dim</ar> and  the ranges of those dimensions are stored in the array pointed to by the argument <ar>rng</ar>.</p>
+<p>The argument <ar>data</ar> is a pointer to the location that stores the array.</p>
+</description>
+<returns>Returns zero on success. On error, (-1) is returned.</returns>
+<errors>On error, (-1) is returned.</errors>
+<example type="source">DataMapAddArray.c</example>
+</function>
+
+<function>
+<name>DataMapAddScalar</name>
+<location>src.lib/dmap</location>
+<header>general/dmap.h</header>
+<syntax>int DataMapAddScalar(<sn href="structDataMap.html">struct DataMap</sn> *ptr, char *name,int type,void *data);</syntax>
+<description><p>The <fn href="DataMapAddScalar.html">DataMapAddScalar</fn> function adds a scalar variable to a <code>DataMap</code> data structure.</p>
+<p>The data structure is pointed to by the argument <ar>ptr</ar>. The name of the scalar variable to add is given by the zero terminated string pointed to by the argument <ar>name</ar>.</p>
+<p>The scalar type is given by the argument <ar>type</ar>. Possible values are:</p>
+<center><table>
+<tr><td><pre>DATACHAR</pre></td><td>A single character of type <code>char</code>.</td></tr>
+<tr><td><pre>DATASHORT</pre></td><td>A 16-bit short integer of type <code>int16</code>.</td></tr>
+<tr><td><pre>DATAINT</pre></td><td>A 32-bit integer integer of type <code>int32</code>.</td></tr>
+<tr><td><pre>DATAFLOAT</pre></td><td>A single precision floating point number of type <code>float</code>.</td></tr>
+<tr><td><pre>DATADOUBLE</pre></td><td>A double precision floating point number of type <code>double</code>.</td></tr>
+<tr><td><pre>DATASTRING</pre></td><td>A pointer to a zero terminated text string of type <code>char *</code>.</td></tr>
+</table>
+</center>
+<p>The argument <ar>data</ar> is a pointer to the location that stores the scalar value.</p>
+</description>
+<returns>Returns zero on success. On error, (-1) is returned.</returns>
+<errors>On error, (-1) is returned.</errors>
+<example type="source">DataMapAddScalar.c</example>
+</function>
+
+<function>
+<name>DataMapDecodeBuffer</name>
+<location>src.lib/dmap</location>
+<header>general/dmap.h</header>
+<syntax><sn href="structDataMap.html">struct DataMap</sn> *DataMapDecodeBuffer(unsigned char *buf,int size);</syntax>
+<description><p>The <fn href="DataMapDecodeBuffer.html">DataMapDecodeBuffer</fn> function decodes a <code>DataMap</code> data structure from a memory buffer.</p>
+<p>The memory buffer to decode is pointed to by the argument <ar>buf</ar>, and the size of the buffer is given by the argument <ar>size</ar>.</p>
+</description>
+<returns>Returns a pointer to the decoded data structure on success. On error, a <code>NULL</code> pointer is returned.</returns>
+<errors>On error, a <code>NULL</code> pointer is returned.</errors>
+<example type="source">DataMapDecodeBuffer.c</example>
+</function>
+
+<function>
+<name>DataMapEncodeBuffer</name>
+<location>src.lib/dmap</location>
+<header>general/dmap.h</header>
+<syntax>unsigned char *DataMapEncodeBuffer(<sn href="structDataMap.html">struct DataMap</sn> *ptr,int *size);</syntax>
+<description><p>The <fn href="DataMapEncodeBuffer.html">DataMapEncodeBuffer</fn> function encodes a <code>DataMap</code> data structure into a memory buffer.</p>
+<p>The data structure is pointed to by the argument <ar>ptr</ar>.</p>
+<p>The structure is encoded and stored in a memory buffer, the size of this memory buffer is stored at the location pointed to by the argument <ar>size</ar>.</p>
+</description>
+<returns>Returns a pointer to the memory buffer on success. On error, a <code>NULL</code> pointer is returned.</returns>
+<errors>On error, a <code>NULL</code> pointer is returned.</errors>
+<example type="source">DataMapEncodeBuffer.c</example>
+</function>
+
+<function>
+<name>DataMapFread</name>
+<location>src.lib/dmap</location>
+<header>general/dmap.h</header>
+<syntax><sn href="structDataMap.html">struct DataMap</sn> *DataMapFread(FILE *fp);</syntax>
+<description><p>The <fn href="DataMapFread.html">DataMapFread</fn> function reads a <code>DataMap</code> data structure from an open stream.</p>
+<p>The structure is read from the open stream pointed to by the argument <ar>fp</ar>.</p>
+</description>
+<returns>Returns a pointer to the data structure on success. On error, a <code>NULL</code> pointer is returned.</returns>
+<errors>On error, a <code>NULL</code> pointer is returned.</errors>
+<example type="source">DataMapFread.c</example>
+</function>
+
+<function>
+<name>DataMapFree</name>
+<location>src.lib/dmap</location>
+<header>general/dmap.h</header>
+<syntax>void DataMapFree(<sn href="structDataMap.html">struct DataMap</sn> *ptr);</syntax>
+<description><p>The <fn href="DataMapFree.html">DataMapFree</fn> function releases the memory used to store a <code>DataMap</code> data structure.</p>
+<p>The data structure is pointed to by the argument <ar>ptr</ar>.</p>
+</description>
+<example type="source">DataMapFree.c</example>
+</function>
+
+<function>
+<name>DataMapFwrite</name>
+<location>src.lib/dmap</location>
+<header>general/dmap.h</header>
+<syntax>int DataMapFwrite(FILE *fp,<sn href="structDataMap.html">struct DataMap</sn> *ptr);</syntax>
+<description><p>The <fn href="DataMapFwrite.html">DataMapFwrite</fn> function writes a <code>DataMap</code> data structure to an open stream.</p>
+<p>The structure is written to the open file with the descriptor give by the argument <ar>fp</ar>.</p>
+<p>The structure is pointed to by the argument <ar>ptr</ar>.</p>
+</description>
+<returns>Returns the number of bytes written to the file. On error, (-1) is returned.</returns>
+<errors>On error, (-1) is returned.</errors>
+<example type="source">DataMapFwrite.c</example>
+</function>
+
+<function>
+<name>DataMapMake</name>
+<location>src.lib/dmap</location>
+<header>general/dmap.h</header>
+<syntax><sn href="structDataMap.html">struct DataMap</sn> *DataMapMake();</syntax>
+<description><p>The <fn href="DataMapMake.html">DataMapMake</fn> function allocates and initializes  a <code>DataMap</code> data structure.</p>
+</description>
+<returns>Returns a pointer to the data structure on success. On error, a <code>NULL</code> pointer is returned.</returns>
+<errors>On error, a <code>NULL</code> pointer is returned.</errors>
+<example type="source">DataMapMake.c</example>
+</function>
+
+<function>
+<name>DataMapRead</name>
+<location>src.lib/dmap</location>
+<header>general/dmap.h</header>
+<syntax><sn href="structDataMap.html">struct DataMap</sn> *DataMapRead(int fid);</syntax>
+<description><p>The <fn href="DataMapRead.html">DataMapRead</fn> function reads a <code>DataMap</code> data structure from an open file.</p>
+<p>The structure is read from the open file with the descriptor given by the argument <ar>fid</ar>.</p>
+</description>
+<returns>Returns a pointer to the data structure on success. On error, a <code>NULL</code> pointer is returned.</returns>
+<errors>On error, a <code>NULL</code> pointer is returned.</errors>
+<example type="source">DataMapRead.c</example>
+</function>
+
+<function>
+<name>DataMapSize</name>
+<location>src.lib/dmap</location>
+<header>general/dmap.h</header>
+<syntax>int DataMapSize(<sn href="structDataMap.html">struct DataMap</sn> *ptr);</syntax>
+<description><p>The <fn href="DataMapSize.html">DataMapSize</fn> function calculates the number of bytes required to store a <code>DataMap</code> data structure.</p>
+<p>The structure is pointed to by the argument <ar>ptr</ar>.</p>
+</description>
+<returns>Returns the size in bytes of bytes required to encode the data structure. On error, (-1) is returned.</returns>
+<errors>On error, (-1) is returned.</errors>
+<example type="source">DataMapSize.c</example>
+</function>
+
+<function>
+<name>DataMapWrite</name>
+<location>src.lib/dmap</location>
+<header>general/dmap.h</header>
+<syntax>int DataMapWrite(int fid,<sn href="structDataMap.html">struct DataMap</sn> *ptr);</syntax>
+<description><p>The <fn href="DataMapWrite.html">DataMapWrite</fn> function writes a <code>DataMap</code> data structure to an open file.</p>
+<p>The structure is written to the open file with the descriptor given by the argument <ar>fid</ar>.</p>
+<p>The structure is pointed to by the argument <ar>ptr</ar>.</p>
+</description>
+<returns>Returns the number of bytes written to the file. On error, (-1) is returned.</returns>
+<errors>On error, (-1) is returned.</errors>
+<example type="source">DataMapWrite.c</example>
+</function>
+
+
+
+<structure>
+  <name>DataMap</name>
+  <location>src.lib/dmap</location>
+  <header>general/dmap.h</header>
+  <struct>
+
+    <member>
+      <proto>int sze;</proto>
+      <description>Size in bytes of the memory buffer used to store the data in the structure.</description>
+    </member>
+
+    <member>
+      <proto>char *buf;</proto>
+      <description>Pointer the memory buffer used to store the data.</description>
+    </member>
+
+    <member>
+      <proto>int snum;</proto>
+      <description>Number of scalar variables.</description>
+    </member>
+
+    <member>
+      <proto>int anum;</proto>
+      <description>Number of array variables.</description>
+    </member>
+
+    <member>
+      <proto><sn href="structDataMapScalar.html">struct DataMapScalar</sn> **scl;</proto>
+      <description>Pointer to an array of scalar variables.</description>
+    </member>
+
+    <member>
+      <proto><sn href="structDataMapArray.html">struct DataMapArray</sn> **arr;</proto>
+      <description>Pointer to an array of array variables.</description>
+    </member>
+
+  </struct>
+
+  <description>
+  <p>The <sn href="structDataMap.html">struct DataMap</sn> structure stores a DataMap data structure.</p>
+  </description>
+</structure>
+
+
+<structure>
+  <name>DataMapArray</name>
+  <location>src.lib/dmap</location>
+  <header>general/dmap.h</header>
+  <struct>
+
+    <member>
+      <proto>char *name;</proto>
+      <description>Pointer the zero terminated string that gives the name of the variable.</description>
+    </member>
+
+    <member>
+      <proto>unsigned char type;</proto>
+      <description>Type proto.</description>
+    </member>
+
+    <member>
+      <proto>int32 dim;</proto>
+      <description>Dimensions of the array.</description>
+    </member>
+
+    <member>
+      <proto>int32 *rng;</proto>
+      <description>Pointer to an array containing the range each dimension.</description>
+    </member>
+
+    <member>
+      <proto><un href="unionDataMapPointer.html">union DataMapPointer</un> data;</proto>
+      <description>Data values stored in the array.</description>
+    </member>
+
+  </struct>
+
+  <description>
+  <p>The <sn href="structDataMapArray.html">struct DataMapArray</sn> structure stores an array variable for a DataMap data structure.</p>
+  </description>
+</structure>
+
+
+<structure>
+  <name>DataMapScalar</name>
+  <location>src.lib/dmap</location>
+  <header>general/dmap.h</header>
+  <struct>
+
+    <member>
+      <proto>char *name;</proto>
+      <description>Pointer the zero terminated string that gives the name of the variable.</description>
+    </member>
+
+    <member>
+      <proto>unsigned char type;</proto>
+      <description>Type proto.</description>
+    </member>
+
+    <member>
+      <proto><un href="unionDataMapPointer.html">union DataMapPointer</un> data;</proto>
+      <description>Data value of the scalar.</description>
+    </member>
+
+  </struct>
+
+  <description>
+  <p>The <sn href="structDataMapScalar.html">struct DataMapScalar</sn> structure stores a scalar variable for a DataMap data structure.</p>
+  </description>
+</structure>
+
+
+<union>
+  <name>DataMapPointer</name>
+  <location>src.lib/dmap</location>
+  <header>general/dmap.h</header>
+  <union>
+
+    <member>
+      <proto>char *cptr;</proto>
+      <description>Pointer to a character.</description>
+    </member>
+
+    <member>
+      <proto>int16 *sptr;</proto>
+      <description>Pointer to a 16 bit integer.</description>
+    </member>
+
+    <member>
+      <proto>int32 *lptr;</proto>
+      <description>Pointer to a 32 bit integer.</description>
+    </member>
+
+    <member>
+      <proto>int32 *fptr;</proto>
+      <description>Pointer to a single precision floating point number.</description>
+    </member>
+
+    <member>
+      <proto>int32 *dptr;</proto>
+      <description>Pointer to a double precision floating point number.</description>
+    </member>
+
+    <member>
+      <proto>void *dptr;</proto>
+      <description>Pointer to a void data type.</description>
+    </member>
+
+  </union>
+
+  <description>
+  <p>The <sn href="unionDataMapPointer.html">union DataMapScalar</sn> union contains the union of different data pointers for a DataMap data structure.</p>
+  </description>
+</union>
+
+</library>

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapAddArray/DataMapAddArray.c
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapAddArray/DataMapAddArray.c
@@ -1,0 +1,36 @@
+/* DataMapAddArray.c
+   =================
+   Author: R.J.Barnes */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "rtypes.h"
+#include "dmap.h"
+
+
+
+int main(int argc,char *argv[]) {
+
+  int t,n;
+
+  float set[3]={0.1,0.2,10.2};
+
+  int32 dim=1;
+  int32 rng[1]={3};
+
+  struct DataMap *dmap;
+
+  dmap=DataMapMake();
+
+  DataMapAddArray(dmap,"set",DATAFLOAT,dim,rng,&set);
+
+  for (t=0;t<100;t++) {
+    for (n=0;n<3;n++) set[n]=set[n]+0.1;
+    DataMapFwrite(stdout,dmap);
+  }
+  DataMapFree(dmap);
+  return 0;
+
+}

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapAddArray/makefile
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapAddArray/makefile
@@ -1,0 +1,15 @@
+# Makefile for DataMapAddArray
+# ============================
+# by R.J.Barnes
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general 
+IGNVER=1
+OBJS = DataMapAddArray.o
+OUTPUT = DataMapAddArray
+LIBS=-ldmap.1 -lrcnv.1 
+SLIB=-lm
+ 
+include $(MAKELIB).$(SYSTEM)

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapAddScalar/DataMapAddScalar.c
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapAddScalar/DataMapAddScalar.c
@@ -1,0 +1,33 @@
+/* DataMapAddScalar.c
+   ==================
+   Author: R.J.Barnes */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "rtypes.h"
+#include "dmap.h"
+
+
+
+int main(int argc,char *argv[]) {
+
+  int t;
+
+  int value=0;
+
+  struct DataMap *dmap;
+
+  dmap=DataMapMake();
+
+  DataMapAddScalar(dmap,"value",DATAINT,&value);
+
+  for (t=0;t<100;t++) {
+    value=value+1;
+    DataMapFwrite(stdout,dmap);
+  }
+  DataMapFree(dmap);
+  return 0;
+
+}

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapAddScalar/makefile
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapAddScalar/makefile
@@ -1,0 +1,15 @@
+# Makefile for DataMapAddScalar
+# ============================
+# by R.J.Barnes
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general 
+IGNVER=1
+OBJS = DataMapAddScalar.o
+OUTPUT = DataMapAddScalar
+LIBS=-ldmap.1 -lrcnv.1 
+SLIB=-lm
+ 
+include $(MAKELIB).$(SYSTEM)

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapDecodeBuffer/DataMapDecodeBuffer.c
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapDecodeBuffer/DataMapDecodeBuffer.c
@@ -1,0 +1,170 @@
+/* DataMapRead.c
+   ==============
+   Author: R.J.Barnes */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+
+#include "rtypes.h"
+#include "dmap.h"
+#include "connex.h"
+
+
+int main(int argc,char *argv[]) {
+
+  char *host;
+  int port;
+
+  int sock;
+  int flag,status,size;
+  unsigned char *buffer=NULL;
+ 
+  struct DataMap *ptr=NULL;
+  struct DataMapScalar *s;
+  struct DataMapArray *a;
+  char **tmp;
+
+ 
+  int c;
+  int x,n;
+
+  if (argc<3) { 
+    fprintf(stderr,"host and port must be specified.'n");
+    exit(-1);
+  }
+
+  host=argv[1];
+  port=atoi(argv[2]);
+ 
+  sock=ConnexOpen(host,port); 
+  if (sock<0) {
+    fprintf(stderr,"Could not connect to host.'n");
+    exit(-1);
+  }
+  do {
+   status=ConnexRead(1,&sock,&buffer,&size,&flag,NULL);
+   if (status==-1) break;
+   if (flag !=1) continue;
+   if (size==0) continue;
+
+   ptr=DataMapDecodeBuffer(buffer,size);
+   if (ptr==NULL) fprintf(stderr,"Not a recognized message.\n");
+
+    fprintf(stdout,"scalars:\n");
+    for (c=0;c<ptr->snum;c++) {
+      s=ptr->scl[c];
+      switch (s->type) {
+        case DATACHAR:
+        fprintf(stdout,"\tchar");
+        break;
+        case DATASHORT:
+        fprintf(stdout,"\tshort");
+        break;
+        case DATAINT:
+        fprintf(stdout,"\tint");
+        break;
+        case DATAFLOAT:
+        fprintf(stdout,"\tfloat");
+        break;
+        case DATADOUBLE:
+        fprintf(stdout,"\tdouble");
+        break;
+        case DATASTRING:
+        fprintf(stdout,"\tstring");
+        break;
+      }
+      fprintf(stdout,"\t%c%s%c",'"',s->name,'"');
+      fprintf(stdout," = ");
+      switch (s->type) {
+        case DATACHAR:
+        fprintf(stdout,"%d",*(s->data.cptr));
+        break;
+        case DATASHORT:
+        fprintf(stdout,"%d",*(s->data.sptr));
+        break;
+        case DATAINT:
+        fprintf(stdout,"%d",*(s->data.lptr));
+        break;
+        case DATAFLOAT:
+        fprintf(stdout,"%g",*(s->data.fptr));
+        break;
+        case DATADOUBLE:
+        fprintf(stdout,"%g",*(s->data.dptr));
+        break;
+        case DATASTRING:
+	tmp=(char **) s->data.vptr;
+        fprintf(stdout,"%c%s%c",'"',*tmp,'"');
+        break;
+      }
+      fprintf(stdout,"\n");
+    }
+    fprintf(stdout,"arrays:\n");
+    for (c=0;c<ptr->anum;c++) {
+      a=ptr->arr[c];
+      switch (a->type) {
+        case DATACHAR:
+        fprintf(stdout,"\tchar");
+        break;
+        case DATASHORT:
+        fprintf(stdout,"\tshort");
+        break;
+        case DATAINT:
+        fprintf(stdout,"\tint");
+        break;
+        case DATAFLOAT:
+        fprintf(stdout,"\tfloat");
+        break;
+        case DATADOUBLE:
+        fprintf(stdout,"\tdouble");
+        break;
+        case DATASTRING:
+        fprintf(stdout,"\tstring");
+        break;
+      }
+      fprintf(stdout,"\t%c%s%c",'"',a->name,'"');
+      fprintf(stdout," ");
+      for (x=0;x<a->dim;x++) fprintf(stdout,"[%d]",a->rng[a->dim-1-x]);
+    
+      fprintf(stdout,"=");
+      n=1;
+      for (x=0;x<a->dim;x++) n=a->rng[x]*n;
+      for (x=0;x<n;x++) {
+        if (x % a->rng[0]==0) fprintf(stdout,"\n\t\t");
+        else if (x !=0) fprintf(stdout,",\t");
+        switch (a->type) {
+        case DATACHAR:
+          fprintf(stdout,"%d",a->data.cptr[x]);
+          break;
+        case DATASHORT:
+          fprintf(stdout,"%d",a->data.sptr[x]);
+          break;
+        case DATAINT:
+          fprintf(stdout,"%d",a->data.lptr[x]);
+          break;
+        case DATAFLOAT:
+          fprintf(stdout,"%g",a->data.fptr[x]);
+          break;
+        case DATADOUBLE:
+          fprintf(stdout,"%g",a->data.dptr[x]);
+          break;	    
+        case DATASTRING:
+          tmp=(char **) a->data.vptr;
+          fprintf(stdout,"%c%s%c",'"',tmp[x],'"');
+          break;
+	    
+        }  
+        fprintf(stdout,"\n");
+      } 
+    }  
+    DataMapFree(ptr);
+
+  } while (1);
+  return 0;
+
+}

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapDecodeBuffer/makefile
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapDecodeBuffer/makefile
@@ -1,0 +1,25 @@
+# Makefile for DataMapDecodeBuffer
+# ================================
+# by R.J.Barnes
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general 
+IGNVER=1
+OBJS = DataMapDecodeBuffer.o
+OUTPUT = DataMapDecodeBuffer
+LIBS=-lcnx.1 -ldmap.1 -lrcnv.1 
+
+ifeq ($(OSTYPE),solaris)
+SLIB =-lsocket -lnsl
+endif
+
+NET=$(shell find /usr/include/sys -name "socket.h")
+ifeq ($(NET),/usr/include/sys/socket.h)
+else
+  nonet:
+        echo "TCP/IP development libraries not available."
+endif
+ 
+include $(MAKELIB).$(SYSTEM)

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapEncodeBuffer/DataMapEncodeBuffer.c
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapEncodeBuffer/DataMapEncodeBuffer.c
@@ -1,0 +1,42 @@
+/* DataMapEncodeBuffer.c
+   =====================
+   Author: R.J.Barnes */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "rtypes.h"
+#include "dmap.h"
+
+
+
+int main(int argc,char *argv[]) {
+
+  int t,n;
+  unsigned char *buffer=NULL;
+  int size;
+
+  float set[3]={0.1,0.2,10.2};
+  int value;
+
+  int32 dim=1;
+  int32 rng[1]={3};
+
+  struct DataMap *dmap;
+
+  dmap=DataMapMake();
+
+  DataMapAddArray(dmap,"set",DATAFLOAT,dim,rng,&set);
+  DataMapAddScalar(dmap,"value",DATAINT,&value);
+
+  for (t=0;t<100;t++) {
+    for (n=0;n<3;n++) set[n]=set[n]+0.1;
+    buffer=DataMapEncodeBuffer(dmap,&size);
+    fprintf(stderr,"Buffer size=%d\n",size);
+
+  }
+  DataMapFree(dmap);
+  return 0;
+
+}

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapEncodeBuffer/makefile
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapEncodeBuffer/makefile
@@ -1,0 +1,15 @@
+# Makefile for DataMapEncodeBuffer
+# ================================
+# by R.J.Barnes
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general 
+IGNVER=1
+OBJS = DataMapEncodeBuffer.o
+OUTPUT = DataMapEncodeBuffer
+LIBS=-ldmap.1 -lrcnv.1 
+SLIB=-lm
+ 
+include $(MAKELIB).$(SYSTEM)

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapFread/DataMapFread.c
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapFread/DataMapFread.c
@@ -1,0 +1,149 @@
+/* DataMapFread.c
+   ==============
+   Author: R.J.Barnes */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "rtypes.h"
+#include "dmap.h"
+
+
+
+int main(int argc,char *argv[]) {
+
+ 
+
+  struct DataMap *ptr=NULL;
+  struct DataMapScalar *s;
+  struct DataMapArray *a;
+  char **tmp;
+
+  FILE *fp;
+  int c;
+  int x,n;
+
+
+  fp=fopen(argv[1],"r");
+  if (fp==NULL) {
+    fprintf(stderr,"File not found.\n");
+    exit (-1);
+  }
+
+
+
+ while ((ptr=DataMapFread(fp)) !=NULL) {
+    fprintf(stdout,"scalars:\n");
+    for (c=0;c<ptr->snum;c++) {
+      s=ptr->scl[c];
+      switch (s->type) {
+        case DATACHAR:
+        fprintf(stdout,"\tchar");
+        break;
+        case DATASHORT:
+        fprintf(stdout,"\tshort");
+        break;
+        case DATAINT:
+        fprintf(stdout,"\tint");
+        break;
+        case DATAFLOAT:
+        fprintf(stdout,"\tfloat");
+        break;
+        case DATADOUBLE:
+        fprintf(stdout,"\tdouble");
+        break;
+        case DATASTRING:
+        fprintf(stdout,"\tstring");
+        break;
+      }
+      fprintf(stdout,"\t%c%s%c",'"',s->name,'"');
+      fprintf(stdout," = ");
+      switch (s->type) {
+        case DATACHAR:
+        fprintf(stdout,"%d",*(s->data.cptr));
+        break;
+        case DATASHORT:
+        fprintf(stdout,"%d",*(s->data.sptr));
+        break;
+        case DATAINT:
+        fprintf(stdout,"%d",*(s->data.lptr));
+        break;
+        case DATAFLOAT:
+        fprintf(stdout,"%g",*(s->data.fptr));
+        break;
+        case DATADOUBLE:
+        fprintf(stdout,"%g",*(s->data.dptr));
+        break;
+        case DATASTRING:
+	tmp=(char **) s->data.vptr;
+        fprintf(stdout,"%c%s%c",'"',*tmp,'"');
+        break;
+      }
+      fprintf(stdout,"\n");
+    }
+    fprintf(stdout,"arrays:\n");
+    for (c=0;c<ptr->anum;c++) {
+      a=ptr->arr[c];
+      switch (a->type) {
+        case DATACHAR:
+        fprintf(stdout,"\tchar");
+        break;
+        case DATASHORT:
+        fprintf(stdout,"\tshort");
+        break;
+        case DATAINT:
+        fprintf(stdout,"\tint");
+        break;
+        case DATAFLOAT:
+        fprintf(stdout,"\tfloat");
+        break;
+        case DATADOUBLE:
+        fprintf(stdout,"\tdouble");
+        break;
+        case DATASTRING:
+        fprintf(stdout,"\tstring");
+        break;
+      }
+      fprintf(stdout,"\t%c%s%c",'"',a->name,'"');
+      fprintf(stdout," ");
+      for (x=0;x<a->dim;x++) fprintf(stdout,"[%d]",a->rng[a->dim-1-x]);
+    
+      fprintf(stdout,"=");
+      n=1;
+      for (x=0;x<a->dim;x++) n=a->rng[x]*n;
+      for (x=0;x<n;x++) {
+        if (x % a->rng[0]==0) fprintf(stdout,"\n\t\t");
+        else if (x !=0) fprintf(stdout,",\t");
+        switch (a->type) {
+        case DATACHAR:
+          fprintf(stdout,"%d",a->data.cptr[x]);
+          break;
+        case DATASHORT:
+          fprintf(stdout,"%d",a->data.sptr[x]);
+          break;
+        case DATAINT:
+          fprintf(stdout,"%d",a->data.lptr[x]);
+          break;
+        case DATAFLOAT:
+          fprintf(stdout,"%g",a->data.fptr[x]);
+          break;
+        case DATADOUBLE:
+          fprintf(stdout,"%g",a->data.dptr[x]);
+          break;	    
+        case DATASTRING:
+          tmp=(char **) a->data.vptr;
+          fprintf(stdout,"%c%s%c",'"',tmp[x],'"');
+          break;
+	    
+        }  
+        fprintf(stdout,"\n");
+      } 
+    }  
+    DataMapFree(ptr);
+
+  }
+  fclose(fp);
+  return 0;
+
+}

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapFread/makefile
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapFread/makefile
@@ -1,0 +1,15 @@
+# Makefile for DataMapFread
+# =========================
+# by R.J.Barnes
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general 
+IGNVER=1
+OBJS = DataMapFread.o
+OUTPUT = DataMapFread
+LIBS=-ldmap.1 -lrcnv.1 
+SLIB=-lm
+ 
+include $(MAKELIB).$(SYSTEM)

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapFree/DataMapFree.c
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapFree/DataMapFree.c
@@ -1,0 +1,38 @@
+/* DataMapFree.c
+   =============
+   Author: R.J.Barnes */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "rtypes.h"
+#include "dmap.h"
+
+
+
+int main(int argc,char *argv[]) {
+
+  int t,n;
+
+  float set[3]={0.1,0.2,10.2};
+  int value;
+
+  int32 dim=1;
+  int32 rng[1]={3};
+
+  struct DataMap *dmap;
+
+  dmap=DataMapMake();
+
+  DataMapAddArray(dmap,"set",DATAFLOAT,dim,rng,&set);
+  DataMapAddScalar(dmap,"value",DATAINT,&value);
+
+  for (t=0;t<100;t++) {
+    for (n=0;n<3;n++) set[n]=set[n]+0.1;
+    DataMapFwrite(stdout,dmap);
+  }
+  DataMapFree(dmap);
+  return 0;
+
+}

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapFree/makefile
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapFree/makefile
@@ -1,0 +1,15 @@
+# Makefile for DataMapFree
+# ===========================
+# by R.J.Barnes
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general 
+IGNVER=1
+OBJS = DataMapFree.o
+OUTPUT = DataMapFree
+LIBS=-ldmap.1 -lrcnv.1 
+SLIB=-lm
+ 
+include $(MAKELIB).$(SYSTEM)

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapFwrite/DataMapFwrite.c
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapFwrite/DataMapFwrite.c
@@ -1,0 +1,38 @@
+/* DataMapFwrite.c
+   ===============
+   Author: R.J.Barnes */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "rtypes.h"
+#include "dmap.h"
+
+
+
+int main(int argc,char *argv[]) {
+
+  int t,n;
+
+  float set[3]={0.1,0.2,10.2};
+  int value;
+
+  int32 dim=1;
+  int32 rng[1]={3};
+
+  struct DataMap *dmap;
+
+  dmap=DataMapMake();
+
+  DataMapAddArray(dmap,"set",DATAFLOAT,dim,rng,&set);
+  DataMapAddScalar(dmap,"value",DATAINT,&value);
+
+  for (t=0;t<100;t++) {
+    for (n=0;n<3;n++) set[n]=set[n]+0.1;
+    DataMapFwrite(stdout,dmap);
+  }
+  DataMapFree(dmap);
+  return 0;
+
+}

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapFwrite/makefile
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapFwrite/makefile
@@ -1,0 +1,15 @@
+# Makefile for DataMapFwrite
+# ===========================
+# by R.J.Barnes
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general 
+IGNVER=1
+OBJS = DataMapFwrite.o
+OUTPUT = DataMapFwrite
+LIBS=-ldmap.1 -lrcnv.1 
+SLIB=-lm
+ 
+include $(MAKELIB).$(SYSTEM)

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapMake/DataMapMake.c
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapMake/DataMapMake.c
@@ -1,0 +1,38 @@
+/* DataMapMake.c
+   =============
+   Author: R.J.Barnes */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "rtypes.h"
+#include "dmap.h"
+
+
+
+int main(int argc,char *argv[]) {
+
+  int t,n;
+
+  float set[3]={2.1,2.2,12.2};
+  int value;
+
+  int32 dim=1;
+  int32 rng[1]={3};
+
+  struct DataMap *dmap;
+
+  dmap=DataMapMake();
+
+  DataMapAddArray(dmap,"set",DATAFLOAT,dim,rng,&set);
+  DataMapAddScalar(dmap,"value",DATAINT,&value);
+
+  for (t=0;t<100;t++) {
+    for (n=0;n<3;n++) set[n]=set[n]+0.6;
+    DataMapFwrite(stdout,dmap);
+  }
+  DataMapFree(dmap);
+  return 0;
+
+}

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapMake/makefile
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapMake/makefile
@@ -1,0 +1,15 @@
+# Makefile for DataMapMake
+# ===========================
+# by R.J.Barnes
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general 
+IGNVER=1
+OBJS = DataMapMake.o
+OUTPUT = DataMapMake
+LIBS=-ldmap.1 -lrcnv.1 
+SLIB=-lm
+ 
+include $(MAKELIB).$(SYSTEM)

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapRead/DataMapRead.c
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapRead/DataMapRead.c
@@ -1,0 +1,155 @@
+/* DataMapRead.c
+   ==============
+   Author: R.J.Barnes */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+
+#include "rtypes.h"
+#include "dmap.h"
+
+
+
+int main(int argc,char *argv[]) {
+
+ 
+
+  struct DataMap *ptr=NULL;
+  struct DataMapScalar *s;
+  struct DataMapArray *a;
+  char **tmp;
+
+  int fid;
+  int c;
+  int x,n;
+
+
+  fid=open(argv[1],O_RDONLY,0);
+ 
+  if (fid==-1) {
+    fprintf(stderr,"File not found.\n");
+    exit (-1);
+  }
+
+
+
+ while ((ptr=DataMapRead(fid)) !=NULL) {
+    fprintf(stdout,"scalars:\n");
+    for (c=0;c<ptr->snum;c++) {
+      s=ptr->scl[c];
+      switch (s->type) {
+        case DATACHAR:
+        fprintf(stdout,"\tchar");
+        break;
+        case DATASHORT:
+        fprintf(stdout,"\tshort");
+        break;
+        case DATAINT:
+        fprintf(stdout,"\tint");
+        break;
+        case DATAFLOAT:
+        fprintf(stdout,"\tfloat");
+        break;
+        case DATADOUBLE:
+        fprintf(stdout,"\tdouble");
+        break;
+        case DATASTRING:
+        fprintf(stdout,"\tstring");
+        break;
+      }
+      fprintf(stdout,"\t%c%s%c",'"',s->name,'"');
+      fprintf(stdout," = ");
+      switch (s->type) {
+        case DATACHAR:
+        fprintf(stdout,"%d",*(s->data.cptr));
+        break;
+        case DATASHORT:
+        fprintf(stdout,"%d",*(s->data.sptr));
+        break;
+        case DATAINT:
+        fprintf(stdout,"%d",*(s->data.lptr));
+        break;
+        case DATAFLOAT:
+        fprintf(stdout,"%g",*(s->data.fptr));
+        break;
+        case DATADOUBLE:
+        fprintf(stdout,"%g",*(s->data.dptr));
+        break;
+        case DATASTRING:
+	tmp=(char **) s->data.vptr;
+        fprintf(stdout,"%c%s%c",'"',*tmp,'"');
+        break;
+      }
+      fprintf(stdout,"\n");
+    }
+    fprintf(stdout,"arrays:\n");
+    for (c=0;c<ptr->anum;c++) {
+      a=ptr->arr[c];
+      switch (a->type) {
+        case DATACHAR:
+        fprintf(stdout,"\tchar");
+        break;
+        case DATASHORT:
+        fprintf(stdout,"\tshort");
+        break;
+        case DATAINT:
+        fprintf(stdout,"\tint");
+        break;
+        case DATAFLOAT:
+        fprintf(stdout,"\tfloat");
+        break;
+        case DATADOUBLE:
+        fprintf(stdout,"\tdouble");
+        break;
+        case DATASTRING:
+        fprintf(stdout,"\tstring");
+        break;
+      }
+      fprintf(stdout,"\t%c%s%c",'"',a->name,'"');
+      fprintf(stdout," ");
+      for (x=0;x<a->dim;x++) fprintf(stdout,"[%d]",a->rng[a->dim-1-x]);
+    
+      fprintf(stdout,"=");
+      n=1;
+      for (x=0;x<a->dim;x++) n=a->rng[x]*n;
+      for (x=0;x<n;x++) {
+        if (x % a->rng[0]==0) fprintf(stdout,"\n\t\t");
+        else if (x !=0) fprintf(stdout,",\t");
+        switch (a->type) {
+        case DATACHAR:
+          fprintf(stdout,"%d",a->data.cptr[x]);
+          break;
+        case DATASHORT:
+          fprintf(stdout,"%d",a->data.sptr[x]);
+          break;
+        case DATAINT:
+          fprintf(stdout,"%d",a->data.lptr[x]);
+          break;
+        case DATAFLOAT:
+          fprintf(stdout,"%g",a->data.fptr[x]);
+          break;
+        case DATADOUBLE:
+          fprintf(stdout,"%g",a->data.dptr[x]);
+          break;	    
+        case DATASTRING:
+          tmp=(char **) a->data.vptr;
+          fprintf(stdout,"%c%s%c",'"',tmp[x],'"');
+          break;
+	    
+        }  
+        fprintf(stdout,"\n");
+      } 
+    }  
+    DataMapFree(ptr);
+
+  }
+  close(fid);
+  return 0;
+
+}

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapRead/makefile
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapRead/makefile
@@ -1,0 +1,15 @@
+# Makefile for DataMapRead
+# =========================
+# by R.J.Barnes
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general 
+IGNVER=1
+OBJS = DataMapRead.o
+OUTPUT = DataMapRead
+LIBS=-ldmap.1 -lrcnv.1 
+SLIB=-lm
+ 
+include $(MAKELIB).$(SYSTEM)

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapSize/DataMapSize.c
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapSize/DataMapSize.c
@@ -1,0 +1,40 @@
+/* DataMapSize.c
+   =============
+   Author: R.J.Barnes */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "rtypes.h"
+#include "dmap.h"
+
+
+
+int main(int argc,char *argv[]) {
+
+  int t,n;
+
+  float set[3]={2.1,2.2,12.2};
+  int value;
+
+  int32 dim=1;
+  int32 rng[1]={3};
+
+  struct DataMap *dmap;
+  int size;
+
+  dmap=DataMapMake();
+
+  DataMapAddArray(dmap,"set",DATAFLOAT,dim,rng,&set);
+  DataMapAddScalar(dmap,"value",DATAINT,&value);
+
+  for (t=0;t<100;t++) {
+    for (n=0;n<3;n++) set[n]=set[n]+0.6;
+    size=DataMapSize(dmap);
+    fprintf(stdout,"Size of data block:%d\n",size);
+  }
+  DataMapFree(dmap);
+  return 0;
+
+}

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapSize/makefile
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapSize/makefile
@@ -1,0 +1,15 @@
+# makefile for DataMapSize
+# ===========================
+# by R.J.Barnes
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general 
+IGNVER=1
+OBJS = DataMapSize.o
+OUTPUT = DataMapSize
+LIBS=-ldmap.1 -lrcnv.1 
+SLIB=-lm
+ 
+include $(MAKELIB).$(SYSTEM)

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapWrite/DataMapWrite.c
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapWrite/DataMapWrite.c
@@ -1,0 +1,50 @@
+/* DataMapWrite.c
+   ==============
+   Author: R.J.Barnes */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+
+#include "rtypes.h"
+#include "dmap.h"
+
+
+
+int main(int argc,char *argv[]) {
+
+  int t,n;
+
+  float set[3]={0.1,0.2,10.2};
+  int value;
+
+  int32 dim=1;
+  int32 rng[1]={3};
+
+  struct DataMap *dmap;
+
+  int fid=0;
+  int mask=S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+
+  dmap=DataMapMake();
+
+  DataMapAddArray(dmap,"set",DATAFLOAT,dim,rng,&set);
+  DataMapAddScalar(dmap,"value",DATAINT,&value);
+
+  fid=open("test.dmap",O_WRONLY | O_TRUNC | O_CREAT,mask);
+  
+
+  for (t=0;t<100;t++) {
+    for (n=0;n<3;n++) set[n]=set[n]+0.1;
+    DataMapWrite(fid,dmap);
+  }
+  DataMapFree(dmap);
+  close(fid);
+  return 0;
+
+}

--- a/codebase/general/src.lib/dmap.1.25/doc/src/DataMapWrite/makefile
+++ b/codebase/general/src.lib/dmap.1.25/doc/src/DataMapWrite/makefile
@@ -1,0 +1,15 @@
+# Makefile for DataMapWrite
+# ===========================
+# by R.J.Barnes
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general 
+IGNVER=1
+OBJS = DataMapWrite.o
+OUTPUT = DataMapWrite
+LIBS=-ldmap.1 -lrcnv.1 
+SLIB=-lm
+ 
+include $(MAKELIB).$(SYSTEM)

--- a/codebase/imagery/src.lib/szamap.1.11/doc/szamap.doc.xml
+++ b/codebase/imagery/src.lib/szamap.1.11/doc/szamap.doc.xml
@@ -8,7 +8,7 @@
 <name>SZAContour</name>
 <location>src.lib/szamap</location>
 <header>imagery/szamap.h</header>
-<syntax><sn href="&root;/src.lib/general/polygon/structPolygonData.html">struct PolygonData</sn> **SZAContour(int yr,int mo,int dy,int hr,int mt,int sc,int flg,int mode,float step,int znum,double *zenith);</syntax>
+<syntax><sn href="&root;/general/src.lib/polygon/structPolygonData.html">struct PolygonData</sn> **SZAContour(int yr,int mo,int dy,int hr,int mt,int sc,int flg,int mode,float step,int znum,double *zenith);</syntax>
 <description><p>The <fn href="SZAContour.html">SZACountour</fn> function generates a set of polygon contours for Solar Zenith Angle.</p>
 <p>The date and time at which to calculate the terminator is given by the arguments <ar>yr</ar>, <ar>mo</ar>, <ar>dy</ar>, <ar>hr</ar>, <ar>mt</ar>, and <ar>sc</ar>.</p>
 <p>The argument <ar>flg</ar> indicates which hemisphere to use. A value of (-1) finds the terminator in the southern hemisphere, a value of (1) finds the terminator in the northern hemisphere, and a value of zero will find it in both. The argument <ar>mode</ar> indicates whether geographic or geomagnetic coordinates are use. A value of zero will produce a polygon in geographic coordinates and a a value of (1) will produce one in geomagnetic coordinates.</p>
@@ -16,12 +16,9 @@
 <p>The argument <ar>znum</ar> gives the number of contour levels to calculate and the argument <ar>zenith</ar> is a pointer to an array containing the values of solar zenith angle.</p>
 </description> 
 <returns>Returns a pointer to a polygon array of contours of the desired solar zenith angles. On error, a <code>NULL</code> pointer is returned.</returns><errors>On error, a <code>NULL</code> pointer is returned.</errors>
-
 <example type="rplot">SZAContour</example>  
 <example type="source">SZAContour.c</example>
-
 </function>
-
 
 <function>
 <name>SZAMap</name>
@@ -36,7 +33,6 @@
 <p>The width and height of the grid are given by the arguments <ar>wdt</ar> and <ar>hgt</ar>.</p>
 <p>The argument <ar>mode</ar> indicates whether geographic or geomagnetic coordinates are use. A value of zero will produce a polygon in geographic coordinates and a a value of (1) will produce one in geomagnetic coordinates.</p>
 <p>The argument <ar>trnf</ar> is a pointer to a function of the form:</p>
-
 <fd>int (*trnf) (int ssze,void *src,int dsze,void *dst,void *dptr);</fd>
 <p>This function performs the transformation of the map projection.</p>
 <p>The size in bytes of the input coordinate is given be the argument <ar>ssze</ar>. The coordinate data is pointed to by the argument <ar>src</ar>. The first two elements stored in the coordinate data block are assumed to be single precision floating point numbers of type float that represent the actual latitude and longitude of the point to transform.</p>
@@ -48,18 +44,15 @@
 </description> 
 <returns>Returns a pointer to a two-dimensional array containing the solar zenith angles. On error a <code>NULL</code> pointer is returned.</returns>
 <errors>On error a <code>NULL</code> pointer is returned.</errors>
-
 <example type="rplot">SZAMap</example>  
 <example type="source">SZAMap.c</example>
-
-
 </function>
 
 <function>
 <name>SZATerminator</name>
 <location>src.lib/szamap</location>
 <header>imagery/szamap.h</header>
-<syntax><sn href="&root;/src.lib/general/polygon/structPolygonData.html">struct PolygonData</sn> *SZATerminator(int yr,int mo,int dy,int hr,int mt,int sc,int flg,int mode,float step,float zenith);</syntax>
+<syntax><sn href="&root;/general/src.lib/polygon/structPolygonData.html">struct PolygonData</sn> *SZATerminator(int yr,int mo,int dy,int hr,int mt,int sc,int flg,int mode,float step,float zenith);</syntax>
 <description><p>The <fn href="SZATerminator.html">SZATerminator</fn> function generates a polygon array for a given solar zenith angle.</p>
 <p>The date and time at which to calculate the terminator is given by the arguments <ar>yr</ar>, <ar>mo</ar>, <ar>dy</ar>, <ar>hr</ar>, <ar>mt</ar>, and <ar>sc</ar>.</p>
 <p>The argument <ar>flg</ar> indicates which hemisphere to use. A value of (-1) finds the terminator in the southern hemisphere, a value of (1) finds the terminator in the northern hemisphere, and a value of zero will find it in both. The argument <ar>mode</ar> indicates whether geographic or geomagnetic coordinates are use. A value of zero will produce a polygon in geographic coordinates and a a value of (1) will produce one in geomagnetic coordinates.</p>
@@ -67,12 +60,8 @@
 <p>The final argument <ar>zenith</ar> gives the desired solar zenith angle.</p>
 </description> 
 <returns>Returns a pointer to a polygon that matches the contour of the desired solar zenith angle. On error, a <code>NULL</code> pointer is returned.</returns><errors>On error, a <code>NULL</code> pointer is returned.</errors>
-
 <example type="rplot">SZATerminator</example>  
 <example type="source">SZATerminator.c</example>
-
 </function>
 
 </library>
-
-

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/fit.doc.xml
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/fit.doc.xml
@@ -163,7 +163,7 @@
 <name>FitToCFit</name>
 <location>src.lib/tk/fit</location>
 <header>superdarn/fitcfit.h</header>
-<syntax>int FitToCFit(double minpwr,<sn href="&root;/superdarn/src.lib/tk/cfit/structCFitData.html">struct CFitdata</sn> *ptr, <sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm</sn> *prm, <sn href="structFitData.html">struct FitData</sn> *fit);</syntax>
+<syntax>int FitToCFit(double minpwr,<sn href="&root;/superdarn/src.lib/tk/cfit/structCFitdata.html">struct CFitdata</sn> *ptr, <sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm</sn> *prm, <sn href="structFitData.html">struct FitData</sn> *fit);</syntax>
 <description><p>The <fn href="FitToCFit.html">FitToCFit</fn> function encodes a <code>fitacf</code> data record into a <code>CFit</code> data record.</p>
 <p>The argument <ar>minpwr</ar> gives the minimum value of lag-zero power to store; ranges with lag-zero power below this threshold are ignored.</p>
 <p>The <code>fit</code> data is encoded into the <code>CFit</code> data structure pointed to by the argument <ar>ptr</ar>. The <code>CFit</code> structure is encoded from the parameter block pointed to by the argument <ar>prm</ar> and the <code>fit</code> data structure pointer to by the argument <ar>fit</ar>.</p>  

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/oldfit.doc.xml
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/oldfit.doc.xml
@@ -7,7 +7,7 @@
 <name>OldFitClose</name>
 <location>src.lib/tk/oldfit</location>
 <header>superdarn/oldfitread.h</header>
-<syntax>void OldFitClose(<sn href="structOldFitFtp.html">struct OldFitFp</sn> *ptr);</syntax>
+<syntax>void OldFitClose(<sn href="structOldFitFp.html">struct OldFitFp</sn> *ptr);</syntax>
 
 <description><p>The <fn href="OldFitClose.html">OldFitClose</fn> function closes <code>fit</code> data file.</p>
 <p>The open file is pointed to by the argument <ar>ptr</ar>.</p>
@@ -20,7 +20,7 @@
 <name>OldFitFwrite</name>
 <location>src.lib/tk/oldfit</location>
 <header>superdarn/oldfitwrite.h</header>
-<syntax>int OldFitFwrite(FILE *fitfp,<sn href="&root;/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>, <sn href="&root;/src.lib/superdarn/atk/fit/structFitData.html">struct FitData</sn> *fit,int *rtab);</syntax>
+<syntax>int OldFitFwrite(FILE *fitfp,<sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>, <sn href="&root;/superdarn/src.lib/tk/fit/structFitData.html">struct FitData</sn> *fit,int *rtab);</syntax>
 <description><p>The <fn href="OldFitFwrite.html">OldFitFwrite</fn> function writes a <code>fit</code> data record to an open stream.</p>
 <p>The data is written to the open stream pointed to by the argument <ar>fp</ar>. The data record is contructed the radar parameter block pointed to by the argument <ar>prm</ar> and the <code>fit</code> data structure pointer to by the argument <ar>fit</ar>.</p>
 <p>The <code>raw</code> data records are limited to a maximum of 75 ranges. However the data could consist of more ranges than this and some form of mapping from the actual number of ranges to the (75)allowed in the file is required. This is done by using the <ar>rtab</ar> argument which is a pointer to an array listing which actual range each of the (75) allowed in the file. If this argument is set to a <code>NULL</code> pointer then no mapping is done and the first (75) ranges are used.</p>
@@ -64,7 +64,7 @@
 <name>OldFitInxClose</name>
 <location>src.lib/tk/oldfit</location>
 <header>superdarn/oldfitwrite.h</header>
-<syntax>int OldFitInxClose(int inxfd,<sn href="&root;/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>,int irec);</syntax>
+<syntax>int OldFitInxClose(int inxfd,<sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>,int irec);</syntax>
 
 <description><p>The <fn href="OldFitInxClose.html">OldFitInxClose</fn> function prepares an index file of a <code>fit</code> data file for closure.</p>
 <p>The file descriptor of the open index file is  given by the argument <ar>inxfd</ar>. The argument <ar>prm</ar> point to the last radar parameter block stored in the <code>fit</code> file and the argument <ar>irec</ar> is the index of the last record stored in the index file.</p>
@@ -80,7 +80,7 @@
 <name>OldFitInxFclose</name>
 <location>src.lib/tk/oldfit</location>
 <header>superdarn/oldfitwrite.h</header>
-<syntax>int OldFitInxFclose(FILE *inxfp,<sn href="&root;/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>,int irec);</syntax>
+<syntax>int OldFitInxFclose(FILE *inxfp,<sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>,int irec);</syntax>
 
 <description><p>The <fn href="OldFitInxFclose.html">OldFitInxFclose</fn> function prepares an index of a <code>fit</code> data file for closure.</p>
 <p>The index is written to the open stream pointed to by the argument <ar>inxfp</ar>. The argument <ar>prm</ar> point to the last radar parameter block stored in the <code>fit</code> file and the argument <ar>irec</ar> is the index of the last record stored in the index file.</p>
@@ -97,7 +97,7 @@
 <name>OldFitInxFwrite</name>
 <location>src.lib/tk/oldfit</location>
 <header>superdarn/oldfitwrite.h</header>
-<syntax>int OldFitInxFwrite(FILE *inxfp,int drec,int dnum,<sn href="&root;/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>);</syntax>
+<syntax>int OldFitInxFwrite(FILE *inxfp,int drec,int dnum,<sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>);</syntax>
 <description><p>The <fn href="OldFitInxFwrite.html">OldFitInxFwrite</fn> function writes a record to an index of a <code>fit</code> data file.</p>
 <p>The index is written to the open stream pointed to by the argument <ar>inxfp</ar>.The argument <ar>drec</ar>, is the block number of the start of the <code>fit</code> record in the associated <code>fit</code> file and the argument <ar>dnum</ar>, is the number of blocks required to store the <code>fit</code> data.</p>
 <p>The final argument <ar>prm</ar> is a pointer to the radar parameter block associated with the <code>fit</code> data.</p>
@@ -113,7 +113,7 @@
 <name>OldFitInxHeaderFwrite</name>
 <location>src.lib/tk/oldfit</location>
 <header>superdarn/oldfitwrite.h</header>
-<syntax>int OldFitInxHeaderFwrite(FILE *inxfp,<sn href="&root;/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>);</syntax>
+<syntax>int OldFitInxHeaderFwrite(FILE *inxfp,<sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>);</syntax>
 <description><p>The <fn href="OldFitInxHeaderFwrite.html">OldFitInxHeaderFwrite</fn> function writes a header record to an index of a <code>fit</code> data file.</p>
 <p>The header is written to the open stream pointed to by the argument <ar>inxfp</ar>.</p>
 <p>The argument <ar>prm</ar> is a pointer to the radar parameter block associated with the <code>fit</code> data.</p>
@@ -128,7 +128,7 @@
 <name>OldFitInxHeaderWrite</name>
 <location>src.lib/tk/oldfit</location>
 <header>superdarn/oldfitwrite.h</header>
-<syntax>int OldFitInxHeaderWrite(int inxfd,<sn href="&root;/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>);</syntax>
+<syntax>int OldFitInxHeaderWrite(int inxfd,<sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>);</syntax>
 <description><p>The <fn href="OldFitInxHeaderWrite.html">OldFitInxHeaderWrite</fn> function writes a header record to an index file of a <code>fit</code> data file.</p>
 <p>The header is written to the file with the descriptor given by the argument <ar>inxfd</ar>.</p>
 <p>The argument <ar>prm</ar> is a pointer to the radar parameter block associated with the <code>fit</code> data.</p>
@@ -143,7 +143,7 @@
 <name>OldFitInxWrite</name>
 <location>src.lib/tk/oldfit</location>
 <header>superdarn/oldfitwrite.h</header>
-<syntax>int OldFitInxWrite(int inxfp,int drec,int dnum,<sn href="&root;/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>);</syntax>
+<syntax>int OldFitInxWrite(int inxfp,int drec,int dnum,<sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>);</syntax>
 
 <description><p>The <fn href="OldFitInxWrite.html">OldFitInxWrite</fn> function writes a record to an index file of a <code>fit</code> data file.</p>
 <p>The record is written to the file with the descriptor given by the argument <ar>inxfd</ar>.The argument <ar>drec</ar>, is the block number of the start of the <code>fit</code> record in the associated <code>fit</code> file and the argument <ar>dnum</ar>, is the number of blocks required to store the <code>fit</code> data.</p>
@@ -161,7 +161,7 @@
 <header>superdarn/oldfitread.h</header>
 <syntax><sn href="structOldFitFp.html">struct OldFitFp</sn> *OldFitOpen(char *fitfile,char *inxfile);</syntax>
 
-<description><p>The <fn href="OldfitOpen.html">OldFitOpen</fn> function opens a <code>fit</code> data file for reading.</p>
+<description><p>The <fn href="OldFitOpen.html">OldFitOpen</fn> function opens a <code>fit</code> data file for reading.</p>
 <p>The name of the file to open is given by the zero terminated string pointed to by the argument <ar>fitfile</ar>. If the argument <ar>inxfile</ar> is not a <code>NULL</code> pointer is is assumed to point to a zero terminated string that gives the name of the index file associated with the <code>fit</code> file.</p>
 </description>
 <returns>Returns a pointer to the file control structure.On error, a <code>NULL</code> pointer is returned.</returns>
@@ -173,7 +173,7 @@
 <name>OldFitRead</name>
 <location>src.lib/tk/oldfit</location>
 <header>superdarn/oldfitread.h</header>
-<syntax>int OldFitRead(<sn href="structOldFitFp.html">struct OldFitFp *ptr</sn>,<sn href="&root;/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>, <sn href="&root;/src.lib/superdarn/atk/fit/structFitData.html">struct FitData</sn> *fit);</syntax>
+<syntax>int OldFitRead(<sn href="structOldFitFp.html">struct OldFitFp *ptr</sn>,<sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>, <sn href="&root;/superdarn/src.lib/tk/fit/structFitData.html">struct FitData</sn> *fit);</syntax>
 <description><p>The <fn href="OldFitRead.html">OldFitRead</fn> function reads a record from a <code>fit</code> data file.</p>
 <p>The data is read from the open file pointed to by the argument <ar>ptr</ar>. The data is decoded and used to populate the radar parameter block pointed to by the argument <ar>raw</ar> and the <code>fit</code> data structure pointer to by the argument <ar>fit</ar>.</p>  
 </description>
@@ -187,7 +187,7 @@
 <name>OldFitReadRadarScan</name>
 <location>src.lib/tk/oldfit</location>
 <header>superdarn/oldfitread.h</header>
-<syntax>int OldFitReadRadarScan(<sn href="structOldFitFp.html">struct OldFitFp</sn> *fp,int *state,  <sn href="&root;/src.lib/tk/scan/structRadarScan.html">struct RadarScan *ptr</sn>, <sn href="&root;/src.lib/superdarn/atk/radar/structRadarParm.html">struct RadarParm *prm</sn>, <sn href="&root;/src.lib/superdarn/atk/fit/structFitData.html">struct FitData</sn> *fit, int tlen, int lock,int chn);</syntax>
+<syntax>int OldFitReadRadarScan(<sn href="structOldFitFp.html">struct OldFitFp</sn> *fp,int *state,  <sn href="&root;/superdarn/src.lib/tk/scan/structRadarScan.html">struct RadarScan *ptr</sn>, <sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>, <sn href="&root;/superdarn/src.lib/tk/fit/structFitData.html">struct FitData</sn> *fit, int tlen, int lock,int chn);</syntax>
 
 <description><p>The <fn href="OldFitReadRadarScan.html">OldFitReadRadarScan</fn> function reads one full scan of data from a <code>fit</code> data file.</p>
 <p>The data is read from the open file pointed to by the argument <ar>fp</ar>.</p>
@@ -221,7 +221,7 @@
 <name>OldFitWrite</name>
 <location>src.lib/tk/oldfit</location>
 <header>superdarn/oldfitwrite.h</header>
-<syntax>int OldFitWrite(int fitfp,<sn href="&root;/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>, <sn href="&root;/src.lib/superdarn/atk/fit/structFitData.html">struct FitData</sn> *fit,int *rtab);</syntax>
+<syntax>int OldFitWrite(int fitfp,<sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>, <sn href="&root;/superdarn/src.lib/tk/fit/structFitData.html">struct FitData</sn> *fit,int *rtab);</syntax>
 
 <description><p>The <fn href="OldFitWrite.html">OldFitWrite</fn> function writes a <code>fit</code> data record to an open file.</p>
 <p>The data is written to the open file with the descriptor given by the argument <ar>fid</ar>. The data record is contructed the radar parameter block pointed to by the argument <ar>prm</ar> and the <code>fit</code> data structure pointer to by the argument <ar>fit</ar>.</p>
@@ -332,7 +332,7 @@
   </member>
 
   <member>
-      <proto>int (*fitread)(<sn href="structOldFitFp.html">struct OldFitFp</sn> *fp,<sn href="&root;/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>, <sn href="&root;/src.lib/superdarn/atk/fit/structFitData.html">struct FitData</sn> *fit);</proto>
+      <proto>int (*fitread)(<sn href="structOldFitFp.html">struct OldFitFp</sn> *fp,<sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>, <sn href="&root;/superdarn/src.lib/tk/fit/structFitData.html">struct FitData</sn> *fit);</proto>
       <description>Pointer to the function that reads records from the file.</description>
   </member>
  </struct>

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/oldraw.doc.xml
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/oldraw.doc.xml
@@ -178,7 +178,7 @@
     </member>
 
     <member>
-      <proto>int (*rawread)(<sn href="structOldRawFp.html">struct OldRawFp</sn> *fp,<sn href="&root;/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>, <sn href="&root;/src.lib/superdarn/atk/raw/structRawData.html">struct RawData</sn> *raw);</proto>
+        <proto>int (*rawread)(<sn href="structOldRawFp.html">struct OldRawFp</sn> *fp,<sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm *prm</sn>, <sn href="&root;/superdarn/src.lib/tk/raw/structRawData.html">struct RawData</sn> *raw);</proto>
       <description>Pointer to the function that reads records from the file.</description>
     </member>
 

--- a/codebase/superdarn/src.lib/tk/raw.1.22/doc/raw.doc.xml
+++ b/codebase/superdarn/src.lib/tk/raw.1.22/doc/raw.doc.xml
@@ -86,7 +86,7 @@
 <name>RawRead</name>
 <location>src.lib/tk/raw</location>
 <header>superdarn/rawread.h</header>
-<syntax>int RawRead(int fid,<sn href="&root;/superdarn/src.lib/tk/radar/RadarParm.html">struct RadarParm</sn> *prm, <sn href="structRawData.html">struct RawData</sn> *raw);</syntax>
+<syntax>int RawRead(int fid,<sn href="&root;/superdarn/src.lib/tk/radar/structRadarParm.html">struct RadarParm</sn> *prm, <sn href="structRawData.html">struct RawData</sn> *raw);</syntax>
 <description><p>The <fn href="RawRead.html">RawRead</fn> function reads a <code>rawacf</code> data record from an open file.</p>
 <p>The data is read from the file with the descriptor given by the argument <ar>fid</ar>. The data is decoded and used to populate the radar parameter block pointed to by the argument <ar>prm</ar> and the raw data structure pointer to by the argument <ar>raw</ar>.</p>  
 </description>


### PR DESCRIPTION
I've recompiled the documentation hosted at http://superdarn.thayer.dartmouth.edu/software.html using the release-4.0 branch and came across a few final errors.  The first commit here fixes a broken link, and the second re-introduces the dmap library documentation from an older copy of RST (3.2) here at Dartmouth.  Not sure why the dmap documentation was removed (apparently between releases 3.2 and 3.3), but it caused a lot of links to break.  There may be a few more minor documentation fixes incoming over the next few days; these should in no way affect compilation or functionality of any of the software.