### PR TITLE
Fixing 'update' keyword bugs in several DLMs

### DIFF
--- a/codebase/analysis/src.dlm/igrfdlm.1.3/igrfdlm.c
+++ b/codebase/analysis/src.dlm/igrfdlm.1.3/igrfdlm.c
@@ -1,5 +1,5 @@
-/* aacgmdlm.c
-   =========== 
+/* igrfdlm.c
+   =========
    Author R.J.Barnes
 */
 

--- a/codebase/superdarn/src.dlm/cnvmapdlm.1.7/cnvmapdlm.c
+++ b/codebase/superdarn/src.dlm/cnvmapdlm.1.7/cnvmapdlm.c
@@ -453,16 +453,16 @@ static IDL_VPTR IDLCnvMapOpen(int argc,IDL_VPTR *argv,char *argk) {
   int access=0;
 
   static IDL_KW_PAR kw_pars[]={IDL_KW_FAST_SCAN,
-			       {"READ",IDL_TYP_LONG,1,
+                               {"READ",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iread)},
-			       {"WRITE",IDL_TYP_LONG,1,
+                               {"UPDATE",IDL_TYP_LONG,1,
+                                IDL_KW_ZERO,0,
+                                IDL_CHARA(iupdate)},
+                               {"WRITE",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iwrite)},
-         	               {"UPDATE",IDL_TYP_LONG,1,
-                                IDL_KW_ZERO,0,
-                                IDL_CHARA(iwrite)},
-				 {NULL}};
+                                 {NULL}};
 
   IDL_KWCleanup(IDL_KW_MARK);
   IDL_KWGetParams(argc,argv,argk,kw_pars,outargv,1);

--- a/codebase/superdarn/src.dlm/cnvmapdlm.1.7/makefile
+++ b/codebase/superdarn/src.dlm/cnvmapdlm.1.7/makefile
@@ -1,5 +1,5 @@
-# Makefile for grddlm DLM
-# =======================
+# Makefile for cnvmapdlm DLM
+# ==========================
 # by R.J.Barnes
 #
 #

--- a/codebase/superdarn/src.dlm/fitdlm.1.7/fitdlm.c
+++ b/codebase/superdarn/src.dlm/fitdlm.1.7/fitdlm.c
@@ -372,16 +372,16 @@ static IDL_VPTR IDLFitOpen(int argc,IDL_VPTR *argv,char *argk) {
   int access=0;
 
   static IDL_KW_PAR kw_pars[]={IDL_KW_FAST_SCAN,
-			       {"READ",IDL_TYP_LONG,1,
+                               {"READ",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iread)},
-			       {"WRITE",IDL_TYP_LONG,1,
+                               {"UPDATE",IDL_TYP_LONG,1,
+                                IDL_KW_ZERO,0,
+                                IDL_CHARA(iupdate)},
+                               {"WRITE",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iwrite)},
-         	               {"UPDATE",IDL_TYP_LONG,1,
-                                IDL_KW_ZERO,0,
-                                IDL_CHARA(iwrite)},
-				 {NULL}};
+                                 {NULL}};
 
   IDL_KWCleanup(IDL_KW_MARK);
   IDL_KWGetParams(argc,argv,argk,kw_pars,outargv,1);

--- a/codebase/superdarn/src.dlm/grddlm.1.7/grddlm.c
+++ b/codebase/superdarn/src.dlm/grddlm.1.7/grddlm.c
@@ -383,16 +383,16 @@ static IDL_VPTR IDLGridOpen(int argc,IDL_VPTR *argv,char *argk) {
   int access=0;
 
   static IDL_KW_PAR kw_pars[]={IDL_KW_FAST_SCAN,
-			       {"READ",IDL_TYP_LONG,1,
+                               {"READ",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iread)},
-			       {"WRITE",IDL_TYP_LONG,1,
+                               {"UPDATE",IDL_TYP_LONG,1,
+                                IDL_KW_ZERO,0,
+                                IDL_CHARA(iupdate)},
+                               {"WRITE",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iwrite)},
-         	               {"UPDATE",IDL_TYP_LONG,1,
-                                IDL_KW_ZERO,0,
-                                IDL_CHARA(iwrite)},
-				 {NULL}};
+                                 {NULL}};
 
   IDL_KWCleanup(IDL_KW_MARK);
   IDL_KWGetParams(argc,argv,argk,kw_pars,outargv,1);

--- a/codebase/superdarn/src.dlm/iqdlm.1.6/iqdlm.c
+++ b/codebase/superdarn/src.dlm/iqdlm.1.6/iqdlm.c
@@ -422,16 +422,16 @@ static IDL_VPTR IDLIQOpen(int argc,IDL_VPTR *argv,char *argk) {
   int access=0;
 
   static IDL_KW_PAR kw_pars[]={IDL_KW_FAST_SCAN,
-			       {"READ",IDL_TYP_LONG,1,
+                               {"READ",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iread)},
-			       {"WRITE",IDL_TYP_LONG,1,
+                               {"UPDATE",IDL_TYP_LONG,1,
+                                IDL_KW_ZERO,0,
+                                IDL_CHARA(iupdate)},
+                               {"WRITE",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iwrite)},
-         	               {"UPDATE",IDL_TYP_LONG,1,
-                                IDL_KW_ZERO,0,
-                                IDL_CHARA(iwrite)},
-				 {NULL}};
+                                 {NULL}};
 
   IDL_KWCleanup(IDL_KW_MARK);
   IDL_KWGetParams(argc,argv,argk,kw_pars,outargv,1);

--- a/codebase/superdarn/src.dlm/oldcnvmapdlm.1.4/oldcnvmapdlm.c
+++ b/codebase/superdarn/src.dlm/oldcnvmapdlm.1.4/oldcnvmapdlm.c
@@ -492,16 +492,16 @@ static IDL_VPTR IDLOldCnvMapOpen(int argc,IDL_VPTR *argv,char *argk) {
   int access=0;
 
   static IDL_KW_PAR kw_pars[]={IDL_KW_FAST_SCAN,
-			       {"READ",IDL_TYP_LONG,1,
+                               {"READ",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iread)},
-			       {"WRITE",IDL_TYP_LONG,1,
+                               {"UPDATE",IDL_TYP_LONG,1,
+                                IDL_KW_ZERO,0,
+                                IDL_CHARA(iupdate)},
+                               {"WRITE",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iwrite)},
-         	               {"UPDATE",IDL_TYP_LONG,1,
-                                IDL_KW_ZERO,0,
-                                IDL_CHARA(iwrite)},
-				 {NULL}};
+                                 {NULL}};
 
   IDL_KWCleanup(IDL_KW_MARK);
   IDL_KWGetParams(argc,argv,argk,kw_pars,outargv,1);

--- a/codebase/superdarn/src.dlm/oldgrddlm.1.6/makefile
+++ b/codebase/superdarn/src.dlm/oldgrddlm.1.6/makefile
@@ -1,5 +1,5 @@
-# Makefile for grddlm DLM
-# =======================
+# Makefile for oldgrddlm DLM
+# ==========================
 # by R.J.Barnes
 #
 #

--- a/codebase/superdarn/src.dlm/oldgrddlm.1.6/oldgrddlm.c
+++ b/codebase/superdarn/src.dlm/oldgrddlm.1.6/oldgrddlm.c
@@ -426,16 +426,16 @@ static IDL_VPTR IDLOldGridOpen(int argc,IDL_VPTR *argv,char *argk) {
   int access=0;
 
   static IDL_KW_PAR kw_pars[]={IDL_KW_FAST_SCAN,
-			       {"READ",IDL_TYP_LONG,1,
+                               {"READ",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iread)},
-			       {"WRITE",IDL_TYP_LONG,1,
+                               {"UPDATE",IDL_TYP_LONG,1,
+                                IDL_KW_ZERO,0,
+                                IDL_CHARA(iupdate)},
+                               {"WRITE",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iwrite)},
-         	               {"UPDATE",IDL_TYP_LONG,1,
-                                IDL_KW_ZERO,0,
-                                IDL_CHARA(iwrite)},
-				 {NULL}};
+                                 {NULL}};
 
   IDL_KWCleanup(IDL_KW_MARK);
   IDL_KWGetParams(argc,argv,argk,kw_pars,outargv,1);

--- a/codebase/superdarn/src.dlm/oldgrddlm.1.6/oldgrddlm.c
+++ b/codebase/superdarn/src.dlm/oldgrddlm.1.6/oldgrddlm.c
@@ -1,5 +1,5 @@
-/* grddlm.c
-   ========== 
+/* oldgrddlm.c
+   ===========
    Author R.J.Barnes
 */
 

--- a/codebase/superdarn/src.dlm/rawdlm.1.7/rawdlm.c
+++ b/codebase/superdarn/src.dlm/rawdlm.1.7/rawdlm.c
@@ -372,16 +372,16 @@ static IDL_VPTR IDLRawOpen(int argc,IDL_VPTR *argv,char *argk) {
   int access=0;
 
   static IDL_KW_PAR kw_pars[]={IDL_KW_FAST_SCAN,
-			       {"READ",IDL_TYP_LONG,1,
+                               {"READ",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iread)},
-			       {"WRITE",IDL_TYP_LONG,1,
+                               {"UPDATE",IDL_TYP_LONG,1,
+                                IDL_KW_ZERO,0,
+                                IDL_CHARA(iupdate)},
+                               {"WRITE",IDL_TYP_LONG,1,
                                 IDL_KW_ZERO,0,
                                 IDL_CHARA(iwrite)},
-         	               {"UPDATE",IDL_TYP_LONG,1,
-                                IDL_KW_ZERO,0,
-                                IDL_CHARA(iwrite)},
-				 {NULL}};
+                                 {NULL}};
 
   IDL_KWCleanup(IDL_KW_MARK);
   IDL_KWGetParams(argc,argv,argk,kw_pars,outargv,1);


### PR DESCRIPTION
This pull request fixes two bugs identified in the file open functions in several of the superdarn DLMs.  First, the "Keyword UPDATE not allowed in call to: ***OPEN" error message returned when trying to set the
'update' keyword with DLMs enabled is fixed by re-organizing the elements of the kw_par structure into alphabetical order such that the "UPDATE" keyword is listed before the "WRITE" keyword rather than after.
Second, this commit fixes a bug where the iwrite variable was being used for both the 'update' and 'write' keywords in the same file open functions within the kw_par structure of the DLMs.