### PR TITLE
Fixing compilation warning for fprintf/printf/sprintf calls

### DIFF
--- a/codebase/base/src.bin/build/addtext.1.7/addtext.c
+++ b/codebase/base/src.bin/build/addtext.1.7/addtext.c
@@ -39,7 +39,7 @@ char *rtext={"text"};
 
 void print_info(FILE *fp,char *str[]) {
   int i;
-  for (i=0;str[i] !=NULL;i++) fprintf(fp,str[i]);
+  for (i=0;str[i] !=NULL;i++) fprintf(fp,"%s",str[i]);
 }
 
 

--- a/codebase/base/src.bin/build/makeall.1.22/makeall.c
+++ b/codebase/base/src.bin/build/makeall.1.22/makeall.c
@@ -62,8 +62,8 @@ char *patn=NULL;
 
 
 void log_info(char *text) {
-  if (vbflg==1) fprintf(stderr,text);
-  fprintf(stdout,text);
+  if (vbflg==1) fprintf(stderr,"%s",text);
+  fprintf(stdout,"%s",text);
   fflush(stdout);
 }
 
@@ -256,7 +256,7 @@ int dsort(const void *a,const void *b) {
 
 void print_info(FILE *fp,char *str[]) {
   int i;
-  for (i=0;str[i] !=NULL;i++) fprintf(fp,str[i]);
+  for (i=0;str[i] !=NULL;i++) fprintf(fp,"%s",str[i]);
 }
 
 

--- a/codebase/base/src.bin/memory/shmemrecv.1.3/shmemrecv.c
+++ b/codebase/base/src.bin/memory/shmemrecv.1.3/shmemrecv.c
@@ -29,7 +29,7 @@ int main(int argc,char *argv[]) {
 
     ShMemFree(shm,memory,256,0,shmemfd);
 
-    fprintf(stdout,date);
+    fprintf(stdout,"%s",date);
     
     sleep(1);
 

--- a/codebase/base/src.bin/memory/shmemsend.1.3/shmemsend.c
+++ b/codebase/base/src.bin/memory/shmemsend.1.3/shmemsend.c
@@ -43,7 +43,7 @@ int main(int argc,char *argv[]) {
 
     date=asctime(time_of_day);  
 
-    fprintf(stdout,date);
+    fprintf(stdout,"%s",date);
     
     strcpy( (char *) shm,date);
     

--- a/codebase/base/src.bin/tcpip/ipserver.1.12/log_info.c
+++ b/codebase/base/src.bin/tcpip/ipserver.1.12/log_info.c
@@ -51,15 +51,15 @@ void log_info(char *str) {
 
   date[strlen(date)-1]=':';
   
-  fprintf(stderr,date);
-  fprintf(stderr,str);
+  fprintf(stderr,"%s",date);
+  fprintf(stderr,"%s",str);
   fprintf(stderr,"\n");
 
 
   sprintf(logpath,"%s.%.3d",logfname,time_of_day->tm_yday);
   fp=fopen(logpath,"a");
-  fprintf(fp,date);
-  fprintf(fp,str);
+  fprintf(fp,"%s",date);
+  fprintf(fp,"%s",str);
   fprintf(fp,"\n");
   fclose(fp);
 }

--- a/codebase/base/src.lib/graphic/fontdb.1.9/src/fontdb.c
+++ b/codebase/base/src.lib/graphic/fontdb.1.9/src/fontdb.c
@@ -121,7 +121,7 @@ int FrameBufferFontDBEnd(char *name,char *buf,int sze,void *data) {
   fname=malloc(s);
   if (fname==NULL) return -1;
   if (ptr->path !=NULL) sprintf(fname,"%s/%s",ptr->path,ptr->buf);
-  else sprintf(fname,ptr->buf);
+  else sprintf(fname,"%s",ptr->buf);
  
   fp=fopen(fname,"r");
   free(fname);

--- a/codebase/base/src.lib/task/option.1.7/src/printinfo.c
+++ b/codebase/base/src.lib/task/option.1.7/src/printinfo.c
@@ -51,15 +51,15 @@ void OptionPrintInfo(FILE *fp,char *str[]) {
   for (i=0;str[i] !=NULL;i++) {
     for (j=0;str[i][j] !=0;j++) if (str[i][j]=='\t') break;
     if (str[i][j]==0) {
-      fprintf(fp,str[i]);
+      fprintf(fp,"%s",str[i]);
       continue;
     }
     strncpy(buffer,str[i],4095);
     buffer[j]=0;
-    fprintf(fp,buffer);
+    fprintf(fp,"%s",buffer);
     for (k=0;k<(maxtab-j);k++) buffer[k]=' ';
     buffer[k]=0;
-    fprintf(fp,buffer);
+    fprintf(fp,"%s",buffer);
     j++;
     /* chop the rest of the buffer up into 80 character long lines */
     m=0;
@@ -73,11 +73,11 @@ void OptionPrintInfo(FILE *fp,char *str[]) {
           fprintf(fp,"\n");
           for (n=0;n<maxtab;n++) buffer[m+n]=' ';
 	  buffer[m+n]=0;
-          fprintf(fp,buffer+m);
+          fprintf(fp,"%s",buffer+m);
           l=maxtab;
         }
         buffer[m]=0; 
-        fprintf(fp,buffer);
+        fprintf(fp,"%s",buffer);
         l+=m-1;
         m=0;
       }     
@@ -88,7 +88,7 @@ void OptionPrintInfo(FILE *fp,char *str[]) {
       l=maxtab;
     }
     buffer[m]=0;
-    fprintf(fp,buffer);
+    fprintf(fp,"%s",buffer);
   }
 }
 

--- a/codebase/general/src.bin/dmap/dmaptoskeleton.1.8/dmaptoskeleton.c
+++ b/codebase/general/src.bin/dmap/dmaptoskeleton.1.8/dmaptoskeleton.c
@@ -335,7 +335,7 @@ int main(int argc,char *argv[]) {
     fprintf(fp,"! --------          ----     --------  --------  ---------\n");
     fprintf(fp,"\n");
     sprintf(buf,"  %c%s%c",'"',cdfsname[n],'"');
-    fprintf(fp,buf);
+    fprintf(fp,"%s",buf);
     tab=18-strlen(buf);
     if (tab>0) for (c=0;c<tab;c++) fprintf(fp," ");
     else fprintf(fp," ");
@@ -385,7 +385,7 @@ int main(int argc,char *argv[]) {
     fprintf(fp,"  -----  --------  ---------\n");
     fprintf(fp,"\n");
     sprintf(buf,"  %c%s%c",'"',cdfaname[n],'"');
-    fprintf(fp,buf);
+    fprintf(fp,"%s",buf);
     tab=18-strlen(buf);
     if (tab>0) for (c=0;c<tab;c++) fprintf(fp," ");
     else fprintf(fp," ");

--- a/codebase/general/src.bin/task/etime.1.8/etime.c
+++ b/codebase/general/src.bin/task/etime.1.8/etime.c
@@ -174,7 +174,7 @@ int main(int argc,char *argv[]) {
     if (day==0) fprintf(stdout,"%d",(int) tval);
     else fprintf(stdout,"%d",(int) tval % (24*3600));
 
-    fprintf(stdout,buffer);
+    fprintf(stdout,"%s",buffer);
   }
   if (fp !=stdin) fclose(fp);
   return 0;

--- a/codebase/general/src.bin/tcpip/rtmultiplex.1.32/loginfo.c
+++ b/codebase/general/src.bin/tcpip/rtmultiplex.1.32/loginfo.c
@@ -53,9 +53,9 @@ void loginfo(char *fname,char *str) {
   date[strlen(date)-1]=':';
   
   sprintf(pid,"(%d):",getpid());
-  fprintf(stderr,date);
-  fprintf(stderr,pid);
-  fprintf(stderr,str);
+  fprintf(stderr,"%s",date);
+  fprintf(stderr,"%s",pid);
+  fprintf(stderr,"%s",str);
   fprintf(stderr,"\n");
 
   sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
@@ -68,9 +68,9 @@ void loginfo(char *fname,char *str) {
     return;
   }
 
-  fprintf(fp,date);
-  fprintf(fp,pid);
-  fprintf(fp,str);
+  fprintf(fp,"%s",date);
+  fprintf(fp,"%s",pid);
+  fprintf(fp,"%s",str);
   fprintf(fp,"\n");
   fclose(fp);
 }

--- a/codebase/general/src.bin/tcpip/rtpoll.1.15/log_info.c
+++ b/codebase/general/src.bin/tcpip/rtpoll.1.15/log_info.c
@@ -49,8 +49,8 @@ void log_info(char *fname,char *str) {
 
   date[strlen(date)-1]=':';
   
-  fprintf(stderr,date);
-  fprintf(stderr,str);
+  fprintf(stderr,"%s",date);
+  fprintf(stderr,"%s",str);
   fprintf(stderr,"\n");
 
   sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
@@ -58,8 +58,8 @@ void log_info(char *fname,char *str) {
           time_of_day->tm_mday);
 
   fp=fopen(logpath,"a");
-  fprintf(fp,date);
-  fprintf(fp,str);
+  fprintf(fp,"%s",date);
+  fprintf(fp,"%s",str);
   fprintf(fp,"\n");
   fclose(fp);
 }

--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfserver.1.17/loginfo.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfserver.1.17/loginfo.c
@@ -49,8 +49,8 @@ void loginfo(char *fname,char *str) {
 
   date[strlen(date)-1]=':';
   
-  fprintf(stderr,date);
-  fprintf(stderr,str);
+  fprintf(stderr,"%s",date);
+  fprintf(stderr,"%s",str);
   fprintf(stderr,"\n");
 
    sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
@@ -62,8 +62,8 @@ void loginfo(char *fname,char *str) {
     fprintf(stderr,"WARNING:Log failed.\n");
     return;
   }
-  fprintf(fp,date);
-  fprintf(fp,str);
+  fprintf(fp,"%s",date);
+  fprintf(fp,"%s",str);
   fprintf(fp,"\n");
   fclose(fp);
 }

--- a/codebase/superdarn/src.bin/tk/tcpip/rtfitacftofit.1.19/loginfo.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/rtfitacftofit.1.19/loginfo.c
@@ -49,8 +49,8 @@ void loginfo(char *fname,char *str) {
 
   date[strlen(date)-1]=':';
   
-  fprintf(stderr,date);
-  fprintf(stderr,str);
+  fprintf(stderr,"%s",date);
+  fprintf(stderr,"%s",str);
   fprintf(stderr,"\n");
 
   sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
@@ -63,8 +63,8 @@ void loginfo(char *fname,char *str) {
     return;
   }
 
-  fprintf(fp,date);
-  fprintf(fp,str);
+  fprintf(fp,"%s",date);
+  fprintf(fp,"%s",str);
   fprintf(fp,"\n");
   fclose(fp);
 }

--- a/codebase/superdarn/src.bin/tk/tcpip/rtfittofitacf.1.20/loginfo.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/rtfittofitacf.1.20/loginfo.c
@@ -49,8 +49,8 @@ void loginfo(char *fname,char *str) {
 
   date[strlen(date)-1]=':';
   
-  fprintf(stderr,date);
-  fprintf(stderr,str);
+  fprintf(stderr,"%s",date);
+  fprintf(stderr,"%s",str);
   fprintf(stderr,"\n");
 
   sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
@@ -63,8 +63,8 @@ void loginfo(char *fname,char *str) {
     return;
   }
 
-  fprintf(fp,date);
-  fprintf(fp,str);
+  fprintf(fp,"%s",date);
+  fprintf(fp,"%s",str);
   fprintf(fp,"\n");
   fclose(fp);
 }

--- a/codebase/superdarn/src.bin/tk/tool/merge_rt.1.19/log_info.c
+++ b/codebase/superdarn/src.bin/tk/tool/merge_rt.1.19/log_info.c
@@ -49,8 +49,8 @@ void log_info(char *fname,char *str) {
 
   date[strlen(date)-1]=':';
   
-  fprintf(stderr,date);
-  fprintf(stderr,str);
+  fprintf(stderr,"%s",date);
+  fprintf(stderr,"%s",str);
   fprintf(stderr,"\n");
 
   sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
@@ -58,8 +58,8 @@ void log_info(char *fname,char *str) {
           time_of_day->tm_mday);
 
   fp=fopen(logpath,"a");
-  fprintf(fp,date);
-  fprintf(fp,str);
+  fprintf(fp,"%s",date);
+  fprintf(fp,"%s",str);
   fprintf(fp,"\n");
   fclose(fp);
 }

--- a/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/loginfo.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/loginfo.c
@@ -51,8 +51,8 @@ void loginfo(char *fname,char *str) {
   date[strlen(date)-1]=':';
   
   if (dotflag==1) fprintf(stderr,"\n");
-  fprintf(stderr,date);
-  fprintf(stderr,str);
+  fprintf(stderr,"%s",date);
+  fprintf(stderr,"%s",str);
   fprintf(stderr,"\n");
   dotflag=0;
   sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
@@ -63,8 +63,8 @@ void loginfo(char *fname,char *str) {
     fprintf(stderr,"WARNING:Log failed.\n");
     return;
   }
-  fprintf(fp,date);
-  fprintf(fp,str);
+  fprintf(fp,"%s",date);
+  fprintf(fp,"%s",str);
   fprintf(fp,"\n");
   fclose(fp);
 }

--- a/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/loginfo.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/loginfo.c
@@ -52,8 +52,8 @@ void loginfo(char *fname,char *str) {
   date[strlen(date)-1]=':';
   
   if (dotflag==1) fprintf(stderr,"\n");
-  fprintf(stderr,date);
-  fprintf(stderr,str);
+  fprintf(stderr,"%s",date);
+  fprintf(stderr,"%s",str);
   fprintf(stderr,"\n");
   dotflag=0;
 
@@ -61,8 +61,8 @@ void loginfo(char *fname,char *str) {
           time_of_day->tm_year,time_of_day->tm_mon+1,
           time_of_day->tm_mday);
   fp=fopen(logpath,"a");
-  fprintf(fp,date);
-  fprintf(fp,str);
+  fprintf(fp,"%s",date);
+  fprintf(fp,"%s",str);
   fprintf(fp,"\n");
   fclose(fp);
 }


### PR DESCRIPTION
This pull request addresses the "...: warning: format not a string literal and no format arguments [-Wformat-security]" error listed for multiple libraries and binaries during compilation via execution of 'make.code superdarn rst'.  As pointed out by Bill Bristow, the fix was simply to insert "%s", e.g. fprintf(fp,"%s",buf). Not only will this reduce the number of compilation errors listed in the logfile but it should also help with installation on MacOS systems.  Note that when I tried compiling on a Mac, make.code failed when I hit a compiler warning about sprintf in the fontdb.1.9 library (see my comments in #62).