### PR TITLE
Adding Travis CI for building/testing functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: C
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get -y install wget
+  - sudo apt-get -y install make
+  - sudo apt-get -y install vim
+  - sudo apt-get -y install git
+  - sudo apt-get -y install libx11-dev
+  - sudo apt-get -y install libxext-dev
+  - sudo apt-get -y install libhdf5-serial-dev
+  - sudo apt-get -y install libnetcdf-dev
+  - sudo apt-get -y install libncurses-dev
+  - sudo apt-get -y install netpbm
+  - sudo apt-get -y install libpng12-dev
+  - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf36_3_1/linux/cdf36_3_1-dist-all.tar.gz
+  - tar -xf cdf36_3_1-dist-all.tar.gz
+  - cd cdf36_3-dist && make clean && make OS=linux ENV=gnu all && make INSTALLDIR=/home/travis/build/superdarn/cdf install
+  - export RSTPATH=/home/travis/build/superdarn/rst
+  - . $RSTPATH/.profile.bash
+  - export CDF_PATH=/home/travis/build/superdarn/cdf
+install:
+  - make.build
+script:
+  - make.code
+after_script:
+  - make.doc
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ before_install:
   - sudo apt-get -y install libpng12-dev
   - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf36_3_1/linux/cdf36_3_1-dist-all.tar.gz
   - tar -xf cdf36_3_1-dist-all.tar.gz
-  - cd cdf36_3-dist && make clean && make OS=linux ENV=gnu all && make INSTALLDIR=/home/travis/build/superdarn/cdf install
-  - export RSTPATH=/home/travis/build/superdarn/rst
+  - cd cdf36_3-dist && make clean && make OS=linux ENV=gnu all && make INSTALLDIR=/home/travis/build/SuperDARN/cdf install
+  - export RSTPATH=/home/travis/build/SuperDARN/rst
   - . $RSTPATH/.profile.bash
-  - export CDF_PATH=/home/travis/build/superdarn/cdf
+  - export CDF_PATH=/home/travis/build/SuperDARN/cdf
 install:
   - make.build
 script:


### PR DESCRIPTION
This pull request adds a `.travis.yml` file which allows Travis CI to automatically build the github-based RST project in a virtual environment and identify any compilation errors which arise from the `make.build`, `make.code`, or `make.doc` commands.  By merging this functionality into the `4.1/release` branch all future branches based on the `master` and `develop` branches will also be able to take advantage of this automatic testing functionality.  For the moment, the `.travis.yml` file will only perform the build in an Ubuntu / gcc environment, however in the future we could expand that to include other Linux distributions and/or MacOS to ensure multi-platform compatibility.