### PR TITLE
Added option to plot elevation angles in time_plot

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/doc/time_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/doc/time_plot.doc.xml
@@ -116,6 +116,11 @@
 <option><on>-wkey_path <ar>wkey_path</ar></on><od>load the spectral width colorkey from the custom path <ar>wkey_path</ar>.</od>
 </option>
 
+<option><on>-ekey <ar>ekeyname</ar></on><od>load the elevation angle colorkey from the file <ar>ekeyname</ar>.</od>
+</option>
+<option><on>-ekey_path <ar>ekey_path</ar></on><od>load the elevation angle colorkey from the custom path <ar>ekey_path</ar>.</od>
+</option>
+
 <option><on>-fkey <ar>fkeyname</ar></on><od>load the frequency colorkey from the file <ar>fkeyname</ar>.</od>
 </option>
 <option><on>-fkey_path <ar>fkey_path</ar></on><od>load the frequency colorkey from the custom path <ar>fkey_path</ar>.</od>
@@ -154,13 +159,15 @@
 <option><on>-scan <ar>scan</ar></on><od>plot beams that have a value for the scan flag of <ar>scan</ar>.</od>
 </option>
 
-<option><on>-a</on><od>plot all parameters.</od>
+<option><on>-a</on><od>plot all parameters (excluding elevation angle).</od>
 </option>
 <option><on>-p</on><od>plot power.</od>
 </option>
 <option><on>-v</on><od>plot velocity.</od>
 </option>
 <option><on>-w</on><od>plot spectral width.</od>
+</option>
+<option><on>-e</on><od>plot elevation angle.</od>
 </option>
 
 <option><on>-pmin <ar>pmin</ar></on><od>set the minimum value of the power scale to <a>pmin</ar>.</od>
@@ -176,6 +183,11 @@
 <option><on>-wmin <ar>wmin</ar></on><od>set the minimum value of the spectral width scale to <a>wmin</ar>.</od>
 </option>
 <option><on>-wmax <ar>wmax</ar></on><od>set the maximum value of the spectral width scale to <a>wmax</ar>.</od>
+</option>
+
+<option><on>-emin <ar>emin</ar></on><od>set the minimum value of the elevation angle scale to <a>emin</ar>.</od>
+</option>
+<option><on>-emax <ar>emax</ar></on><od>set the maximum value of the elevation angle scale to <a>emax</ar>.</od>
 </option>
 
 <option><on>-gs</on><od>color ground scatter.</od>

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/fit.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/fit.c
@@ -134,5 +134,7 @@ void fit_tplot(struct RadarParm *prm,struct FitData *fit,struct tplot *tptr) {
     tptr->p_l_e[i]=fit->rng[i].p_l_err;
     tptr->v_e[i]=fit->rng[i].v_err;
     tptr->w_l_e[i]=fit->rng[i].w_l_err;
+    if (fit->elv!=NULL) tptr->elv[i]=fit->elv[i].normal;
+    else tptr->elv[i]=-1;
   }
 }

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -117,6 +117,7 @@ struct key nkey;
 struct key pkey;
 struct key vkey;
 struct key wkey;
+struct key ekey;
 
 char *mstr[]={"January","February","March","April","May","June","July",
               "August","September","October","November","December",0};
@@ -174,6 +175,14 @@ char *label_wdt(double val,double min,double max,void *data) {
   if ((val !=min) && (val !=max)) return NULL;
   txt=malloc(32);
   sprintf(txt,"%d m/s",(int) val);
+  return txt;
+}
+
+char *label_elv(double val,double min,double max,void *data) {
+  char *txt=NULL;
+  if ((val !=min) && (val !=max)) return NULL;
+  txt=malloc(32);
+  sprintf(txt,"%d deg",(int) val);
   return txt;
 }
 
@@ -293,6 +302,7 @@ int main(int argc,char *argv[]) {
   unsigned char velflg=0;
   unsigned char pwrflg=0;
   unsigned char wdtflg=0;
+  unsigned char elvflg=0;
 
   unsigned char gsflg=0;
   unsigned char gmflg=0;
@@ -306,6 +316,9 @@ int main(int argc,char *argv[]) {
  
   double wmin=0;
   double wmax=500;
+
+  double emin=0;
+  double emax=50;
   
   double fmin=0.9;
   double fmax=1.9;
@@ -343,12 +356,14 @@ int main(int argc,char *argv[]) {
   char *pkey_path=NULL;
   char *vkey_path=NULL;
   char *wkey_path=NULL;
+  char *ekey_path=NULL;
   char *fkey_path=NULL;
   char *nkey_path=NULL;
   char kname[256];
   char *pkey_fname=NULL;
   char *vkey_fname=NULL;
   char *wkey_fname=NULL;
+  char *ekey_fname=NULL;
   char *fkey_fname=NULL;
   char *nkey_fname=NULL;
   size_t len;
@@ -430,8 +445,8 @@ int main(int argc,char *argv[]) {
   int yr,mo,dy,hr,mt;
   double sc;
 
-  int type[3];
-  struct FrameBuffer *blk[3]={NULL,NULL,NULL};
+  int type[4];
+  struct FrameBuffer *blk[4]={NULL,NULL,NULL,NULL};
   struct FrameBuffer *fblk;
   struct FrameBuffer *nblk;
 
@@ -488,6 +503,8 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"vkey_path",'t',&vkey_path); /* velocity key path */
   OptionAdd(&opt,"wkey",'t',&wkey_fname);     /* spectral width key */
   OptionAdd(&opt,"wkey_path",'t',&wkey_path); /* spectral width key path */
+  OptionAdd(&opt,"ekey",'t',&ekey_fname);     /* elevation angle key */
+  OptionAdd(&opt,"ekey_path",'t',&ekey_path); /* elevation angle key path */
   OptionAdd(&opt,"fkey",'t',&fkey_fname);     /* frequency key */
   OptionAdd(&opt,"fkey_path",'t',&fkey_path); /* frequency key path */
   OptionAdd(&opt,"nkey",'t',&nkey_fname);     /* noise key */
@@ -521,6 +538,7 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"p",'x',&pwrflg); /* plot power */
   OptionAdd(&opt,"v",'x',&velflg); /* plot velocity */
   OptionAdd(&opt,"w",'x',&wdtflg); /* plot spectral width */
+  OptionAdd(&opt,"e",'x',&elvflg); /* plot elevation angle */
 
   OptionAdd(&opt,"pmin",'d',&pmin); /* power minimum */
   OptionAdd(&opt,"pmax",'d',&pmax); /* power maximum */
@@ -530,6 +548,9 @@ int main(int argc,char *argv[]) {
 
   OptionAdd(&opt,"wmin",'d',&wmin); /* spectral width minimum */
   OptionAdd(&opt,"wmax",'d',&wmax); /* spectral width maximum */
+
+  OptionAdd(&opt,"emin",'d',&emin); /* elevation angle minimum */
+  OptionAdd(&opt,"emax",'d',&emax); /* elevation angle maximum */
 
   OptionAdd(&opt,"gs",'x',&gsflg); /* shade ground scatter */
   OptionAdd(&opt,"gm",'x',&gmflg); /* mask ground scatter */
@@ -691,6 +712,25 @@ int main(int argc,char *argv[]) {
     }
   }
 
+  if (ekey_fname !=NULL) {
+    if (ekey_path == NULL) ekey_path = getenv("COLOR_TABLE_PATH");
+    if (ekey_path != NULL) {
+      strcpy(kname, ekey_path);
+      len = strlen(ekey_path);
+      if (ekey_path[len-1] != '/') strcat(kname, "/");
+      strcat(kname, ekey_fname);
+    } else {
+      fprintf(stderr, "No COLOR_TABLE_PATH set\n");
+    }
+    fp=fopen(kname,"r");
+    if (fp !=NULL) {
+      load_key(fp,&ekey);
+      fclose(fp);
+    } else {
+      fprintf(stderr, "Elevation angle color table %s not found\n", kname);
+    }
+  }
+
   if (fkey_fname !=NULL) {
     if (fkey_path == NULL) fkey_path = getenv("COLOR_TABLE_PATH");
     if (fkey_path != NULL) {
@@ -792,6 +832,14 @@ int main(int argc,char *argv[]) {
       wkey.r=KeyLinearR[0];
       wkey.g=KeyLinearG[0];
       wkey.b=KeyLinearB[0];
+  }
+
+  if (ekey.max==0) {
+      ekey.max=KeyLinearMax;
+      ekey.a=KeyLinearA[0];
+      ekey.r=KeyLinearR[0];
+      ekey.g=KeyLinearG[0];
+      ekey.b=KeyLinearB[0];
   }
  
   if (nkey.max==0) {
@@ -997,7 +1045,10 @@ int main(int argc,char *argv[]) {
     type[cnt]=2;
     cnt++;
   }
-
+  if (elvflg) {
+    type[cnt]=3;
+    cnt++;
+  }
   plt=GrplotMake(wdt,hgt-150,1,cnt,60,80,0,25,0,120);
   GrplotSetPlot(plt,plot);
   GrplotSetTextBox(plt,txtbox,fontdb);  
@@ -1015,11 +1066,12 @@ int main(int argc,char *argv[]) {
   if (pwrflg) blk[0]=FrameBufferMake("power",bwdt,bhgt,24);
   if (velflg) blk[1]=FrameBufferMake("velocity",bwdt,bhgt,24);
   if (wdtflg) blk[2]=FrameBufferMake("width",bwdt,bhgt,24);
+  if (elvflg) blk[3]=FrameBufferMake("elevation",bwdt,bhgt,24);
 
   FrameBufferClear(fblk,0x0f,bgcolor);
   FrameBufferClear(nblk,0x0f,bgcolor);
   
-  for (n=0;n<3;n++) if (blk[n] !=NULL) FrameBufferClear(blk[n],0x0f,bgcolor);
+  for (n=0;n<4;n++) if (blk[n] !=NULL) FrameBufferClear(blk[n],0x0f,bgcolor);
 
   do {   
 
@@ -1060,7 +1112,7 @@ int main(int argc,char *argv[]) {
     if (lft>=bwdt) lft=bwdt-1;
     if (rgt<0) rgt=0;
     if (rgt>=bwdt) rgt=bwdt-1;
-    for (n=0;n<3;n++) {
+    for (n=0;n<4;n++) {
       if (blk[n]==NULL) continue;
       if (lrngflg==0) {
         sprng=1;
@@ -1131,6 +1183,7 @@ int main(int argc,char *argv[]) {
           if (n==0) val=tplot.p_l[rng];
           if (n==1) val=tplot.v[rng];
           if (n==2) val=tplot.w_l[rng];
+          if (n==3) val=tplot.elv[rng];
           
           if (c<0) c=0;
           if (n==0) {
@@ -1153,7 +1206,7 @@ int main(int argc,char *argv[]) {
             rv=vkey.r[c];
             gv=vkey.g[c];
             bv=vkey.b[c];
-	  } else {
+	  } else if (n==2) {
             val=(val-wmin)/(wmax-wmin);
             c=val*wkey.max;
             if (c<0) c=0;
@@ -1163,7 +1216,23 @@ int main(int argc,char *argv[]) {
             rv=wkey.r[c];
             gv=wkey.g[c];
             bv=wkey.b[c];
-	  }
+	  } else if (n==3) {
+            val=(val-emin)/(emax-emin);
+            c=val*ekey.max;
+            if (c<=0) {
+              av=0;
+              rv=0;
+              gv=0;
+              bv=0;
+            } else {
+            if (c>=ekey.max) c=ekey.max-1; 
+            if (ekey.a !=NULL) av=ekey.a[c];
+		else av=255;
+            rv=ekey.r[c];
+            gv=ekey.g[c];
+            bv=ekey.b[c];
+            }
+          }
         }  
 	  
 	for (x=lft;x<=rgt;x++) {
@@ -1233,7 +1302,10 @@ int main(int argc,char *argv[]) {
     GrplotFitImage(plt,i,blk[2],0x0f);
     i++;
   }
-
+  if (elvflg) {
+    GrplotFitImage(plt,i,blk[3],0x0f);
+    i++;
+  }
   if (xmajor==0) {
     xmajor=3*3600;    
     if ((etime-stime)<8*3600) xmajor=3600;
@@ -1319,6 +1391,14 @@ int main(int argc,char *argv[]) {
               label_wdt,NULL,fontname,fontsize,txtcolor,0x0f,
               width,wkey.max,wkey.a,wkey.r,wkey.g,wkey.b);
       GrplotXaxisTitle(plt,i,0x02,strlen("Spectral Width"),"Spectral Width",
+                     fontname,fontsize,txtcolor,0x0f);
+    }
+    if (type[i]==3) {
+
+      GrplotKey(plt,i,10,0,8,bhgt,emin,emax,(emax-emin)/10,0x02,0x00,NULL,
+              label_elv,NULL,fontname,fontsize,txtcolor,0x0f,
+              width,ekey.max,ekey.a,ekey.r,ekey.g,ekey.b);
+      GrplotXaxisTitle(plt,i,0x02,strlen("Elevation Angle"),"Elevation Angle",
                      fontname,fontsize,txtcolor,0x0f);
     }
     if (i==cnt-1) {

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/tplot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/tplot.c
@@ -94,6 +94,14 @@ int tplotset(struct tplot *ptr,int nrang) {
   if (tmp==NULL) return -1;
   memset(tmp,0,sizeof(double)*nrang);
   ptr->w_l_e=tmp;
+
+
+  if (ptr->elv==NULL) tmp=malloc(sizeof(double)*nrang);
+  else tmp=realloc(ptr->elv,sizeof(double)*nrang);
+  if (tmp==NULL) return -1;
+  memset(tmp,0,sizeof(double)*nrang);
+  ptr->elv=tmp;
+
   return 0;
 
 }

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/tplot.h
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/tplot.h
@@ -55,6 +55,7 @@ struct tplot {
   double *v_e;
   double *w_l;
   double *w_l_e;
+  double *elv;
 }; 
 
 int tplotset(struct tplot *ptr,int nrang);


### PR DESCRIPTION
This pull request adds the ability to display elevation angles in `time_plot` with a new command line option `-e`. 

New command line options `-emin`, `-emax`, `-ekey` and `-ekey_path` are also provided. These are analogous to the options available for the power, velocity and spectral width parameters. 

I chose to keep the original behaviour of the `-a` ("plot all parameters") option, so only the power, velocity and spectral width will be plotted. All four parameters can be plotted using:
 `time_plot [options] -a -e [fitfile]`

When the elevation angle is not available, nothing is plotted. 

![timeplot_elevation_example](https://user-images.githubusercontent.com/22493623/30481450-ff138066-9a1e-11e7-86ce-8034eecd21d0.png)