### PR TITLE
Adding key_path options for custom color tables

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/doc/field_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/doc/field_plot.doc.xml
@@ -209,8 +209,12 @@
 
 <option><on>-vkey <ar>vkeyname</ar></on><od>load the colorkey used to plot velocity vectors from the file <ar>vkeyname</ar>.</od>
 </option>
+<option><on>-vkey_path <ar>vkey_path</ar></on><od>load the colorkey used to plot velocity vectors from the custom path <ar>vkey_path</ar>.</od>
+</option>
 
-<option><on>-key <ar>keyname</ar></on><od>load the colorkey from the file <ar>xkeyname</ar>.</od>
+<option><on>-key <ar>keyname</ar></on><od>load the colorkey from the file <ar>keyname</ar>.</od>
+</option>
+<option><on>-key_path <ar>key_path</ar></on><od>load the colorkey from the custom path <ar>key_path</ar>.</od>
 </option>
 
 <option><on>-p</on><od>plot power.</od>

--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
@@ -456,6 +456,7 @@ int main(int argc,char *argv[]) {
   char *key_fname=NULL;
   char *vkey_fname=NULL;
   FILE *keyfp=NULL;
+  size_t len;
 
   MapTFunction  tfunc;
 
@@ -1204,6 +1205,8 @@ int main(int argc,char *argv[]) {
     if (key_path == NULL) key_path = getenv("COLOR_TABLE_PATH");
     if (key_path != NULL) {
       strcpy(kname, key_path);
+      len = strlen(key_path);
+      if (key_path[len-1] != '/') strcat(kname, "/");
       strcat(kname, key_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -1212,6 +1215,8 @@ int main(int argc,char *argv[]) {
     if (keyfp !=NULL) {
       load_key(keyfp,&key);
       fclose(keyfp);
+    } else {
+      fprintf(stderr, "Color table %s not found\n", kname);
     }
   }
 
@@ -1219,6 +1224,8 @@ int main(int argc,char *argv[]) {
     if (vkey_path == NULL) vkey_path = getenv("COLOR_TABLE_PATH");
     if (vkey_path != NULL) {
       strcpy(kname, vkey_path);
+      len = strlen(vkey_path);
+      if (vkey_path[len-1] != '/') strcat(kname, "/");
       strcat(kname, vkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -1227,6 +1234,8 @@ int main(int argc,char *argv[]) {
     if (keyfp !=NULL) {
       load_key(keyfp,&vkey);
       fclose(keyfp);
+    } else {
+      fprintf(stderr, "Velocity color table %s not found\n", kname);
     }
   }
 

--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
@@ -451,6 +451,7 @@ int main(int argc,char *argv[]) {
   char *bgcol_txt=NULL;
   char *txtcol_txt=NULL;
   char *key_path=NULL;
+  char *vkey_path=NULL;
   char kname[256];
   char *key_fname=NULL;
   char *vkey_fname=NULL;
@@ -747,7 +748,9 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"bgcol",'t',&bgcol_txt);
   OptionAdd(&opt,"txtcol",'t',&txtcol_txt);
   OptionAdd(&opt,"key",'t',&key_fname);
+  OptionAdd(&opt,"key_path",'t',&key_path);
   OptionAdd(&opt,"vkey",'t',&vkey_fname);
+  OptionAdd(&opt,"vkey_path",'t',&vkey_path);
 
   OptionAdd(&opt,"square",'x',&sqflg);
 
@@ -1198,7 +1201,7 @@ int main(int argc,char *argv[]) {
   if (gscol_txt !=NULL) gscol=PlotColorStringRGBA(gscol_txt);
 
   if (key_fname !=NULL) {
-    key_path = getenv("COLOR_TABLE_PATH");
+    if (key_path == NULL) key_path = getenv("COLOR_TABLE_PATH");
     if (key_path != NULL) {
       strcpy(kname, key_path);
       strcat(kname, key_fname);
@@ -1213,9 +1216,9 @@ int main(int argc,char *argv[]) {
   }
 
   if (vkey_fname !=NULL) {
-    if (key_path == NULL) key_path = getenv("COLOR_TABLE_PATH");
-    if (key_path != NULL) {
-      strcpy(kname, key_path);
+    if (vkey_path == NULL) vkey_path = getenv("COLOR_TABLE_PATH");
+    if (vkey_path != NULL) {
+      strcpy(kname, vkey_path);
       strcat(kname, vkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");

--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/doc/grid_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/doc/grid_plot.doc.xml
@@ -159,8 +159,12 @@
 
 <option><on>-vkey <ar>vkeyname</ar></on><od>load the velocity colorkey from the file <ar>vkeyname</ar>.</od>
 </option>
+<option><on>-vkey_path <ar>vkey_path</ar></on><od>load the velocity colorkey from the custom path <ar>vkey_path</ar>.</od>
+</option>
 
 <option><on>-xkey <ar>xkeyname</ar></on><od>load the extra colorkey (used to plot power or spectral width) from the file <ar>xkeyname</ar>.</od>
+</option>
+<option><on>-xkey_path <ar>xkey_path</ar></on><od>load the extra colorkey from the custom path <ar>xkey_path</ar>.</od>
 </option>
 
 <option><on>-raw</on><od>plot raw line of sight velocity vectors.</od>

--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
@@ -437,7 +437,8 @@ int main(int argc,char *argv[]) {
 
   char *bgcol_txt=NULL;
   char *txtcol_txt=NULL;
-  char *key_path=NULL;
+  char *vkey_path=NULL;
+  char *xkey_path=NULL;
   char kname[256];
   char *vkey_fname=NULL;
   char *xkey_fname=NULL;
@@ -693,7 +694,9 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"bgcol",'t',&bgcol_txt);
   OptionAdd(&opt,"txtcol",'t',&txtcol_txt);
   OptionAdd(&opt,"vkey",'t',&vkey_fname);
+  OptionAdd(&opt,"vkey_path",'t',&vkey_path);
   OptionAdd(&opt,"xkey",'t',&xkey_fname);
+  OptionAdd(&opt,"xkey_path",'t',&xkey_path);
 
   OptionAdd(&opt,"square",'x',&sqflg);
 
@@ -997,9 +1000,9 @@ int main(int argc,char *argv[]) {
   if (ffovcol_txt !=NULL) ffovcol=PlotColorStringRGBA(ffovcol_txt);
 
   if (vkey_fname !=NULL) {
-    key_path = getenv("COLOR_TABLE_PATH");
-    if (key_path != NULL) {
-      strcpy(kname, key_path);
+    if (vkey_path == NULL) vkey_path = getenv("COLOR_TABLE_PATH");
+    if (vkey_path != NULL) {
+      strcpy(kname, vkey_path);
       strcat(kname, vkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -1016,9 +1019,9 @@ int main(int argc,char *argv[]) {
   vkey.defcol=veccol;
 
   if (xkey_fname !=NULL) {
-    if (key_path == NULL) key_path = getenv("COLOR_TABLE_PATH");
-    if (key_path != NULL) {
-      strcpy(kname, key_path);
+    if (xkey_path == NULL) xkey_path = getenv("COLOR_TABLE_PATH");
+    if (xkey_path != NULL) {
+      strcpy(kname, xkey_path);
       strcat(kname, xkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");

--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
@@ -1015,7 +1015,7 @@ int main(int argc,char *argv[]) {
       load_key(keyfp,&vkey);
       fclose(keyfp);
     } else {
-      fprintf(stderr, "Velocity color table %s not found\n", vkey_fname);
+      fprintf(stderr, "Velocity color table %s not found\n", kname);
     }
   }
   vkey.max=vmax;
@@ -1036,7 +1036,7 @@ int main(int argc,char *argv[]) {
       load_key(keyfp,&xkey);
       fclose(keyfp);
     } else {
-      fprintf(stderr, "Extra color table %s not found\n", xkey_fname);
+      fprintf(stderr, "Extra color table %s not found\n", kname);
     }
   }
 

--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
@@ -443,6 +443,7 @@ int main(int argc,char *argv[]) {
   char *vkey_fname=NULL;
   char *xkey_fname=NULL;
   FILE *keyfp=NULL;
+  size_t len;
 
   MapTFunction  tfunc;
 
@@ -1003,6 +1004,8 @@ int main(int argc,char *argv[]) {
     if (vkey_path == NULL) vkey_path = getenv("COLOR_TABLE_PATH");
     if (vkey_path != NULL) {
       strcpy(kname, vkey_path);
+      len = strlen(vkey_path);
+      if (vkey_path[len-1] != '/') strcat(kname, "/");
       strcat(kname, vkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -1012,7 +1015,7 @@ int main(int argc,char *argv[]) {
       load_key(keyfp,&vkey);
       fclose(keyfp);
     } else {
-      fprintf(stderr, "Color table %s not found using B&W\n", vkey_fname);
+      fprintf(stderr, "Velocity color table %s not found\n", vkey_fname);
     }
   }
   vkey.max=vmax;
@@ -1022,6 +1025,8 @@ int main(int argc,char *argv[]) {
     if (xkey_path == NULL) xkey_path = getenv("COLOR_TABLE_PATH");
     if (xkey_path != NULL) {
       strcpy(kname, xkey_path);
+      len = strlen(xkey_path);
+      if (xkey_path[len-1] != '/') strcat(kname, "/");
       strcat(kname, xkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -1031,7 +1036,7 @@ int main(int argc,char *argv[]) {
       load_key(keyfp,&xkey);
       fclose(keyfp);
     } else {
-      fprintf(stderr, "Color table %s not found using B&W\n", xkey_fname);
+      fprintf(stderr, "Extra color table %s not found\n", xkey_fname);
     }
   }
 

--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/doc/map_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/doc/map_plot.doc.xml
@@ -176,11 +176,17 @@ ed,green and blue component color.</od>
 
 <option><on>-vkey <ar>vkeyname</ar></on><od>load the velocity colorkey from the file <ar>vkeyname</ar>.</od>
 </option>
+<option><on>-vkey_path <ar>vkey_path</ar></on><od>load the velocity colorkey from the custom path <ar>vkey_path</ar>.</od>
+</option>
 
 <option><on>-pkey <ar>pkeyname</ar></on><od>load the colorkey used to contour polygons from the file <ar>pkeyname</ar>.</od>
 </option>
+<option><on>-pkey_path <ar>pkey_path</ar></on><od>load the colorkey used to contour polygons from the custom path <ar>pkey_path</ar>.</od>
+</option>
 
 <option><on>-xkey <ar>xkeyname</ar></on><od>load the extra colorkey (used to plot power or spectral width) from the file <ar>xkeyname</ar>.</od>
+</option>
+<option><on>-xkey_path <ar>xkey_path</ar></on><od>load the extra colorkey from the custom path <ar>xkey_path</ar>.</od>
 </option>
 <option><on>-fit</on><od>plot the fitted two-dimensional velocity vectors.</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
@@ -577,6 +577,7 @@ int main(int argc,char *argv[]) {
   char *pkey_fname=NULL;
   char *xkey_fname=NULL;
   FILE *keyfp=NULL;
+  size_t len;
 
   MapTFunction  tfunc;
 
@@ -1215,6 +1216,8 @@ int main(int argc,char *argv[]) {
     if (vkey_path == NULL) vkey_path = getenv("COLOR_TABLE_PATH");
     if (vkey_path != NULL) {
       strcpy(kname, vkey_path);
+      len = strlen(vkey_path);
+      if (vkey_path[len-1] != '/') strcat(kname, "/");
       strcat(kname, vkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -1223,6 +1226,8 @@ int main(int argc,char *argv[]) {
     if (keyfp !=NULL) {
       load_key(keyfp,&vkey);
       fclose(keyfp);
+    } else {
+      fprintf(stderr, "Velocity color table %s not found\n", kname);
     }
   }
   vkey.max=vmax;
@@ -1232,6 +1237,8 @@ int main(int argc,char *argv[]) {
     if (pkey_path == NULL) pkey_path = getenv("COLOR_TABLE_PATH");
     if (pkey_path != NULL) {
       strcpy(kname, pkey_path);
+      len = strlen(pkey_path);
+      if (pkey_path[len-1] != '/') strcat(kname, "/");
       strcat(kname, pkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -1240,6 +1247,8 @@ int main(int argc,char *argv[]) {
     if (keyfp !=NULL) {
       load_key(keyfp,&pkey);
       fclose(keyfp);
+    } else {
+      fprintf(stderr, "Polygon color table %s not found\n", kname);
     }
   }
 
@@ -1247,6 +1256,8 @@ int main(int argc,char *argv[]) {
     if (xkey_path == NULL) xkey_path = getenv("COLOR_TABLE_PATH");
     if (xkey_path != NULL) {
       strcpy(kname, xkey_path);
+      len = strlen(xkey_path);
+      if (xkey_path[len-1] != '/') strcat(kname, "/");
       strcat(kname, xkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -1255,6 +1266,8 @@ int main(int argc,char *argv[]) {
     if (keyfp !=NULL) {
       load_key(keyfp,&xkey);
       fclose(keyfp);
+    } else {
+      fprintf(stderr, "Extra color table %s not found\n", kname);
     }
   }
 

--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
@@ -569,7 +569,9 @@ int main(int argc,char *argv[]) {
 
   char *bgcol_txt=NULL;
   char *txtcol_txt=NULL;
-  char *key_path=NULL;
+  char *vkey_path=NULL;
+  char *pkey_path=NULL;
+  char *xkey_path=NULL;
   char kname[256];
   char *vkey_fname=NULL;
   char *pkey_fname=NULL;
@@ -876,8 +878,11 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"bgcol",'t',&bgcol_txt);
   OptionAdd(&opt,"txtcol",'t',&txtcol_txt);
   OptionAdd(&opt,"vkey",'t',&vkey_fname);
+  OptionAdd(&opt,"vkey_path",'t',&vkey_path);
   OptionAdd(&opt,"xkey",'t',&xkey_fname);
+  OptionAdd(&opt,"xkey_path",'t',&xkey_path);
   OptionAdd(&opt,"pkey",'t',&pkey_fname);
+  OptionAdd(&opt,"pkey_path",'t',&pkey_path);
 
    OptionAdd(&opt,"square",'x',&sqflg);
 
@@ -1207,9 +1212,9 @@ int main(int argc,char *argv[]) {
   if (ffovcol_txt !=NULL) ffovcol=PlotColorStringRGBA(ffovcol_txt);
 
   if (vkey_fname !=NULL) {
-    key_path = getenv("COLOR_TABLE_PATH");
-    if (key_path != NULL) {
-      strcpy(kname, key_path);
+    if (vkey_path == NULL) vkey_path = getenv("COLOR_TABLE_PATH");
+    if (vkey_path != NULL) {
+      strcpy(kname, vkey_path);
       strcat(kname, vkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -1224,9 +1229,9 @@ int main(int argc,char *argv[]) {
   vkey.defcol=veccol;
 
   if (pkey_fname !=NULL) {
-    if (key_path == NULL) key_path = getenv("COLOR_TABLE_PATH");
-    if (key_path != NULL) {
-      strcpy(kname, key_path);
+    if (pkey_path == NULL) pkey_path = getenv("COLOR_TABLE_PATH");
+    if (pkey_path != NULL) {
+      strcpy(kname, pkey_path);
       strcat(kname, pkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -1239,9 +1244,9 @@ int main(int argc,char *argv[]) {
   }
 
   if (xkey_fname !=NULL) {
-    if (key_path == NULL) key_path = getenv("COLOR_TABLE_PATH");
-    if (key_path != NULL) {
-      strcpy(kname, key_path);
+    if (xkey_path == NULL) xkey_path = getenv("COLOR_TABLE_PATH");
+    if (xkey_path != NULL) {
+      strcpy(kname, xkey_path);
       strcat(kname, xkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/doc/time_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/doc/time_plot.doc.xml
@@ -103,17 +103,27 @@
 
 <option><on>-pkey <ar>pkeyname</ar></on><od>load the power colorkey from the file <ar>pkeyname</ar>.</od>
 </option>
+<option><on>-pkey_path <ar>pkey_path</ar></on><od>load the power colorkey from the custom path <ar>pkey_path</ar>.</od>
+</option>
 
 <option><on>-vkey <ar>vkeyname</ar></on><od>load the velocity colorkey from the file <ar>vkeyname</ar>.</od>
+</option>
+<option><on>-vkey_path <ar>vkey_path</ar></on><od>load the velocity colorkey from the custom path <ar>vkey_path</ar>.</od>
 </option>
 
 <option><on>-wkey <ar>wkeyname</ar></on><od>load the spectral width colorkey from the file <ar>wkeyname</ar>.</od>
 </option>
-
-<option><on>-fkey <ar>vkeyname</ar></on><od>load the frequency colorkey from the file <ar>fkeyname</ar>.</od>
+<option><on>-wkey_path <ar>wkey_path</ar></on><od>load the spectral width colorkey from the custom path <ar>wkey_path</ar>.</od>
 </option>
 
-<option><on>-nkey <ar>vkeyname</ar></on><od>load the noise colorkey from the file <ar>nkeyname</ar>.</od>
+<option><on>-fkey <ar>fkeyname</ar></on><od>load the frequency colorkey from the file <ar>fkeyname</ar>.</od>
+</option>
+<option><on>-fkey_path <ar>fkey_path</ar></on><od>load the frequency colorkey from the custom path <ar>fkey_path</ar>.</od>
+</option>
+
+<option><on>-nkey <ar>nkeyname</ar></on><od>load the noise colorkey from the file <ar>nkeyname</ar>.</od>
+</option>
+<option><on>-nkey_path <ar>nkey_path</ar></on><od>load the noise colorkey from the custom path <ar>nkey_path</ar>.</od>
 </option>
 
 <option><on>-fontname <ar>fontname</ar></on><od>plot any labels using the font <ar>fontname</ar>.</od>

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -351,6 +351,7 @@ int main(int argc,char *argv[]) {
   char *wkey_fname=NULL;
   char *fkey_fname=NULL;
   char *nkey_fname=NULL;
+  size_t len;
 
 
   struct FrameBuffer *img=NULL;
@@ -637,6 +638,8 @@ int main(int argc,char *argv[]) {
     if (pkey_path == NULL) pkey_path = getenv("COLOR_TABLE_PATH");
     if (pkey_path != NULL) {
       strcpy(kname, pkey_path);
+      len = strlen(pkey_path);
+      if (pkey_path[len-1] != '/') strcat(kname, "/");
       strcat(kname, pkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -645,6 +648,8 @@ int main(int argc,char *argv[]) {
     if (fp !=NULL) {
       load_key(fp,&pkey);
       fclose(fp);
+    } else {
+      fprintf(stderr, "Power color table %s not found\n", kname);
     }
   }
 
@@ -652,6 +657,8 @@ int main(int argc,char *argv[]) {
     if (vkey_path == NULL) vkey_path = getenv("COLOR_TABLE_PATH");
     if (vkey_path != NULL) {
       strcpy(kname, vkey_path);
+      len = strlen(vkey_path);
+      if (vkey_path[len-1] != '/') strcat(kname, "/");
       strcat(kname, vkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -660,6 +667,8 @@ int main(int argc,char *argv[]) {
     if (fp !=NULL) {
       load_key(fp,&vkey);
       fclose(fp);
+    } else {
+      fprintf(stderr, "Velocity color table %s not found\n", kname);
     }
   }
 
@@ -667,6 +676,8 @@ int main(int argc,char *argv[]) {
     if (wkey_path == NULL) wkey_path = getenv("COLOR_TABLE_PATH");
     if (wkey_path != NULL) {
       strcpy(kname, wkey_path);
+      len = strlen(wkey_path);
+      if (wkey_path[len-1] != '/') strcat(kname, "/");
       strcat(kname, wkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -675,6 +686,8 @@ int main(int argc,char *argv[]) {
     if (fp !=NULL) {
       load_key(fp,&wkey);
       fclose(fp);
+    } else {
+      fprintf(stderr, "Spectral width color table %s not found\n", kname);
     }
   }
 
@@ -682,6 +695,8 @@ int main(int argc,char *argv[]) {
     if (fkey_path == NULL) fkey_path = getenv("COLOR_TABLE_PATH");
     if (fkey_path != NULL) {
       strcpy(kname, fkey_path);
+      len = strlen(fkey_path);
+      if (fkey_path[len-1] != '/') strcat(kname, "/");
       strcat(kname, fkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -690,6 +705,8 @@ int main(int argc,char *argv[]) {
     if (fp !=NULL) {
       load_key(fp,&fkey);
       fclose(fp);
+    } else {
+      fprintf(stderr, "Frequency color table %s not found\n", kname);
     }
   }
 
@@ -697,6 +714,8 @@ int main(int argc,char *argv[]) {
     if (nkey_path == NULL) nkey_path = getenv("COLOR_TABLE_PATH");
     if (nkey_path != NULL) {
       strcpy(kname, nkey_path);
+      len = strlen(nkey_path);
+      if (nkey_path[len-1] != '/') strcat(kname, "/");
       strcat(kname, nkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -705,6 +724,8 @@ int main(int argc,char *argv[]) {
     if (fp !=NULL) {
       load_key(fp,&nkey);
       fclose(fp);
+    } else {
+      fprintf(stderr, "Noise color table %s not found\n", kname);
     }
   }
 

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -340,7 +340,11 @@ int main(int argc,char *argv[]) {
   unsigned int gscolor=0;
   char *gsctxt=NULL;
 
-  char *key_path=NULL;
+  char *pkey_path=NULL;
+  char *vkey_path=NULL;
+  char *wkey_path=NULL;
+  char *fkey_path=NULL;
+  char *nkey_path=NULL;
   char kname[256];
   char *pkey_fname=NULL;
   char *vkey_fname=NULL;
@@ -477,11 +481,16 @@ int main(int argc,char *argv[]) {
 
   OptionAdd(&opt,"gscol",'t',&gsctxt); /* ground scatter color */
 
-  OptionAdd(&opt,"pkey",'t',&pkey_fname); /* power key */
-  OptionAdd(&opt,"vkey",'t',&vkey_fname); /* velocity key */
-  OptionAdd(&opt,"wkey",'t',&wkey_fname); /* spectral width key */
-  OptionAdd(&opt,"fkey",'t',&fkey_fname); /* frequency key */
-  OptionAdd(&opt,"nkey",'t',&nkey_fname); /* noise key */
+  OptionAdd(&opt,"pkey",'t',&pkey_fname);     /* power key */
+  OptionAdd(&opt,"pkey_path",'t',&pkey_path); /* power key path */
+  OptionAdd(&opt,"vkey",'t',&vkey_fname);     /* velocity key */
+  OptionAdd(&opt,"vkey_path",'t',&vkey_path); /* velocity key path */
+  OptionAdd(&opt,"wkey",'t',&wkey_fname);     /* spectral width key */
+  OptionAdd(&opt,"wkey_path",'t',&wkey_path); /* spectral width key path */
+  OptionAdd(&opt,"fkey",'t',&fkey_fname);     /* frequency key */
+  OptionAdd(&opt,"fkey_path",'t',&fkey_path); /* frequency key path */
+  OptionAdd(&opt,"nkey",'t',&nkey_fname);     /* noise key */
+  OptionAdd(&opt,"nkey_path",'t',&nkey_path); /* noise key path */
 
   OptionAdd(&opt,"fontname",'t',&fontname); /* main font name */
   OptionAdd(&opt,"fontsize",'f',&fontsize); /* main font size */
@@ -625,9 +634,9 @@ int main(int argc,char *argv[]) {
   if (txttxt !=NULL)  sscanf(txttxt,"%x",&txtcolor);
 
   if (pkey_fname !=NULL) {
-    key_path = getenv("COLOR_TABLE_PATH");
-    if (key_path != NULL) {
-      strcpy(kname, key_path);
+    if (pkey_path == NULL) pkey_path = getenv("COLOR_TABLE_PATH");
+    if (pkey_path != NULL) {
+      strcpy(kname, pkey_path);
       strcat(kname, pkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -640,9 +649,9 @@ int main(int argc,char *argv[]) {
   }
 
   if (vkey_fname !=NULL) {
-    if (key_path == NULL) key_path = getenv("COLOR_TABLE_PATH");
-    if (key_path != NULL) {
-      strcpy(kname, key_path);
+    if (vkey_path == NULL) vkey_path = getenv("COLOR_TABLE_PATH");
+    if (vkey_path != NULL) {
+      strcpy(kname, vkey_path);
       strcat(kname, vkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -655,9 +664,9 @@ int main(int argc,char *argv[]) {
   }
 
   if (wkey_fname !=NULL) {
-    if (key_path == NULL) key_path = getenv("COLOR_TABLE_PATH");
-    if (key_path != NULL) {
-      strcpy(kname, key_path);
+    if (wkey_path == NULL) wkey_path = getenv("COLOR_TABLE_PATH");
+    if (wkey_path != NULL) {
+      strcpy(kname, wkey_path);
       strcat(kname, wkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -670,9 +679,9 @@ int main(int argc,char *argv[]) {
   }
 
   if (fkey_fname !=NULL) {
-    if (key_path == NULL) key_path = getenv("COLOR_TABLE_PATH");
-    if (key_path != NULL) {
-      strcpy(kname, key_path);
+    if (fkey_path == NULL) fkey_path = getenv("COLOR_TABLE_PATH");
+    if (fkey_path != NULL) {
+      strcpy(kname, fkey_path);
       strcat(kname, fkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");
@@ -685,9 +694,9 @@ int main(int argc,char *argv[]) {
   }
 
   if (nkey_fname !=NULL) {
-    if (key_path == NULL) key_path = getenv("COLOR_TABLE_PATH");
-    if (key_path != NULL) {
-      strcpy(kname, key_path);
+    if (nkey_path == NULL) nkey_path = getenv("COLOR_TABLE_PATH");
+    if (nkey_path != NULL) {
+      strcpy(kname, nkey_path);
       strcat(kname, nkey_fname);
     } else {
       fprintf(stderr, "No COLOR_TABLE_PATH set\n");


### PR DESCRIPTION
This pull request addresses issue #82 raised by @ecbland.  I've added various `key_path` command line options to field_plot, grid_plot, map_plot, and time_plot which should allow the user to specify custom paths for any of the various color table options.  If a color table is specified but no path is provided, the COLOR_TABLE_PATH environment variable will be used as the default.