### PR TITLE
Fixing leftover merge conflicts with make_fov arguments in grid_plot and map_plot

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
@@ -901,7 +901,7 @@ int main(int argc,char *argv[]) {
   if ((lat<0) && (latmin>0)) latmin=-latmin;
   if ((lat>0) && (latmin<0)) latmin=-latmin;
 
-  if (fovflg || ffovflg) fov=make_fov(rgrid->st_time,network); 
+  if (fovflg || ffovflg) fov=make_fov(rgrid->st_time,network,chisham); 
   if ((fovflg || ffovflg) && !magflg) {
     if (old_aacgm) MapModify(fov,AACGMtransform,&flg);
     else           MapModify(fov,AACGM_v2_transform,&flg);

--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/doc/map_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/doc/map_plot.doc.xml
@@ -3,6 +3,7 @@
 <project>superdarn</project>
 <name>map_plot</name>
 <location>src.bin/tk/plot/map_plot</location>
+
 <syntax>map_plot --help</syntax>
 <syntax>map_plot [<ar>options</ar>] <ar>mapname</ar> [<ar>inxname</ar>]
 </syntax>
@@ -26,6 +27,7 @@
 </syntax>
 <syntax>map_plot -x [-display <ar>display</ar>] [-xoff <ar>xoff</ar>] [-yoff <ar>yoff</ar>] [-delay <ar>delay</ar>] [<ar>options</ar>] <ar>mapname</ar> [<ar>inxname</ar>]
 </syntax>
+
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
 <option><on>-path <ar>pathname</ar></on><od>write the plots to the directory given by <ar>pathname</ar>.</od>
@@ -120,70 +122,48 @@
 </option>
 <option><on>-bgcol <ar>aarrggbb</ar></on><od>set the background color to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-txtcol <ar>aarrggbb</ar></on><od>set the color of the text to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-grdcol <ar>aarrggbb</ar></on><od>set the color of the grid to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-igrdcol <ar>aarrggbb</ar></on><od>set the color of the inverse grid to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
-
 <option><on>-cstcol <ar>aarrggbb</ar></on><od>set the color of the coastline to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-bndcol <ar>aarrggbb</ar></on><od>set the color of the state boundaries to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-lndcol <ar>aarrggbb</ar></on><od>set the color of the land to <ar>aarrggbb</ar>, specified as the  hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-seacol <ar>aarrggbb</ar></on><od>set the color of the sea to <ar>aarrggbb</ar>, specified as the  hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-tmkcol <ar>aarrggbb</ar></on><od>set the color of the time clock-dial to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-fovcol <ar>aarrggbb</ar></on><od>set the color of the field of view outline to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-ffovcol <ar>aarrggbb</ar></on><od>set the color of the filled field of view to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-vecccol <ar>aarrggbb</ar></on><od>if a colorkey is not used then set the color of vectors to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-ctrcol <ar>aarrggbb</ar></on><od>set the color of contours to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
-
 <option><on>-polycol <ar>aarrggbb</ar></on><od>set the color of contour polygons to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-fpolycol <ar>aarrggbb</ar></on><od>set the color of filled contour polygons to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-hmbcol <ar>aarrggbb</ar></on><od>set the color of the Heppner-Maynard boundary  to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-trmcol <ar>aarrggbb</ar></on><od>set the color of the terminator outline to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-ftrmcol <ar>aarrggbb</ar></on><od>set the color of the filled terminator outline to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-
 <option><on>-vkey <ar>vkeyname</ar></on><od>load the velocity colorkey from the file <ar>vkeyname</ar>.</od>
 </option>
 <option><on>-vkey_path <ar>vkey_path</ar></on><od>load the velocity colorkey from the custom path <ar>vkey_path</ar>.</od>
 </option>
-
 <option><on>-pkey <ar>pkeyname</ar></on><od>load the colorkey used to contour polygons from the file <ar>pkeyname</ar>.</od>
 </option>
 <option><on>-pkey_path <ar>pkey_path</ar></on><od>load the colorkey used to contour polygons from the custom path <ar>pkey_path</ar>.</od>
 </option>
-
 <option><on>-xkey <ar>xkeyname</ar></on><od>load the extra colorkey (used to plot power or spectral width) from the file <ar>xkeyname</ar>.</od>
 </option>
 <option><on>-xkey_path <ar>xkey_path</ar></on><od>load the extra colorkey from the custom path <ar>xkey_path</ar>.</od>
@@ -198,29 +178,18 @@
 </option>
 <option><on>-nopad</on><od>combined with <ar>-mod</ar> will <b>not</b> show padding model zero vectors.</od>
 </option>
-
 <option><on>-ctr</on><od>plot potential contours.</od>
 </option>
-
 <option><on>-poly</on><od>plot contours as simple polygons.</od>
 </option>
-
-
 <option><on>-fpoly</on><od>plot contours as simple filled polygons.</od>
 </option>
-
-
 <option><on>-maxmin</on><od>plot the points of maximum and minimum potential.</od>
 </option>
-
 <option><on>-hmb</on><od>plot Heppner-Maynard boundary.</od>
 </option>
-
-
 <option><on>-exc</on><od>plot velocity vectors excluded from the fit.</od>
 </option>
-
-
 <option><on>-pwr</on><od>plot power.</od>
 </option>
 <option><on>-swd</on><od>plot spectral width.</od>
@@ -231,8 +200,6 @@
 </option>
 <option><on>-min</on><od>if a cell contains more than one data point, plot the minimum power or spectral width.</od>
 </option>
-
-
 <option><on>-modn</on><od>plot the name of the statistical model.</od>
 </option>
 <option><on>-imf</on><od>plot the IMF clock-dial.</od>
@@ -243,70 +210,46 @@
 </option>
 <option><on>-source</on><od>plot the source string.</od>
 </option>
-
-
 <option><on>-vkeyp</on><od>plot the color key for the velocity scale.</od>
 </option>
-
-
 <option><on>-pkeyp</on><od>plot the color key for the potential scale.</od>
 </option>
-
-
-
 <option><on>-xkeyp</on><od>plot the extra color key for the power or spectrral width scale.</od>
 </option>
-
 <option><on>-vecp</on><od>plot the example vector.</od>
 </option>
-
 <option><on>-vsf <ar>vsf</ar></on><od>set the vector scale factor to <ar>vsf</ar>.</od>
 </option>
-
 <option><on>-vrad <ar>vrad</ar></on><od>set the radius of the dot a the vector root to <ar>vrad</ar>.</od>
 </option>
-
-
 <option><on>-logo</on><od>plot the logo and credits.</od>
 </option>
-
 <option><on>-time</on><od>plot the time of the plotted data.</od>
 </option>
-
 <option><on>-cmax <ar>cmax</ar></on><od>set the potential scale maximum to <ar>cmax</ar> (in units of Volts, not kV).</od>
 </option>
-
 <option><on>-vmax <ar>vmax</ar></on><od>set the absolute velocity scale maximum to <ar>vmax</ar>.</od>
 </option>
-
 <option><on>-pmax <ar>pmax</ar></on><od>set the power scale maximum to <ar>pmax</ar>.</od>
 </option>
-
 <option><on>-wmax <ar>wmax</ar></on><od>set the spectral width scale maximum to <ar>wmax</ar>.</od>
 </option>
-
 <option><on>-frame</on><od>add a frame around the borders of the plot.</od>
 </option>
-
 <option><on>-over</on><od>the output plot will be overlaid on another plot, do not paint the background with the bacground color.</od>
 </option>
-
 <option><on><ar>mapname</ar></on><od>filename of the <code>map</code> or <code>cnvmap</code> format file to plot.</od>
 </option>
-
 <option><on><ar>inxname</ar></on><od>filename of the index file associated with the  grid format file to plot.</od>
 </option>
-
 <option><on>-stdout</on><od>plot a single data record and write the plot to standard output.</od>
 </option>
-
 <option><on>-d <ar>yyyymmdd</ar></on><od>plot the data on date <ar>yyyymmdd</ar>.</od>
 </option>
 <option><on>-t <ar>hr:mn</ar></on><od>plot the data at the time <ar>hr:mn</ar>.</od>
 </option>
 <option><on>-ps</on><od>produce a PostScript plot as the output.</od>
 </option>
-
 <option><on>-xp <ar>xoff</ar></on><od>set the X offset of the PostScript plot to <ar>xoff</ar>.</od>
 </option>
 <option><on>-yp <ar>xoff</ar></on><od>set the Y offset of the PostScript plot to <ar>yoff</ar>.</od>
@@ -317,26 +260,19 @@
 </option>
 <option><on>-xml</on><od>produce an XML image representation as the output.</od>
 </option>
-
-<option><on>-x</on><od>plot the data on an X-terminal.</od></option>
-
-
+<option><on>-x</on><od>plot the data on an X-terminal.</od>
+</option>
 <option><on>-display <ar>display</ar></on><od>connect to the xterminal named <ar>display</ar>.</od>
 </option>
-
 <option><on>-xoff <ar>xoff</ar></on><od>open the window, <ar>xoff</ar> pixels from the left edge of the screen.</od>
 </option>
-
 <option><on>-yoff <ar>yoff</ar></on><od>open the window <ar>ypad</ar> pixels from the top edge of the screen.</od>
 </option>
-
 <option><on>-delay <ar>delay</ar></on><od>set the delay between frames to <ar>delay</ar> milliseconds, a value of 0 will pause the frame until a mouse button is pressed.</od>
 </option>
-
-
+<option><on>-chisham</on><od>draw radar fields of view using the Chisham virtual height model.</od>
+</option>
 <synopsis><p>Plot <code>map</code> and <code>cnvmap</code> format files.</p></synopsis>
-
-
 <description><p>Plot the <code>map</code> and <code>cnvmap</code>format files.</p>
 <p>The output can be to an X terminal, XML rplot file, Portable PixMap (PPM) file, extended Portable PixMap (PPMX) file, or PostScript file. The default output is XML.</p>
 <p>The program usually steps through the convection map data and writes each plot to a file. The output filenames are of the form "<code><em>nnnn.xxx</em></code>", where <em>nnnn</em> is the frame number starting at 0000 and <em>xxx</em> is the suffix "<code>xml</code>","<code>ps</code>","<code>ppm</code>", or "<code>ppmx</code>". The options "<code>-tn</code>" and "<code>-dn</code>" can be used to change this format to one based on the time of each plot.</p>
@@ -347,31 +283,29 @@
 <p>The program usually plots the line of sight or fitted velocity vectors contained in the file. However the options "-pwr" and "-wdt" can be used to plot the power and spectral width information stored in extended grid files as an extra parameter.</p> 
 <p>The options "-vkey" and "-xkey" allows a user defined color key to be used to plot the velocity vectors or the extra parameters.</p>
 <p>The color key file is a plain text file that defines the red green and blue components for each index in the color bar. Any line in the file beginning with a "<code>#</code>" is treated as a comment and ignored. The first line that is not a comment defines the number of entries in the table. The remaining lines in the file contain color values for each index, one value per line. The values are hexadecimal numbers of the form <em>aarrggbb</em>, where <em>aa</em> is the alpha component, <em>rr</em> is the red component, <em>gg</em> is the blue component and <em>bb</em> is the blue component.</p>
-
 <p>The number and complexity of the command line options makes typing them a laborious process, especially when producing multiple plots. To solve this problem, command line options can be placed in plain text file that can be parsed by the program using the " <code>-cf</code>" option. This allows the user to create a set of configuration files for producing different plots.</p> 
 </description>
 
-<example><command>map_plot -x -def -vkey superdarn.key 20040620.map</command>
+<example>
+<command>map_plot -x -def -vkey superdarn.key 20040620.map</command>
 <description>Plot convections maps from the file "<code>20040620.map</code>" on the X-terminal. Use the default set of options and the color key "<code>superdarn.key</code>". 
 </description>
 </example>
 
-<example><command>map_plot -ps -dn -st 12:00 -new -stereo -mag -rotate -fcoast -coast -fterm -tmk -vecp -vkeyp -time -imf -modn -pot -fit -ctr -vkey superdarn.key 20021219.cnvmap</command>
+<example>
+<command>map_plot -ps -dn -st 12:00 -new -stereo -mag -rotate -fcoast -coast -fterm -tmk -vecp -vkeyp -time -imf -modn -pot -fit -ctr -vkey superdarn.key 20021219.cnvmap</command>
 <description>Generate PostScript plots of convections maps from the file "<code>20021219.cnvmap</code>". Store the plots in files named "<code><em>yyyymmdd.hrmn.sc</em>.ps</code>", starting at 12:00UTC. Use a stereographic projection in magnetic coordinates, rotated so that magnetic local noon is at the top of the plot. Plot filled coastlines, terminator, a clockdial representing time, a labelled sample velocity vector, the velocity color bar, the time, IMF conditions, model used, Potential, fitted vectors and the potential contours. The velocity color bar is taken from the file "<code>superdarn.key</code>". 
 </description>
 </example>
+
 <example type="rplot">example1</example>
 
-
-<example><command>map_plot -stdout -t 6:00 -new -stereo -pad 0 -mag -lat 78.4 -lon 16.00 -square -sf 2.00 -fcoast -coast -vecp -vkeyp -grd -time -hmb -fit -ctr -vkey ~/key/superdarn.key 20021219.cnvmap &gt; map.rp.xml</command>
+<example>
+<command>map_plot -stdout -t 6:00 -new -stereo -pad 0 -mag -lat 78.4 -lon 16.00 -square -sf 2.00 -fcoast -coast -vecp -vkeyp -grd -time -hmb -fit -ctr -vkey ~/key/superdarn.key 20021219.cnvmap &gt; map.rp.xml</command>
 <description>Generate a single rPlot XML plot of the convections map at 06:00UTC from the file "<code>20021219.cnvmap</code>". Use a stereographic projection in geographic coordinates and center the plot on latitude 78.4 degrees and longitude 16.00 degrees. Plot filled coastlines, a labelled sample velocity vector, the velocity color bar, the time, fitted vectors, Heppner-Maynard boundary and the potential contours.The velocity color bar is taken from the file "<code>superdarn.key</code>". The plot is stored in the file "<code>map.rp.xml</code>".
 </description>
 </example>
+
 <example type="rplot">example2</example>
-
-
-
-
-
 
 </binary>

--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
@@ -689,6 +689,8 @@ int main(int argc,char *argv[]) {
 
   OptionAdd(&opt,"def",'x',&defflg);
 
+  OptionAdd(&opt,"chisham",'x',&chisham); /* Data mapped using Chisham virtual height model */
+
   arg=OptionProcess(1,argc,argv,&opt,rst_opterr);
 
   if (arg==-1) {
@@ -809,7 +811,7 @@ int main(int argc,char *argv[]) {
   else clip=MapSquareClip();
 
   if (lat>90) lat=90*rcmap->hemisphere;
-  if (fovflg || ffovflg) fov=make_fov(rgrid->st_time,network); 
+  if (fovflg || ffovflg) fov=make_fov(rgrid->st_time,network,chisham); 
   if ((fovflg || ffovflg) && !magflg) {
     if (old_aacgm) MapModify(fov,AACGMtransform,&flg);
     else           MapModify(fov,AACGM_v2_transform,&flg);


### PR DESCRIPTION
This pull request fixes an issue where I forgot to add an argument (chisham) to the make_fov calls in grid_plot and map_plot when resolving merge conflicts between the feature/grid_v2 and feature/map_plotential_v2 branches.  Currently the develop branch will crash when trying to compile - this pull request fixes that (and is thus also currently necessary for the warning_cleanup branch).