### PR TITLE
Modifying make.doc.frame so documentation links are alphabetized

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ For macOS it is also available through macports, as are all listed dependencies
 	 make.code superdarn rst
 	 ```
 
-5. To compile the html documentation, run `make.doc.rfc codebase superdarn` and
-   `make.doc superdarn rst` from the command line. You may need to modify the `URLBASE`
-   environment variable in `$RSTPATH/.profile/rst.bash` for the links in the html pages to
-   function correctly.  Temporary documentation is available at:
+5. To compile the html documentation, run `make.doc superdarn rst` from the command line.
+   You may need to modify the `URLBASE` environment variable in `$RSTPATH/.profile/rst.bash`
+   for the links in the html pages to function correctly.  Temporary documentation is
+   available at:
 
    http://superdarn.thayer.dartmouth.edu/documentation/index.html
 

--- a/build/script/make.doc.frame
+++ b/build/script/make.doc.frame
@@ -106,7 +106,7 @@ makesection() {
 
     echo '<?xml version="1.0" encoding="ISO-8859-1"?>' > ${secxml}
     echo "<index>" >> ${secxml}
-    dlist=`find $dir -maxdepth 1 -mindepth 1 -type d`
+    dlist=`find $dir -maxdepth 1 -mindepth 1 -type d | sort`
     for dname in $dlist
       do
         dleaf=${dname##*/}


### PR DESCRIPTION
This pull request modifies the make.doc.frame script so the binaries and libraries are sorted alphabetically in the html documentation.

For comparison, the contents of the `superdarn/src.bin/tk/tool` directory of the current documentation are listed here:

http://superdarn.thayer.dartmouth.edu/documentation/superdarn/src.bin/tk/tool/index.html

while the alphabetized version can be found here:

http://superdarn.thayer.dartmouth.edu/documentation_fix/superdarn/src.bin/tk/tool/index.html

Note that all other directory listings are also alphabetized.  Now it is much easier to find the binary or library you are searching for.  I've also deleted an unnecessary step from the README file about compiling the rfc docs.