### PR TITLE
Adding .profile.tcsh equivalent of .profile.bash

### DIFF
--- a/.profile.tcsh
+++ b/.profile.tcsh
@@ -1,0 +1,16 @@
+# .profile.tcsh
+# =============
+
+setenv OSTYPE "linux"
+setenv SYSTEM "linux"
+setenv VISUAL "vim"
+setenv EDITOR "$VISUAL"
+setenv PATH "${PATH}:/opt/local/bin:/usr/bin/:${HOME}/bin:${HOME}/script"
+
+source $RSTPATH/.profile/rst.tcsh
+source $RSTPATH/.profile/base.tcsh
+source $RSTPATH/.profile/general.tcsh
+source $RSTPATH/.profile/superdarn.tcsh
+
+source $RSTPATH/.profile/idl.tcsh
+


### PR DESCRIPTION
As the title says, this pull request adds a tcsh equivalent of .profile.bash as requested by Rob Shore at BAS.  Since we already have tcsh versions of all of the scripts in the .profile directory it seems logical to include a .profile.tcsh file too.