### PR TITLE
Adding new cnvmap file format compatibility to native IDL and DLM routines

### DIFF
--- a/codebase/superdarn/src.idl/lib/main.1.25/cnvmap.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/cnvmap.pro
@@ -303,8 +303,8 @@ function CnvMapRead,unit,prm,stvec,gvec,mvec,coef,bvec
       
   if (sclid[25] ne -1) then prm.imf_model[0]=*(sclvec[sclid[25]].ptr)
   if (sclid[26] ne -1) then prm.imf_model[1]=*(sclvec[sclid[26]].ptr)
-  if (sclid[27] ne -1) then prm.imf_model[1]=*(sclvec[sclid[27]].ptr)
-  if (sclid[28] ne -1) then prm.imf_model[1]=*(sclvec[sclid[28]].ptr)
+  if (sclid[27] ne -1) then prm.imf_model[2]=*(sclvec[sclid[27]].ptr)
+  if (sclid[28] ne -1) then prm.imf_model[3]=*(sclvec[sclid[28]].ptr)
 
   prm.hemisphere=*(sclvec[sclid[29]].ptr)
   if (sclid[30] ne -1) then prm.noigrf=*(sclvec[sclid[30]].ptr)

--- a/codebase/superdarn/src.idl/lib/main.1.25/cnvmap.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/cnvmap.pro
@@ -85,8 +85,11 @@ pro CnvMapMakePrm,prm
                   Bx: 0.0D, $
                   By: 0.0D, $
                   Bz: 0.0D, $
-                  imf_model: strarr(2), $
+                  Vx: 0.0D, $
+                  tilt: 0.0D, $
+                  imf_model: strarr(4), $
                   hemisphere: 0, $
+                  noigrf: 0, $
                   fit_order: 0, $
                   latmin: 0.0, $
                   coefnum: 0L, $
@@ -178,9 +181,14 @@ function CnvMapRead,unit,prm,stvec,gvec,mvec,coef,bvec
           'IMF.Bx', $
           'IMF.By', $
           'IMF.Bz', $
+          'IMF.Vx', $
+          'IMF.tilt', $
           'model.angle', $
           'model.level', $
+          'model.tilt', $
+          'model.name', $
           'hemisphere', $
+          'noigrf', $
           'fit.order', $
           'latmin', $
           'chi.sqr', $ 
@@ -201,7 +209,7 @@ function CnvMapRead,unit,prm,stvec,gvec,mvec,coef,bvec
 
   scltype=[2,2,2,2,2,8, $
            2,2,2,2,2,8, $
-           2,2,9,2,2,2,2,2,8,8,8,9,9,2,2,4,8,8,8,4,4,8,8, $
+           2,2,9,2,2,2,2,2,8,8,8,8,8,9,9,9,9,2,2,2,4,8,8,8,4,4,8,8, $
            8,8,8,8,8,8,8]
 
 
@@ -244,6 +252,11 @@ function CnvMapRead,unit,prm,stvec,gvec,mvec,coef,bvec
   if (sclid[14] eq -1) then count=count-1
   if (sclid[23] eq -1) then count=count-1
   if (sclid[24] eq -1) then count=count-1
+  if (sclid[25] eq -1) then count=count-1
+  if (sclid[26] eq -1) then count=count-1
+  if (sclid[27] eq -1) then count=count-1
+  if (sclid[28] eq -1) then count=count-1
+  if (sclid[30] eq -1) then count=count-1
 
   if (count ne 0) then begin
     print,'File is in the wrong format!'
@@ -285,27 +298,32 @@ function CnvMapRead,unit,prm,stvec,gvec,mvec,coef,bvec
   prm.Bx=*(sclvec[sclid[20]].ptr)
   prm.By=*(sclvec[sclid[21]].ptr)
   prm.Bz=*(sclvec[sclid[22]].ptr)
+  if (sclid[23] ne -1) then prm.Vx=*(sclvec[sclid[23]].ptr)
+  if (sclid[24] ne -1) then prm.tilt=*(sclvec[sclid[24]].ptr)
       
-  if (sclid[23] ne -1) then prm.imf_model[0]=*(sclvec[sclid[23]].ptr)
-  if (sclid[24] ne -1) then prm.imf_model[1]=*(sclvec[sclid[24]].ptr)
+  if (sclid[25] ne -1) then prm.imf_model[0]=*(sclvec[sclid[25]].ptr)
+  if (sclid[26] ne -1) then prm.imf_model[1]=*(sclvec[sclid[26]].ptr)
+  if (sclid[27] ne -1) then prm.imf_model[1]=*(sclvec[sclid[27]].ptr)
+  if (sclid[28] ne -1) then prm.imf_model[1]=*(sclvec[sclid[28]].ptr)
 
-  prm.hemisphere=*(sclvec[sclid[25]].ptr)
-  prm.fit_order=*(sclvec[sclid[26]].ptr)
-  prm.latmin=*(sclvec[sclid[27]].ptr)
-  prm.chi_sqr=*(sclvec[sclid[28]].ptr)
-  prm.chi_sqr_dat=*(sclvec[sclid[29]].ptr)
-  prm.rms_err=*(sclvec[sclid[30]].ptr)
-  prm.lon_shft=*(sclvec[sclid[31]].ptr)
-  prm.lat_shft=*(sclvec[sclid[32]].ptr)
-  prm.mlt.st=*(sclvec[sclid[33]].ptr)
-  prm.mlt.ed=*(sclvec[sclid[34]].ptr)
-  prm.mlt.av=*(sclvec[sclid[35]].ptr)
-  prm.pot_drop=*(sclvec[sclid[36]].ptr)
-  prm.pot_drop_err=*(sclvec[sclid[37]].ptr)
-  prm.pot_max=*(sclvec[sclid[38]].ptr)
-  prm.pot_max_err=*(sclvec[sclid[39]].ptr)
-  prm.pot_min=*(sclvec[sclid[40]].ptr)
-  prm.pot_min_err=*(sclvec[sclid[41]].ptr)
+  prm.hemisphere=*(sclvec[sclid[29]].ptr)
+  if (sclid[30] ne -1) then prm.noigrf=*(sclvec[sclid[30]].ptr)
+  prm.fit_order=*(sclvec[sclid[31]].ptr)
+  prm.latmin=*(sclvec[sclid[32]].ptr)
+  prm.chi_sqr=*(sclvec[sclid[33]].ptr)
+  prm.chi_sqr_dat=*(sclvec[sclid[34]].ptr)
+  prm.rms_err=*(sclvec[sclid[35]].ptr)
+  prm.lon_shft=*(sclvec[sclid[36]].ptr)
+  prm.lat_shft=*(sclvec[sclid[37]].ptr)
+  prm.mlt.st=*(sclvec[sclid[38]].ptr)
+  prm.mlt.ed=*(sclvec[sclid[39]].ptr)
+  prm.mlt.av=*(sclvec[sclid[40]].ptr)
+  prm.pot_drop=*(sclvec[sclid[41]].ptr)
+  prm.pot_drop_err=*(sclvec[sclid[42]].ptr)
+  prm.pot_max=*(sclvec[sclid[43]].ptr)
+  prm.pot_max_err=*(sclvec[sclid[44]].ptr)
+  prm.pot_min=*(sclvec[sclid[45]].ptr)
+  prm.pot_min_err=*(sclvec[sclid[46]].ptr)
                 
   prm.stnum=N_ELEMENTS(*(arrvec[arrid[0]].ptr))
   stvec=replicate(stvec,prm.stnum)

--- a/codebase/superdarn/src.lib/tk/idl/cnvmapidl.1.3/include/cnvmapidl.h
+++ b/codebase/superdarn/src.lib/tk/idl/cnvmapidl.1.3/include/cnvmapidl.h
@@ -64,10 +64,14 @@ struct CnvMapIDLPrm {
   double Bx;
   double By;
   double Bz;
-  
-  IDL_STRING model[2];
+
+  double Vx;
+  double tilt;
+
+  IDL_STRING model[4];
 
   int16 hemisphere;
+  int16 noigrf;
   int16 fit_order;
   float latmin;
   int16 coefnum;

--- a/codebase/superdarn/src.lib/tk/idl/cnvmapidl.1.3/src/cnvmapidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/cnvmapidl.1.3/src/cnvmapidl.c
@@ -77,6 +77,18 @@ void IDLCopyCnvMapPrmFromIDL(struct CnvMapIDLPrm *iprm,
     strncpy(map->imf_model[1],IDL_STRING_STR(&iprm->model[1]),n);
   }
 
+  if (IDL_STRING_STR(&iprm->model[2]) !=NULL) {
+    n=strlen(IDL_STRING_STR(&iprm->model[2]));
+    if (n>64) n=64;
+    strncpy(map->imf_model[2],IDL_STRING_STR(&iprm->model[2]),n);
+  }
+
+  if (IDL_STRING_STR(&iprm->model[3]) !=NULL) {
+    n=strlen(IDL_STRING_STR(&iprm->model[3]));
+    if (n>64) n=64;
+    strncpy(map->imf_model[3],IDL_STRING_STR(&iprm->model[3]),n);
+  }
+
   
 
   map->hemisphere=iprm->hemisphere;
@@ -226,6 +238,9 @@ void IDLCopyCnvMapPrmToIDL(struct CnvMapData *map,struct GridData *grd,
   iprm->By=map->By;
   iprm->Bz=map->Bz;
 
+  iprm->Vx=map->Vx;
+  iprm->tilt=map->tilt;
+
   if (map->imf_model[0] !=NULL) {
      strncpy(tmp,map->imf_model[0],64);
      IDL_StrStore(&iprm->model[0],tmp);
@@ -235,8 +250,19 @@ void IDLCopyCnvMapPrmToIDL(struct CnvMapData *map,struct GridData *grd,
     strncpy(tmp,map->imf_model[1],64);
     IDL_StrStore(&iprm->model[1],tmp);
   }
-  
+
+  if (map->imf_model[2] !=NULL) {
+    strncpy(tmp,map->imf_model[2],64);
+    IDL_StrStore(&iprm->model[2],tmp);
+  }
+
+  if (map->imf_model[3] !=NULL) {
+    strncpy(tmp,map->imf_model[3],64);
+    IDL_StrStore(&iprm->model[3],tmp);
+  }
+
   iprm->hemisphere=map->hemisphere;
+  iprm->noigrf=map->noigrf;
   iprm->fit_order=map->fit_order;
   iprm->latmin=map->latmin;
   iprm->coefnum=map->num_coef;
@@ -304,7 +330,7 @@ struct CnvMapIDLPrm *IDLMakeCnvMapPrm(IDL_VPTR *vptr) {
   void *s=NULL;
 
 
-  static IDL_MEMINT mdim[]={1,2};
+  static IDL_MEMINT mdim[]={1,4};
 
   static IDL_STRUCT_TAG_DEF ttime[]={
     {"YR",0,(void *) IDL_TYP_INT},
@@ -324,10 +350,10 @@ struct CnvMapIDLPrm *IDLMakeCnvMapPrm(IDL_VPTR *vptr) {
 
   static IDL_STRUCT_TAG_DEF cnvmapprm[]={    
     {"STME",0,NULL},   /* 0 */
-    {"ETME",0,NULL},   /* 1 */ 
+    {"ETME",0,NULL},   /* 1 */
     {"STNUM",0,(void *) IDL_TYP_LONG}, /* 2 */
     {"VCNUM",0,(void *) IDL_TYP_LONG}, /* 3 */
-    {"XTD",0,(void *) IDL_TYP_INT}, /* 4 */ 
+    {"XTD",0,(void *) IDL_TYP_INT}, /* 4 */
     {"MAJOR_REV",0,(void *) IDL_TYP_INT}, /* 5 */
     {"MINOR_REV",0,(void *) IDL_TYP_INT}, /* 6 */
     {"SOURCE",0,(void *) IDL_TYP_STRING}, /* 7 */ 
@@ -337,27 +363,30 @@ struct CnvMapIDLPrm *IDLMakeCnvMapPrm(IDL_VPTR *vptr) {
     {"ERROR_WT",0,(void *) IDL_TYP_INT}, /* 11 */ 
     {"IMF_FLAG",0,(void *) IDL_TYP_INT}, /* 12 */
     {"IMF_DELAY",0,(void *) IDL_TYP_INT}, /* 13 */
-    {"BX",0,(void *) IDL_TYP_DOUBLE}, /* 14 */ 
+    {"BX",0,(void *) IDL_TYP_DOUBLE}, /* 14 */
     {"BY",0,(void *) IDL_TYP_DOUBLE}, /* 15 */
     {"BZ",0,(void *) IDL_TYP_DOUBLE}, /* 16 */
-    {"IMF_MODEL",mdim,(void *) IDL_TYP_STRING}, /* 17 */ 
-    {"HEMISPHERE",0,(void *) IDL_TYP_INT}, /* 18 */ 
-    {"FIT_ORDER",0,(void *) IDL_TYP_INT}, /* 19 */
-    {"LATMIN",0,(void *) IDL_TYP_FLOAT}, /* 20 */
-    {"COEFNUM",0,(void *) IDL_TYP_LONG}, /* 21 */ 
-    {"CHI_SQR",0,(void *) IDL_TYP_DOUBLE}, /* 22 */
-    {"CHI_SQR_DAT",0,(void *) IDL_TYP_DOUBLE}, /* 23 */
-    {"RMS_ERR",0,(void *) IDL_TYP_DOUBLE}, /* 24 */ 
-    {"LON_SHFT",0,(void *) IDL_TYP_FLOAT}, /* 25 */ 
-    {"LAT_SHFT",0,(void *) IDL_TYP_FLOAT}, /* 26 */ 
-    {"MLT",0, NULL}, /* 27 */ 
-    {"POT_DROP",0,(void *) IDL_TYP_DOUBLE}, /* 28 */ 
-    {"POT_DROP_ERR",0,(void *) IDL_TYP_DOUBLE}, /* 29 */ 
-    {"POT_MAX",0,(void *) IDL_TYP_DOUBLE}, /* 30 */ 
-    {"POT_MAX_ERR",0,(void *) IDL_TYP_DOUBLE}, /* 31 */ 
-    {"POT_MIN",0,(void *) IDL_TYP_DOUBLE}, /* 32 */ 
-    {"POT_MIN_ERR",0,(void *) IDL_TYP_DOUBLE}, /* 33 */ 
-    {"BNDNUM",0,(void *) IDL_TYP_LONG}, /* 34 */ 
+    {"VX",0,(void *) IDL_TYP_DOUBLE}, /* 17 */
+    {"TILT",0,(void *) IDL_TYP_DOUBLE}, /* 18 */
+    {"IMF_MODEL",mdim,(void *) IDL_TYP_STRING}, /* 19 */
+    {"HEMISPHERE",0,(void *) IDL_TYP_INT}, /* 20 */
+    {"NOIGRF",0,(void *) IDL_TYP_INT}, /* 21 */
+    {"FIT_ORDER",0,(void *) IDL_TYP_INT}, /* 22 */
+    {"LATMIN",0,(void *) IDL_TYP_FLOAT}, /* 23 */
+    {"COEFNUM",0,(void *) IDL_TYP_LONG}, /* 24 */
+    {"CHI_SQR",0,(void *) IDL_TYP_DOUBLE}, /* 25 */
+    {"CHI_SQR_DAT",0,(void *) IDL_TYP_DOUBLE}, /* 26 */
+    {"RMS_ERR",0,(void *) IDL_TYP_DOUBLE}, /* 27 */
+    {"LON_SHFT",0,(void *) IDL_TYP_FLOAT}, /* 28 */
+    {"LAT_SHFT",0,(void *) IDL_TYP_FLOAT}, /* 29 */
+    {"MLT",0, NULL}, /* 30 */
+    {"POT_DROP",0,(void *) IDL_TYP_DOUBLE}, /* 31 */
+    {"POT_DROP_ERR",0,(void *) IDL_TYP_DOUBLE}, /* 32 */
+    {"POT_MAX",0,(void *) IDL_TYP_DOUBLE}, /* 33 */
+    {"POT_MAX_ERR",0,(void *) IDL_TYP_DOUBLE}, /* 34 */
+    {"POT_MIN",0,(void *) IDL_TYP_DOUBLE}, /* 35 */
+    {"POT_MIN_ERR",0,(void *) IDL_TYP_DOUBLE}, /* 36 */
+    {"BNDNUM",0,(void *) IDL_TYP_LONG}, /* 37 */
     
     {0}};
 
@@ -365,7 +394,7 @@ struct CnvMapIDLPrm *IDLMakeCnvMapPrm(IDL_VPTR *vptr) {
  
   cnvmapprm[0].type=IDL_MakeStruct("CNVMAPTIME",ttime);
   cnvmapprm[1].type=IDL_MakeStruct("CNVMAPTIME",ttime);
-  cnvmapprm[27].type=IDL_MakeStruct("CNVMAPMLT",tmlt);
+  cnvmapprm[30].type=IDL_MakeStruct("CNVMAPMLT",tmlt);
 
   s=IDL_MakeStruct("CNVMAPPRM",cnvmapprm);
            


### PR DESCRIPTION
This pull request adds compatibility to the native IDL and C-based DLM routines for handling the new cnvmap format files (which have new data fields such as Vx and tilt) while also maintaining backwards compatibility with the older format files (ie those without Vx and tilt).  @sshepherd already did this for the C code but not the IDL/DLMs.

I think we should hold off on merging the release branch today so that we can include this compatibility fix and ensure consistency across both IDL and C when handling the newer map_potential_v2 type files.