### PR TITLE
Simplifying make.code and make.doc commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DOI](https://zenodo.org/badge/74060190.svg)](https://zenodo.org/badge/latestdoi/74060190)
+
 Radar Software Toolkit
 ========
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For macOS it is also available through macports, as are all listed dependencies
 	 ```
 
 5. To compile the html documentation, run `make.doc.rfc codebase superdarn` and
-   `make.doc superdarn rst` from the command line. You may need to modify the `URLBASE`
+   `make.doc` from the command line. You may need to modify the `URLBASE`
    environment variable in `$RSTPATH/.profile/rst.bash` for the links in the html pages to
    function correctly.  Temporary documentation is available at:
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For macOS it is also available through macports, as are all listed dependencies
 3. Run `make.build` from the command line.  You may need to change directory to `$RSTPATH/build/script`.
    This runs a helper script that sets up other compiling code.
 
-4. In the same directory run `make.code superdarn rst` to compile all of the code.
+4. In the same directory run `make.code` to compile all of the code.
    This runs a script to find all of the source codes and compile them into binaries.
    A log of this compilation is stored in `$RSTPATH/log`.
 
@@ -66,7 +66,7 @@ For macOS it is also available through macports, as are all listed dependencies
 	 tar -P -czuf idl.tar.gz idl
 	 rm -rf idl
 	 cd $RSTPATH/build/script
-	 make.code superdarn rst
+	 make.code
 	 ```
 
    4b.	 If the order of make.code is executed incorrectly, you will see an error upon

--- a/build/script/README.txt
+++ b/build/script/README.txt
@@ -45,11 +45,11 @@ make.code
 
 Syntax:
 
-make.code project package type [pattern]
+make.code type [pattern]
 
 Description:
 
-Compiles source code in an RST package according to the package build rules. The project and the associated package are given by "project" and "package" respectively. The script compiles the software in the package according to the ordering rules given by the package "build.txt" file. A time-stamped log is generated and stored in the log directory.  At the end the cmpfit-1.2 library is compile through some hardcoded values.  This is to fix the code not compiling on a fresh install.
+Compiles source code in an RST package according to the package build rules. The script compiles the software in the package according to the ordering rules given by the package "build.txt" file. A time-stamped log is generated and stored in the log directory.  At the end the cmpfit-1.2 library is compile through some hardcoded values.  This is to fix the code not compiling on a fresh install.
 
 The "type" option will compile only code of a given type, either "bin" or "lib". The optional "pattern" can be used to compile only a sub-set of code whose module pathnames contain the given string. 
 
@@ -94,11 +94,11 @@ make.doc
 
 Syntax:
 
-make.doc [-w] project package
+make.doc [-w]
 
 Description:
 
-Make the documentation for a package. The project and package name are given by "project" and "package" respectively. If the "-w" option is given, then the documuntation is created for the web; otherwise a local version is created.
+Make the documentation for a package. If the "-w" option is given, then the documuntation is created for the web; otherwise a local version is created.
 
 make.doc.bin
 ------------

--- a/build/script/make.code
+++ b/build/script/make.code
@@ -22,36 +22,25 @@ set -e
 
 ############################################################################
 
-prj=${1}
-pkg=${2}
-
-############################################################################
-
 # Command line options
 
 ############################################################################
 
-if [ ${#} -gt 2 ]
+if [ ${#} -ge 1 ]
 then
-  mtype=${3}
+  mtype=${1}
 else
   mtype=""
 fi
 
-if [ ${#} -gt 3 ]
+if [ ${#} -gt 1 ]
 then
-  patn="-p "${4}
+  patn="-p "${2}
 else
   patn=""
 fi
 
-if [ -z "${pkg}" ]
-then
-  echo "make.code project package"
-  exit 1
-fi
-
-log="${LOGPATH}/${prj}-${pkg}.build"
+log="${LOGPATH}/superdarn-rst.build"
 dtval=$(date +%Y%m%d.%H%M)
 
 

--- a/build/script/make.doc
+++ b/build/script/make.doc
@@ -21,14 +21,11 @@ set -e
 
 ############################################################################
 
-############################################################################
-
 # Command line options
 
 ############################################################################
 
 option=""
-c=0
 
 for arg in ${*}
  do
@@ -36,27 +33,13 @@ for arg in ${*}
    if test "${arg}" = "-w"
    then
       option="-w"
-   else
-      if test ${c} -eq 0
-      then 
-         prj=${arg}
-      else
-         pkg=${arg}
-      fi
-      let c=c+1
    fi
  done
-
-if test -z "${pkg}"
-then
-  echo "make.doc [-w] project package"
-  exit
-fi
 
 
 build=${BUILD}
 
-log="${LOGPATH}/${prj}-${pkg}.doc"
+log="${LOGPATH}/superdarn-rst.doc"
 dtval=`date +%Y%m%d.%H%M`
 
 


### PR DESCRIPTION
This pull request removes the unnecessary `superdarn rst` arguments from calls to `make.code` and `make.doc`.  These were only being used to label the log files - those filenames have now been hardcoded as `"${LOGPATH}/superdarn-rst.build.${dtval}"`.  Users can also still compile a single binary or library matching a particular pattern by entering something like `make.code bin make_fit` or `make.code lib gtable`.  The relevant portions of the README files have also been updated to reflect these changes.