### PR TITLE
Fixing bug in GridSeek when records are missing (trim_grid and grid_plot)

### DIFF
--- a/codebase/superdarn/src.lib/tk/grid.1.24/src/gridseek.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/src/gridseek.c
@@ -123,13 +123,14 @@ int GridSeek(int fid,
       if (tfile>tval) fptr=lseek(fid,0,SEEK_SET);
     } else fptr=lseek(fid,0,SEEK_SET);
     if (atme!=NULL) *atme=tfile;
-    while (tval>=tfile) {
+    while (tval>tfile) {
       tptr=lseek(fid,0,SEEK_CUR);
       ptr=DataMapRead(fid);
       if (ptr==NULL) break;
       tfile=GridGetTime(ptr);
       DataMapFree(ptr);
-      if (tval>=tfile) fptr=tptr;
+      /*if (tval>=tfile) fptr=tptr;*/
+      fptr=tptr;
       if (atme !=NULL) *atme=tfile;
     }
     if (tval>tfile) return -1;


### PR DESCRIPTION
This commit fixes an issue identified by Maria-Theresia Walach at Lancaster University with `trim_grid` when there are records missing in a grid file.  Currently, `trim_grid` calls GridSeek to identify the starting record based on the command line option inputs. If a record is missing, rather than going to the next available record after the provided start time, GridSeek will point to the last record before the gap, ie earlier than the provided start time.  This problem also occurs in `grid_plot` as it is the only other piece of code which uses GridSeek.

To test, on the `develop` branch execute `make_grid -new -i 120 -tl 120 -c 20140104.*.cve.fitacf > 20140104.cve.grdmap` with the following files:
```
20140104.0401.00.cve.fitacf
20140104.0530.57.cve.fitacf 
20140104.0545.57.cve.fitacf 
20140104.0600.58.cve.fitacf
20140104.0801.00.cve.fitacf
```
There will be a data gap in the resulting grid file between 05:48 and 06:02 UT.  Try plotting with a start time of 06:00 UT to see what happens:
```
grid_plot -x -delay 0 -mag -rotate -fcoast -vecp -vkeyp -vkey color.key -time -raw -grd -grdontop -sd 20140104 -st 06:00 -new 20140104.cve.grdmap
```
Notice how the first figure to appear corresponds to the 05:48 record and not 06:02 - this is because of the bug in GridSeek.  Now try trimming the grid file to a 2-hour grid file from 06:00-08:00 UT with the following command:
```
trim_grid -sd 20140104 -st 06:00 -et 08:00 -new 20140104.cve.grdmap > 2014010406.cve.grdmap
```
Again, the 05:48 record appears in the trimmed grid file.  Now switch to the `trim_bugfix` branch and repeat the plotting and trimming steps - everything should now work as expected.