### PR TITLE
Fixing error check in gridtogrdmap and maptocnvmap

### DIFF
--- a/codebase/superdarn/src.bin/tk/reformat/gridtogrdmap.1.7/gridtogrdmap.c
+++ b/codebase/superdarn/src.bin/tk/reformat/gridtogrdmap.1.7/gridtogrdmap.c
@@ -100,7 +100,7 @@ int main (int argc,char *argv[]) {
               yr,mo,dy,hr,mt,(int) sc,grd->vcnum);
     }
     s=GridFwrite(stdout,grd);
-    if (s !=0) {
+    if (s <=0) {
         fprintf(stderr,"GridFwrite failed.\n");
         if (fp !=stdin) fclose(fp);
         exit(-1);

--- a/codebase/superdarn/src.bin/tk/reformat/maptocnvmap.1.6/maptocnvmap.c
+++ b/codebase/superdarn/src.bin/tk/reformat/maptocnvmap.1.6/maptocnvmap.c
@@ -104,7 +104,7 @@ int main (int argc,char *argv[]) {
               yr,mo,dy,hr,mt,(int) sc);
     }
     s=CnvMapFwrite(stdout,map,grd);
-    if (s !=0) {
+    if (s <=0) {
         fprintf(stderr,"CnvMapFwrite failed.\n");
         if (fp !=stdin) fclose(fp);
         exit(-1);


### PR DESCRIPTION
This commit fixes a bug in the way `gridtogrdmap` and `maptocnvmap` check for errors which was added in the warning_cleanup branch prior to the 4.1 software release. The error check added to the end of these binaries looks for a non-zero return value from GridFwrite and CnvmapFwrite respectively, when it should actually check for values less than or equal to zero. The check for non-zero return values was only appropriate for the OldGridFwrite and OldCnvMapFwrite functions in `grdmaptogrid` and `cnvmaptomap` respectively. This commit makes the necessary changes so that `gridtogrdmap` and `maptocnvmap` do not always return a "GridFwrite/CnvmapFwrite failed." error message.

As they stand, `gridtogrdmap` and `maptocnvmap` are currently unusable.  Whether this warrants a fix directly to the master branch is left to the working group.