### PR TITLE
Adding checks for backwards compatibility for pre-v2 map files

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/plot_vec.c
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/plot_vec.c
@@ -73,7 +73,6 @@ void plot_vec(struct Plot *plot,float px,float py,int or,double max, int magflg,
   if (!magflg) {
     mlat = lat;
     mlon = lon;
-fprintf(stderr, "Plot_vec: %f %f\n", mlat,mlon);
     if (old_aacgm) s = AACGMConvert(mlat,mlon,150,&glat,&glon,&r,1);
     else           s = AACGM_v2_Convert(mlat,mlon,150,&glat,&glon,&r,1);
     lat = glat;
@@ -81,7 +80,6 @@ fprintf(stderr, "Plot_vec: %f %f\n", mlat,mlon);
   }
   map[0] = lat;
   map[1] = lon;
-fprintf(stderr, "Plot_vec: %f %f\n", lat,lon);
 
   s = (*trnf)(2*sizeof(float),map,2*sizeof(float),pnt,data);
   if (s == -1) return;
@@ -116,7 +114,6 @@ fprintf(stderr, "Plot_vec: %f %f\n", lat,lon);
   else if (or == 2) PlotLine(plot,px,py-mag,px,py,color,0x0f,width,NULL);    
   else if (or == 3) PlotLine(plot,px,py,px,py+mag,color,0x0f,width,NULL);    
 
-fprintf(stderr, "Plot_vec\n");
   sprintf(txt,"%g m/s",max);
   txtbox(fontname,fontsize,strlen(txt),txt,txbox,txtdata);
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/readmap.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/readmap.c
@@ -167,7 +167,7 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
   ptr=DataMapReadBlock(fid,&size);
 
   if (ptr==NULL){
-    fprintf(stderr, "pointer f rom DataMapReadBlock null\n");
+    fprintf(stderr, "pointer from DataMapReadBlock in CnvMapRead null\n");
     return -1;
   }
   for (c=0;sname[c] !=0;c++) sdata[c]=NULL;
@@ -201,8 +201,6 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
     if (x==27) continue;
     if (x==28) continue;  /* SGS */
     if (x==30) continue;
-/*    fprintf(stdout, "%d\n",x);
-    fprintf(stdout, "sname[x]: %s\n", sname[x]); */
     if (sdata[x]==NULL) break;
   }
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/readmap.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/readmap.c
@@ -1,31 +1,31 @@
 /* readmap.c
-   ========== 
+   ==========
    Author: R.J.Barnes
 */
 
 
 /*
  LICENSE AND DISCLAIMER
- 
+
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- 
+
  This file is part of the Radar Software Toolkit (RST).
- 
+
  RST is free software: you can redistribute it and/or modify
  it under the terms of the GNU Lesser General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  any later version.
- 
+
  RST is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public License
  along with RST.  If not, see <http://www.gnu.org/licenses/>.
- 
- 
- 
+
+
+
 */
 
 #include <stdio.h>
@@ -54,7 +54,7 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
                  "start.minute","start.second",
                  "end.year","end.month","end.day","end.hour",
                  "end.minute","end.second",
-                 "map.major.revision","map.minor.revision", 
+                 "map.major.revision","map.minor.revision",
                  "source",
                  "doping.level",
                  "model.wt",
@@ -88,7 +88,7 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
                  "pot.max.err",
                  "pot.min",
                  "pot.min.err",
-              
+
 
                  0};
 
@@ -166,14 +166,16 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
 
   ptr=DataMapReadBlock(fid,&size);
 
-  if (ptr==NULL) return -1;
-
+  if (ptr==NULL){
+    fprintf(stderr, "pointer f rom DataMapReadBlock null\n");
+    return -1;
+  }
   for (c=0;sname[c] !=0;c++) sdata[c]=NULL;
   for (c=0;aname[c] !=0;c++) adata[c]=NULL;
 
   for (c=0;c<ptr->snum;c++) {
     s=ptr->scl[c];
-    for (x=0;sname[x] !=0;x++) 
+    for (x=0;sname[x] !=0;x++)
       if ((strcmp(s->name,sname[x])==0) && (s->type==stype[x])) {
         sdata[x]=s;
         if (s == NULL) break;   /* SGS */
@@ -186,16 +188,21 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
       if ((strcmp(a->name,aname[x])==0) && (a->type==atype[x])) {
         adata[x]=a;
         break;
-      } 
+      }
     }
   }
 
   for (x=0;sname[x] !=0;x++) {
     if (x==14) continue;
+    if (x==23) continue;
+    if (x==24) continue;
     if (x==25) continue;  /* SGS */
     if (x==26) continue;
     if (x==27) continue;
     if (x==28) continue;  /* SGS */
+    if (x==30) continue;
+/*    fprintf(stdout, "%d\n",x);
+    fprintf(stdout, "sname[x]: %s\n", sname[x]); */
     if (sdata[x]==NULL) break;
   }
 
@@ -243,23 +250,26 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
   map->Bx=*(sdata[20]->data.dptr);
   map->By=*(sdata[21]->data.dptr);
   map->Bz=*(sdata[22]->data.dptr);
-  map->Vx=*(sdata[23]->data.dptr);
-  map->tilt=*(sdata[24]->data.dptr);
+  if (sdata[23] !=NULL)
+    map->Vx=*(sdata[23]->data.dptr);
+  if (sdata[24] !=NULL)
+    map->tilt=*(sdata[24]->data.dptr);
 
-  if (sdata[25] !=NULL) 
+  if (sdata[25] !=NULL)
     strncpy(map->imf_model[0],*((char **) sdata[25]->data.vptr),64);
-  if (sdata[26] !=NULL) 
+  if (sdata[26] !=NULL)
     strncpy(map->imf_model[1],*((char **) sdata[26]->data.vptr),64);
-  if (sdata[27] !=NULL) 
+  if (sdata[27] !=NULL)
     strncpy(map->imf_model[2],*((char **) sdata[27]->data.vptr),64);
-  if (sdata[28] !=NULL) 
+  if (sdata[28] !=NULL)
     strncpy(map->imf_model[3],*((char **) sdata[28]->data.vptr),64);
 
   map->hemisphere=*(sdata[29]->data.sptr);
-  map->noigrf=*(sdata[30]->data.sptr);
+  if (sdata[30] !=NULL)
+    map->noigrf=*(sdata[30]->data.sptr);
   map->fit_order=*(sdata[31]->data.sptr);
   map->latmin=*(sdata[32]->data.fptr);
- 
+
   map->chi_sqr=*(sdata[33]->data.dptr);
   map->chi_sqr_dat=*(sdata[34]->data.dptr);
   map->rms_err=*(sdata[35]->data.dptr);
@@ -284,7 +294,7 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
   if (grd->stnum==0) {
     DataMapFree(ptr);
     return -1;
-  }  
+  }
 
   if (grd->sdata !=NULL) {
     tmp=realloc(grd->sdata,sizeof(struct GridSVec)*grd->stnum);
@@ -299,8 +309,8 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
      DataMapFree(ptr);
      return -1;
   }
- 
-  for (n=0;n<grd->stnum;n++) {    
+
+  for (n=0;n<grd->stnum;n++) {
     grd->sdata[n].st_id=adata[0]->data.sptr[n];
     grd->sdata[n].chn=adata[1]->data.sptr[n];
     grd->sdata[n].npnt=adata[2]->data.sptr[n];
@@ -350,17 +360,17 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
       grd->data[n].mlat=adata[18]->data.fptr[n];
       grd->data[n].mlon=adata[19]->data.fptr[n];
       grd->data[n].azm=adata[20]->data.fptr[n];
-    
+
       grd->data[n].st_id=adata[21]->data.sptr[n];
       grd->data[n].chn=adata[22]->data.sptr[n];
       grd->data[n].index=adata[23]->data.iptr[n];
       grd->data[n].vel.median=adata[24]->data.fptr[n];
       grd->data[n].vel.sd=adata[25]->data.fptr[n];
-   
+
       if (adata[26] !=NULL) grd->data[n].pwr.median=adata[26]->data.fptr[n];
       if (adata[27] !=NULL) grd->data[n].pwr.sd=adata[27]->data.fptr[n];
       if (adata[28] !=NULL) grd->data[n].wdt.median=adata[28]->data.fptr[n];
-      if (adata[29] !=NULL) grd->data[n].wdt.sd=adata[29]->data.fptr[n];    
+      if (adata[29] !=NULL) grd->data[n].wdt.sd=adata[29]->data.fptr[n];
     }
   }
 
@@ -421,9 +431,9 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
     }
   }
 
-  
+
   if (adata[38] !=NULL) {
-   
+
     map->num_bnd=adata[38]->rng[0];
     if (map->bnd_lat !=NULL) {
        tmp=realloc(map->bnd_lat,sizeof(double)*map->num_bnd);
@@ -459,7 +469,7 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
    if (map->bnd_lat !=NULL) {
      for (n=0;n<map->num_bnd;n++) {
         map->bnd_lat[n]=adata[38]->data.fptr[n];
-        map->bnd_lon[n]=adata[39]->data.fptr[n];   
+        map->bnd_lon[n]=adata[39]->data.fptr[n];
      }
   }
 


### PR DESCRIPTION
I think this fixes the backwards compatibility issue of the new grid/map files.  My base test was to try to get an output of a map version 2 file with `map_ascii` and would get an error reading output with the 4.1 release branch.

I am unsure though if these changes break anything else in the code.