### PR TITLE
Updating aacgmeval and mlteval to use v2 coefficients by default

### DIFF
--- a/codebase/analysis/src.bin/aacgm/aacgmeval.1.2/doc/aacgmeval.doc.xml
+++ b/codebase/analysis/src.bin/aacgm/aacgmeval.1.2/doc/aacgmeval.doc.xml
@@ -26,7 +26,7 @@
 </option>
 <option><on>-fmt <ar>format</ar></on><od>use the string <ar>fmt</ar>, to format the output.</od>
 </option>
-<option><on>-f <ar>filename</ar></on><od>read a sequence of dates, times and longitudes from the ASCII file, <ar>filename</ar>.</od>
+<option><on>-f <ar>filename</ar></on><od>read a sequence of latitudes, longitudes and altitudes from the ASCII file, <ar>filename</ar>.</od>
 </option>
 <option><on>-old_aacgm</on><od>use old AACGM coordinates rather than v2.</od>
 </option>

--- a/codebase/analysis/src.bin/aacgm/aacgmeval.1.2/doc/aacgmeval.doc.xml
+++ b/codebase/analysis/src.bin/aacgm/aacgmeval.1.2/doc/aacgmeval.doc.xml
@@ -3,54 +3,47 @@
 <project>analysis</project>
 <name>aacgmeval</name>
 <location>src.bin/aacgm/aacgmeval</location>
+
 <syntax>aacgmeval --help</syntax>
 <syntax>aacgmeval [-i] [-lat <ar>lat</ar>] [-lon <ar>lon</ar>] [-alt <ar>alt</ar>] [-fmt <ar>format</ar>]</syntax>
- <syntax>aacgmeval [-i] [-f <ar>filename</ar>]  [-fmt <ar>format</ar>]</syntax>
+<syntax>aacgmeval [-i] [-f <ar>filename</ar>]  [-fmt <ar>format</ar>]</syntax>
 
-
-<synopsis><p>Convert to and from Altitude Adjusted Corrected Geo-Magnetic Coordinates (AACGM).</p></synopsis>
-
+<synopsis><p>Convert to and from Altitude Adjusted Corrected Geo-Magnetic Coordinates v2 (AACGM_v2).</p></synopsis>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
-
 <option><on>-i</on><od>perform the inverse conversion from AACGM to geographic.</od>
 </option>
-
-
 <option><on>-lat <ar>lat</ar></on><od>calculate for the latitude <ar>lat</ar>.</od>
 </option>
 <option><on>-lon <ar>lon</ar></on><od>calculate for the longitude <ar>lon</ar>.</od>
 </option>
-<option><on>-alt <ar>mlon</ar></on><od>calculate for the altitude in kilometers, e <ar>alt</ar>.</od>
+<option><on>-alt <ar>mlon</ar></on><od>calculate for the altitude in kilometers, <ar>alt</ar>.</od>
 </option>
-
-
-
+<option><on>-d <ar>yyyymmdd</ar></on><od>calculate for the date <ar>yyyymmdd</ar> (v2 only).</od>
+</option>
+<option><on>-t <ar>hr:mn</ar></on><od>calculate for the time <ar>hr:mn</ar> (v2 only).</od>
+</option>
 <option><on>-fmt <ar>format</ar></on><od>use the string <ar>fmt</ar>, to format the output.</od>
 </option>
 <option><on>-f <ar>filename</ar></on><od>read a sequence of dates, times and longitudes from the ASCII file, <ar>filename</ar>.</od>
 </option>
-
+<option><on>-old_aacgm</on><od>use old AACGM coordinates rather than v2.</od>
+</option>
 
 <description>
-<p>Converts to and from Altitude Adjusted Corrected Geo-Magnetic Coordinates (AACGM).The output is written to standard output using the formatting string given by the "<code>-fmt</code>" option. The format string should be in the same format as that used by the <code>printf</code> function and whill take two double precision floating point numbers as arguments.</p>
-<p>If the "<code>-f</code>" option is given, the latitude,longitude and altitude are read from a space separated ASCII file. If the filename is "<code>-</code>" input is read from standard input.</p> 
+<p>Converts to and from Altitude Adjusted Corrected Geo-Magnetic Coordinates v2 (AACGM_v2) [Shepherd 2014].The output is written to standard output using the formatting string given by the "<code>-fmt</code>" option. The format string should be in the same format as that used by the <code>printf</code> function and will take two double precision floating point numbers as arguments.</p>
+<p>If the "<code>-f</code>" option is given, the latitude,longitude and altitude are read from a space separated ASCII file. If the filename is "<code>-</code>" input is read from standard input.</p>
 </description>
-
 
 <example>
 <command>aacgmeval -lat 85.4 -lon 32.4 -alt 300.0</command>
-<description>Convert the coordinate given by latitude of 85.4 degrees, longitude 32.4 degrees and altitude of 300 kilometes to AACGM.</description>
+<description>Convert the coordinate given by latitude of 85.4 degrees, longitude 32.4 degrees and altitude of 300 kilometers to AACGM.</description>
 </example>
 
 <example>
-<command>aacgmeval  -i -f aacgm.txt</command>
-<description>Convert the AACGM coordinated in the file "<code>aacgm.txt</code>", back to geographic coordinates.</description>
+<command>aacgmeval -i -f aacgm.txt</command>
+<description>Convert the AACGM coordinates in the file "<code>aacgm.txt</code>", back to geographic coordinates.</description>
 </example>
-
-
-
-
 
 </binary>

--- a/codebase/analysis/src.bin/aacgm/aacgmeval.1.2/makefile
+++ b/codebase/analysis/src.bin/aacgm/aacgmeval.1.2/makefile
@@ -13,7 +13,7 @@ SRC=hlpstr.h errstr.h aacgm.c
 DSTPATH = $(BINPATH)
 OUTPUT = aacgmeval
 LNK=$(ARC)
-LIBS=-laacgm.1 -lopt.1 -lrtime.1
+LIBS=-laacgm.1 -lopt.1 -lrtime.1 -laacgm_v2.1 -ligrf_v2.1 -lastalg.1
 SLIB=-lm
 
  

--- a/codebase/analysis/src.bin/mlt/mlteval.1.3/doc/mlteval.doc.xml
+++ b/codebase/analysis/src.bin/mlt/mlteval.1.3/doc/mlteval.doc.xml
@@ -2,15 +2,16 @@
 <binary>
 <project>analysis</project>
 <name>mlteval</name>
-<location>src.bin/aacgm/mlteval</location>
+<location>src.bin/mlt/mlteval</location>
+
 <syntax>mlteval --help</syntax>
 <syntax>mlteval [-d <ar>yyyymmdd</ar>] [-t <ar>hr:mn</ar>] [-l <ar>mlon</ar>] [-fmt <ar>format</ar>]</syntax>
- <syntax>mlteval [-f <ar>filename</ar>]  [-fmt <ar>format</ar>]</syntax>
+<syntax>mlteval [-f <ar>filename</ar>]  [-fmt <ar>format</ar>]</syntax>
 
+<synopsis><p>Find Magnetic Local Time (MLT).</p></synopsis>
 
-<synopsis><p>Find Magnetic Local Time (MLT).</p></synopsis><option><on>--help</on><od>print the help message and exit.</od>
+<option><on>--help</on><od>print the help message and exit.</od>
 </option>
-
 <option><on>-d <ar>yyyymmdd</ar></on><od>calculate for the date <ar>yyyymmdd</ar>.</od>
 </option>
 <option><on>-t <ar>hr:mn</ar></on><od>calculate for the time <ar>hr:mn</ar>.</od>
@@ -21,26 +22,22 @@
 </option>
 <option><on>-f <ar>filename</ar></on><od>read a sequence of dates, times and longitudes from the ASCII file, <ar>filename</ar>.</od>
 </option>
-
+<option><on>-old_mlt</on><od>use old MLT procedure rather than v2.</od>
+</option>
 
 <description>
-<p>Calulates Magnetic Local Time (UTC) for a given Universal Coordinated Time (UTC) and magnetic longitude. The output is written to standard output using the formatting string given by the "<code>-fmt</code>" option. The format string should be in the same format as that used by the <code>printf</code> function and whill take one double precision floating point number as an argument.</p>
-<p>If the "<code>-f</code>" option is given, the time and longitude are read from a space separated ASCII file. If the filename is "<code>-</code>" input is read from standard input.</p> 
+<p>Calulates Magnetic Local Time (UTC) for a given Universal Coordinated Time (UTC) and magnetic longitude. The output is written to standard output using the formatting string given by the "<code>-fmt</code>" option. The format string should be in the same format as that used by the <code>printf</code> function and will take one double precision floating point number as an argument.</p>
+<p>If the "<code>-f</code>" option is given, the time and longitude are read from a space separated ASCII file. If the filename is "<code>-</code>" input is read from standard input.</p>
 </description>
 
-
 <example>
-<command>mlteval  -d 19990406 -t 00:30 -lon 75.0</command>
-<description>Find the MLT for 0 degress magnetic lognitude at  00:30UT on April, 6 1999.</description>
+<command>mlteval -d 19990406 -t 00:30 -lon 75.0</command>
+<description>Find the MLT for 0 degrees magnetic lognitude at 00:30UT on April, 6 1999.</description>
 </example>
 
 <example>
-<command>mlteval  -f mlt.txt -fmt "MLT=%f\n"</command>
+<command>mlteval -f mlt.txt -fmt "MLT=%f\n"</command>
 <description>Find the MLT for the times and longitudes in the file "<code>mlt.txt</code>", format the output using the string "MLT=%f\n".</description>
 </example>
-
-
-
-
 
 </binary>

--- a/codebase/analysis/src.bin/mlt/mlteval.1.3/makefile
+++ b/codebase/analysis/src.bin/mlt/mlteval.1.3/makefile
@@ -13,7 +13,7 @@ SRC=hlpstr.h errstr.h mlt.c
 DSTPATH = $(BINPATH)
 OUTPUT = mlteval
 LNK=$(ARC)
-LIBS=-lmlt.1 -laacgm.1 -lastalg.1 -lopt.1 -lrtime.1
+LIBS=-lmlt_v2.1 -laacgm_v2.1 -ligrf_v2.1 -lmlt.1 -laacgm.1 -lastalg.1 -lopt.1 -lrtime.1
 SLIB=-lm
 
  

--- a/codebase/analysis/src.bin/mlt/mlteval.1.3/mlt.c
+++ b/codebase/analysis/src.bin/mlt/mlteval.1.3/mlt.c
@@ -36,6 +36,8 @@
 #include "errstr.h"
 #include "hlpstr.h"
 #include "mlt.h"
+#include "mlt_v2.h"
+#include "aacgmlib_v2.h"
 
 
 
@@ -94,6 +96,8 @@ int main(int argc,char *argv[]) {
   double dval=0,tval=0;
   int c;
 
+  int old_mlt=0;
+
   char txt[256];
   
   OptionAdd(&opt,"-help",'x',&help);
@@ -103,6 +107,7 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"l",'d',&mlon);
   OptionAdd(&opt,"fmt",'t',&fmt);
   OptionAdd(&opt,"f",'t',&fname);
+  OptionAdd(&opt,"old_mlt",'x',&old_mlt);   /* Use old MLT procedure rather than v2 */
 
   arg=OptionProcess(1,argc,argv,&opt,NULL);
 
@@ -126,7 +131,8 @@ int main(int argc,char *argv[]) {
       TimeEpochToYMDHMS(tval,&yr,&mo,&dy,&hr,&mt,&sc);
       isc=sc;
     } else TimeReadClock(&yr,&mo,&dy,&hr,&mt,&isc,&usc);
-    mlt=MLTConvertYMDHMS(yr,mo,dy,hr,mt,isc,mlon);
+    if (old_mlt) mlt=MLTConvertYMDHMS(yr,mo,dy,hr,mt,isc,mlon);
+    else mlt=MLTConvertYMDHMS_v2(yr,mo,dy,hr,mt,isc,mlon);
     fprintf(stdout,fmt,mlt);    
   } else {
     if (strcmp(fname,"-")==0) fp=stdin;
@@ -139,7 +145,8 @@ int main(int argc,char *argv[]) {
       if (sscanf(txt,"%d %d %d %d %d %lf %lf\n",
           &yr,&mo,&dy,&hr,&mt,&sc,&mlon) !=7) continue;
       isc=sc;
-      mlt=MLTConvertYMDHMS(yr,mo,dy,hr,mt,isc,mlon);
+      if (old_mlt) mlt=MLTConvertYMDHMS(yr,mo,dy,hr,mt,isc,mlon);
+      else mlt=MLTConvertYMDHMS_v2(yr,mo,dy,hr,mt,isc,mlon);
       fprintf(stdout,fmt,mlt);  
     }
   }


### PR DESCRIPTION
This pull request updates the `aacgmeval` and `mlteval` binaries to use the new v2 coefficients and procedures by default.  The old AACGM and MLT convert routines may still be used by setting the `-old_aacgm` and `-old_mlt` command line options for the respective eval functions.  Results can be tested against the output of Simon's online AACGM_v2 calculator.