### PR TITLE
Feature/igrfeval

### DIFF
--- a/codebase/analysis/src.bin/aacgm/aacgmeval.1.2/doc/aacgmeval.doc.xml
+++ b/codebase/analysis/src.bin/aacgm/aacgmeval.1.2/doc/aacgmeval.doc.xml
@@ -18,7 +18,7 @@
 </option>
 <option><on>-lon <ar>lon</ar></on><od>calculate for the longitude <ar>lon</ar>.</od>
 </option>
-<option><on>-alt <ar>mlon</ar></on><od>calculate for the altitude in kilometers, <ar>alt</ar>.</od>
+<option><on>-alt <ar>alt</ar></on><od>calculate for the altitude in kilometers, <ar>alt</ar>.</od>
 </option>
 <option><on>-d <ar>yyyymmdd</ar></on><od>calculate for the date <ar>yyyymmdd</ar> (v2 only).</od>
 </option>

--- a/codebase/analysis/src.bin/igrf/igrfeval.1.0/doc/igrfeval.doc.xml
+++ b/codebase/analysis/src.bin/igrf/igrfeval.1.0/doc/igrfeval.doc.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<binary>
+<project>analysis</project>
+<name>igrfeval</name>
+<location>src.bin/igrf/igrfeval</location>
+
+<syntax>igrfeval --help</syntax>
+<syntax>igrfeval [-m] [-lat <ar>lat</ar>] [-lon <ar>lon</ar>] [-alt <ar>alt</ar>] [-fmt <ar>format</ar>]</syntax>
+<syntax>igrfeval [-m] [-f <ar>filename</ar>] [-fmt <ar>format</ar>]</syntax>
+
+<synopsis><p>Calculate IGRF Bx, By, and Bz magnetic field components and magnitude.</p></synopsis>
+
+<option><on>--help</on><od>print the help message and exit.</od>
+</option>
+<option><on>-m</on><od>location is in geomagnetic rather than geographic coordinates.</od>
+</option>
+<option><on>-lat <ar>lat</ar></on><od>calculate for the latitude <ar>lat</ar>.</od>
+</option>
+<option><on>-lon <ar>lon</ar></on><od>calculate for the longitude <ar>lon</ar>.</od>
+</option>
+<option><on>-alt <ar>alt</ar></on><od>calculate for the altitude in kilometers, <ar>alt</ar>.</od>
+</option>
+<option><on>-re <ar>Re</ar></on><od>calculate for the Earth radius in kilometers, <ar>Re</ar>.</od>
+</option>
+<option><on>-d <ar>yyyymmdd</ar></on><od>calculate for the date <ar>yyyymmdd</ar> (v2 only).</od>
+</option>
+<option><on>-t <ar>hr:mn</ar></on><od>calculate for the time <ar>hr:mn</ar> (v2 only).</od>
+</option>
+<option><on>-fmt <ar>format</ar></on><od>use the string <ar>fmt</ar>, to format the output.</od>
+</option>
+<option><on>-f <ar>filename</ar></on><od>read a sequence of latitudes, longitudes and altitudes from the ASCII file, <ar>filename</ar>.</od>
+</option>
+<option><on>-old_aacgm</on><od>use old AACGM coordinates rather than v2.</od>
+</option>
+
+<description>
+<p>Calculates IGRF Bx, By, and Bz magnetic field components and magnitude. The output is written to standard output using the formatting string given by the "<code>-fmt</code>" option. The format string should be in the same format as that used by the <code>printf</code> function and will take two double precision floating point numbers as arguments.</p>
+<p>If the "<code>-f</code>" option is given, the latitude,longitude and altitude are read from a space separated ASCII file. If the filename is "<code>-</code>" input is read from standard input.</p>
+</description>
+
+<example>
+<command>igrfeval -lat 85.4 -lon 32.4 -alt 300.0</command>
+<description>Calculate the IGRF magnetic field components at the coordinate given by latitude of 85.4 degrees, longitude 32.4 degrees and altitude of 300 kilometers to AACGM.</description>
+</example>
+
+<example>
+<command>igrfeval -m -f aacgm.txt</command>
+<description>Calculate the IGRF magnetic field components for the geomagnetic coordinates in the file "<code>aacgm.txt</code>".</description>
+</example>
+
+</binary>

--- a/codebase/analysis/src.bin/igrf/igrfeval.1.0/doc/igrfeval.doc.xml
+++ b/codebase/analysis/src.bin/igrf/igrfeval.1.0/doc/igrfeval.doc.xml
@@ -40,7 +40,7 @@
 
 <example>
 <command>igrfeval -lat 85.4 -lon 32.4 -alt 300.0</command>
-<description>Calculate the IGRF magnetic field components at the coordinate given by latitude of 85.4 degrees, longitude 32.4 degrees and altitude of 300 kilometers to AACGM.</description>
+<description>Calculate the IGRF magnetic field components at the coordinate given by latitude of 85.4 degrees, longitude 32.4 degrees and altitude of 300 kilometers.</description>
 </example>
 
 <example>

--- a/codebase/analysis/src.bin/igrf/igrfeval.1.0/doc/igrfeval.doc.xml
+++ b/codebase/analysis/src.bin/igrf/igrfeval.1.0/doc/igrfeval.doc.xml
@@ -8,7 +8,7 @@
 <syntax>igrfeval [-m] [-lat <ar>lat</ar>] [-lon <ar>lon</ar>] [-alt <ar>alt</ar>] [-fmt <ar>format</ar>]</syntax>
 <syntax>igrfeval [-m] [-f <ar>filename</ar>] [-fmt <ar>format</ar>]</syntax>
 
-<synopsis><p>Calculate IGRF Bx, By, and Bz magnetic field components and magnitude.</p></synopsis>
+<synopsis><p>Calculate IGRF magnetic field components and magnitude [nT].</p></synopsis>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
@@ -28,13 +28,15 @@
 </option>
 <option><on>-fmt <ar>format</ar></on><od>use the string <ar>fmt</ar>, to format the output.</od>
 </option>
+<option><on>-xyz</on><od>Output should be in Cartesian rather than North/East/Down coordinates.</od>
+</option>
 <option><on>-f <ar>filename</ar></on><od>read a sequence of latitudes, longitudes and altitudes from the ASCII file, <ar>filename</ar>.</od>
 </option>
 <option><on>-old_aacgm</on><od>use old AACGM coordinates rather than v2.</od>
 </option>
 
 <description>
-<p>Calculates IGRF Bx, By, and Bz magnetic field components and magnitude. The output is written to standard output using the formatting string given by the "<code>-fmt</code>" option. The format string should be in the same format as that used by the <code>printf</code> function and will take two double precision floating point numbers as arguments.</p>
+<p>Calculates IGRF magnetic field components and magnitude in units of nanotesla [nT]. The output is written to standard output using the formatting string given by the "<code>-fmt</code>" option. The format string should be in the same format as that used by the <code>printf</code> function and will take two double precision floating point numbers as arguments.</p>
 <p>If the "<code>-f</code>" option is given, the latitude,longitude and altitude are read from a space separated ASCII file. If the filename is "<code>-</code>" input is read from standard input.</p>
 </description>
 

--- a/codebase/analysis/src.bin/igrf/igrfeval.1.0/igrf.c
+++ b/codebase/analysis/src.bin/igrf/igrfeval.1.0/igrf.c
@@ -43,6 +43,11 @@
 
 struct OptionData opt;
 
+int opterr(char *txt) {
+    fprintf(stderr,"Option not recognized: %s\n",txt);
+    return(-1);
+}
+
 /**
  * Converts an input date from YYYYMMDD format to an epoch time in number of
  * seconds since 00:00 UT on January 1, 1970.
@@ -131,7 +136,11 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"t",'t',&tmetxt);              /* Time for IGRF calculation */
   OptionAdd(&opt,"d",'t',&dtetxt);              /* Date for IGRF calculation */
 
-  arg=OptionProcess(1,argc,argv,&opt,NULL);
+  arg=OptionProcess(1,argc,argv,&opt,opterr);
+
+  if (arg==-1) {
+    exit(0);
+  }
 
   if (help==1) {
     OptionPrintInfo(stdout,hlpstr);

--- a/codebase/analysis/src.bin/igrf/igrfeval.1.0/igrf.c
+++ b/codebase/analysis/src.bin/igrf/igrfeval.1.0/igrf.c
@@ -103,6 +103,7 @@ int main(int argc,char *argv[]) {
   unsigned char option=0;
   unsigned char help=0;
   unsigned char mag=0;
+  unsigned char xyz=0;
   int c;
 
   int old_aacgm=0;
@@ -123,6 +124,7 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"lat",'d',&ilat);              /* Latitude [deg] */
   OptionAdd(&opt,"alt",'d',&alt);               /* Altitude [km] */
   OptionAdd(&opt,"re",'d',&Re);                 /* Earth radius [km] */
+  OptionAdd(&opt,"xyz",'x',&xyz);                /* Output in Cartesian rather than North/East/Down coords */
   OptionAdd(&opt,"fmt",'t',&fmt);
   OptionAdd(&opt,"f",'t',&fname);
   OptionAdd(&opt,"old_aacgm",'x',&old_aacgm);   /* Use old AACGM coefficicents rather than v2 */
@@ -183,7 +185,8 @@ int main(int argc,char *argv[]) {
     IGRF_compute(rtp,brtp);
     bspcar(rtp[1],rtp[2],brtp,bxyz);
     bmag = sqrt(bxyz[0]*bxyz[0]+bxyz[1]*bxyz[1]+bxyz[2]*bxyz[2]);
-    fprintf(stdout,fmt,bxyz[0],bxyz[1],bxyz[2],bmag);
+    if (xyz) fprintf(stdout,fmt,bxyz[0],bxyz[1],bxyz[2],bmag);
+    else fprintf(stdout,fmt,-brtp[1],brtp[2],-brtp[0],bmag);
   } else {
     if (strcmp(fname,"-")==0) fp=stdin;
     else fp=fopen(fname,"r");
@@ -207,7 +210,9 @@ int main(int argc,char *argv[]) {
       IGRF_compute(rtp,brtp);
       bspcar(rtp[1],rtp[2],brtp,bxyz);
       bmag = sqrt(bxyz[0]*bxyz[0]+bxyz[1]*bxyz[1]+bxyz[2]*bxyz[2]);
-      fprintf(stdout,fmt,bxyz[0],bxyz[1],bxyz[2],bmag);
+      if (xyz) fprintf(stdout,fmt,bxyz[0],bxyz[1],bxyz[2],bmag);
+      else fprintf(stdout,fmt,-brtp[1],brtp[2],-brtp[0],bmag);
+      fprintf(stdout,fmt,-brtp[1],brtp[2],-brtp[0],bmag);
     }
   }
   return 0;

--- a/codebase/analysis/src.bin/igrf/igrfeval.1.0/igrf.c
+++ b/codebase/analysis/src.bin/igrf/igrfeval.1.0/igrf.c
@@ -1,0 +1,214 @@
+/* igrf.c
+   ======
+   Author: E.G.Thomas
+*/
+
+/*
+ LICENSE AND DISCLAIMER
+ 
+ Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+ 
+ This file is part of the Radar Software Toolkit (RST).
+ 
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ any later version.
+ 
+ RST is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with RST.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ 
+ 
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h> 
+#include "option.h"
+#include "rtime.h"
+#include "rmath.h"
+#include "errstr.h"
+#include "hlpstr.h"
+#include "aacgm.h"
+#include "aacgmlib_v2.h"
+#include "igrflib.h"
+
+
+struct OptionData opt;
+
+/**
+ * Converts an input date from YYYYMMDD format to an epoch time in number of
+ * seconds since 00:00 UT on January 1, 1970.
+ **/
+double strdate(char *text) {
+
+    double tme;
+    int val;
+    int yr,mo,dy;
+
+    /* Calculate day, month, and year from YYYYMMDD format date */
+    val=atoi(text);
+    dy=val % 100;
+    mo=(val / 100) % 100;
+    yr=(val / 10000);
+
+    /* If only 2-digit year provided then assume it was pre-2000 */
+    if (yr<1970) yr+=1900;
+
+    /* Calculate epoch time of input year, month, and day */
+    tme=TimeYMDHMSToEpoch(yr,mo,dy,0,0,0);
+
+    /* Return epoch time in number of seconds since 00:00UT on January 1, 1970 */
+    return tme;
+
+}
+
+
+/**
+ * Converts an input time from HHMM format to number of seconds.
+ **/
+double strtime(char *text) {
+
+    int hr,mn;
+    int i;
+
+    for (i=0;(text[i] !=':') && (text[i] !=0);i++);
+    if (text[i]==0) return atoi(text)*3600L;
+    text[i]=0;
+    hr=atoi(text);
+    mn=atoi(text+i+1);
+    return hr*3600L+mn*60L;
+
+}
+
+int main(int argc,char *argv[]) {
+  int arg;
+ 
+  double ilon=0.0,ilat=0.0,alt=0.0;
+  double rtp[3],brtp[3],bxyz[3];
+  double bmag;
+  double glat,glon,r;
+  char *fmt=NULL;
+  char *dfmt="%f %f %f %f\n";
+  char *fname=NULL;
+  FILE *fp;
+
+  unsigned char option=0;
+  unsigned char help=0;
+  unsigned char mag=0;
+  int c;
+
+  int old_aacgm=0;
+  char *tmetxt=NULL;
+  char *dtetxt=NULL;
+  double Re=-1;
+  double dval=-1;
+  double tval=-1;
+  int yr,mo,dy,hr,mt,sc,dno;
+  double sec;
+
+  char txt[256];
+
+  OptionAdd(&opt,"-help",'x',&help);
+  OptionAdd(&opt,"-option",'x',&option);
+  OptionAdd(&opt,"m",'x',&mag);                 /* Input is in magnetic rather than geographic coords */
+  OptionAdd(&opt,"lon",'d',&ilon);              /* Longitude [deg] */
+  OptionAdd(&opt,"lat",'d',&ilat);              /* Latitude [deg] */
+  OptionAdd(&opt,"alt",'d',&alt);               /* Altitude [km] */
+  OptionAdd(&opt,"re",'d',&Re);                 /* Earth radius [km] */
+  OptionAdd(&opt,"fmt",'t',&fmt);
+  OptionAdd(&opt,"f",'t',&fname);
+  OptionAdd(&opt,"old_aacgm",'x',&old_aacgm);   /* Use old AACGM coefficicents rather than v2 */
+  OptionAdd(&opt,"t",'t',&tmetxt);              /* Time for IGRF calculation */
+  OptionAdd(&opt,"d",'t',&dtetxt);              /* Date for IGRF calculation */
+
+  arg=OptionProcess(1,argc,argv,&opt,NULL);
+
+  if (help==1) {
+    OptionPrintInfo(stdout,hlpstr);
+    exit(0);
+  }
+
+  if (option==1) {
+    OptionDump(stdout,&opt);
+    exit(0);
+  }
+
+  if (Re!=-1) Re*=1000.0;
+  else Re=6371.0*1000.0;
+
+  if (fmt==NULL) fmt=dfmt;
+
+  if (tmetxt !=NULL) tval=strtime(tmetxt);
+  if (dtetxt !=NULL) dval=strdate(dtetxt);
+
+  if (dval !=-1) {
+    if (tval !=-1) {
+      tval+=dval;
+      TimeEpochToYMDHMS(tval,&yr,&mo,&dy,&hr,&mt,&sec);
+      IGRF_SetDateTime(yr,mo,dy,hr,mt,0);
+      if (mag && !old_aacgm) AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,0);
+    } else {
+      tval=dval;
+      TimeEpochToYMDHMS(tval,&yr,&mo,&dy,&hr,&mt,&sec);
+      IGRF_SetDateTime(yr,mo,dy,0,0,0);
+      if (mag && !old_aacgm) AACGM_v2_SetDateTime(yr,mo,dy,0,0,0);
+    }
+  } else {
+    fprintf(stderr,"\nDate must be set, using today's date\n\n");
+    IGRF_SetNow();
+    IGRF_GetDateTime(&yr,&mo,&dy,&hr,&mt,&sc,&dno);
+    IGRF_SetDateTime(yr,mo,dy,0,0,0);
+    if (mag && !old_aacgm) AACGM_v2_SetDateTime(yr,mo,dy,0,0,0);
+  }
+
+  if (fname==NULL) {
+    if (mag) {
+      if (old_aacgm) AACGMConvert(ilat,ilon,alt,&glat,&glon,&r,1);
+      else AACGM_v2_Convert(ilat,ilon,alt,&glat,&glon,&r,1);
+    } else {
+      glat = ilat;
+      glon = ilon;
+    }
+    rtp[0] = (Re+alt*1000.0)/Re;
+    rtp[1] = (90.-glat)*PI/180.;
+    rtp[2] = glon*PI/180.;
+    IGRF_compute(rtp,brtp);
+    bspcar(rtp[1],rtp[2],brtp,bxyz);
+    bmag = sqrt(bxyz[0]*bxyz[0]+bxyz[1]*bxyz[1]+bxyz[2]*bxyz[2]);
+    fprintf(stdout,fmt,bxyz[0],bxyz[1],bxyz[2],bmag);
+  } else {
+    if (strcmp(fname,"-")==0) fp=stdin;
+    else fp=fopen(fname,"r");
+    if (fp==NULL) exit(1);
+    while(fgets(txt,255,fp) !=NULL) {
+      for (c=0;(txt[c] !=0) && (c<256);c++) 
+      if (txt[c]=='#') break;
+      if (txt[c]=='#') continue;
+      if (sscanf(txt,"%lf %lf %lf\n",
+          &ilat,&ilon,&alt) !=3) continue;
+      if (mag) {
+        if (old_aacgm) AACGMConvert(ilat,ilon,alt,&glat,&glon,&r,1);
+        else AACGM_v2_Convert(ilat,ilon,alt,&glat,&glon,&r,1);
+      } else {
+        glat = ilat;
+        glon = ilon;
+      }
+      rtp[0] = (Re+alt*1000.0)/Re;
+      rtp[1] = (90.-glat)*PI/180.;
+      rtp[2] = glon*PI/180.;
+      IGRF_compute(rtp,brtp);
+      bspcar(rtp[1],rtp[2],brtp,bxyz);
+      bmag = sqrt(bxyz[0]*bxyz[0]+bxyz[1]*bxyz[1]+bxyz[2]*bxyz[2]);
+      fprintf(stdout,fmt,bxyz[0],bxyz[1],bxyz[2],bmag);
+    }
+  }
+  return 0;
+}

--- a/codebase/analysis/src.bin/igrf/igrfeval.1.0/makefile
+++ b/codebase/analysis/src.bin/igrf/igrfeval.1.0/makefile
@@ -1,0 +1,19 @@
+# Makefile for igrfeval
+# =====================
+# Author: E.G.Thomas
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/analysis
+OBJS = igrf.o
+
+SRC=hlpstr.h errstr.h igrf.c
+DSTPATH = $(BINPATH)
+OUTPUT = igrfeval
+LNK=$(ARC)
+LIBS=-laacgm.1 -lopt.1 -lrtime.1 -laacgm_v2.1 -ligrf_v2.1 -lastalg.1
+SLIB=-lm
+
+ 
+include $(MAKEBIN).$(SYSTEM)


### PR DESCRIPTION
This was something I hastily adapted from the `aacgmeval` command and `calc_bmag` function because I wanted a simple way to get the IGRF B-field components at a particular lat/lon/alt location.  By default the input location is assumed to be in geographic coords while geomagnetic coords can be used by setting the `-m` flag.  Users can also define their own Earth radius value if they like; otherwise it defaults to 6371 km.  Today's date is used if no input date/time information is provided.

I don't know if there are any online calculators or other tools to allow easy validation, so testing is definitely needed.