### PR TITLE
Fixing dlm return value of AACGM_v2_GetDateTime on error

### DIFF
--- a/codebase/analysis/src.dlm/aacgmdlm.2.0/aacgmdlm.c
+++ b/codebase/analysis/src.dlm/aacgmdlm.2.0/aacgmdlm.c
@@ -25,6 +25,7 @@
 #define AACGM_MISMATCHDIMS -1
 #define AACGM_MISMATCHELMS -2
 #define AACGM_BADTYPE -3
+#define AACGM_DATENOTSET -4
 
 static IDL_MSG_DEF msg_arr[] =
   {
@@ -32,6 +33,7 @@ static IDL_MSG_DEF msg_arr[] =
     {  "AACGM_MISMATCHDIMS","%NMismatched array dimensions %s"},
     {  "AACGM_MISMATCHELMS","%NNumber of array elements do not match %s"},
     {  "AACGM_BADTYPE","%NArrays of floating point type are allowed %s"},
+    {  "AACGM_DATENOTSET","%NDate and Time are not currently set"},
   };
 
 static IDL_MSG_BLOCK msg_block;
@@ -255,6 +257,13 @@ static IDL_VPTR IDLAACGM_v2_GetDateTime(int argc,IDL_VPTR *argv,char *argk) {
     outargc=IDL_KWGetParams(argc,argv,argk,kw_pars,outargv,1);
 
     s=AACGM_v2_GetDateTime(&yr,&mo,&dy,&hr,&mt,&sc,&dayno);
+
+    if (yr==-1) {
+        IDL_MessageFromBlock(msg_block,AACGM_DATENOTSET,IDL_MSG_RET);
+        s=-1;
+        IDL_KWCleanup(IDL_KW_CLEAN);
+        return (IDL_GettmpLong(s));
+    }
 
     IDL_StoreScalar(outargv[0],IDL_TYP_LONG,(IDL_ALLTYPES *) &yr);
     if (month) IDL_StoreScalar(month,IDL_TYP_LONG,(IDL_ALLTYPES *) &mo);


### PR DESCRIPTION
This commit brings the return value of the DLM version of `AACGM_v2_GetDateTime` in sync with the IDL implementation. The IDL function prints an error message and returns -1 if the date/time has not yet been set while the C version always returns 0. 

https://github.com/SuperDARN/rst/blob/develop/codebase/analysis/src.idl/lib/aacgm.2.0/aacgm_v2.pro#L203-L207
https://github.com/SuperDARN/rst/blob/develop/codebase/analysis/src.lib/aacgm_v2/aacgm.1.0/src/aacgmlib_v2.c#L1137-L1145

This commit checks for year==-1 after the call to `AACGM_v2_GetDateTime` in the DLM and will print the same error message and return -1 if appropriate; otherwise the date/time values are stored in the keywords as normal.