### PR TITLE
Changing DLM version of RadarLoadHardware to return 0 on success to match native IDL function

### DIFF
--- a/codebase/superdarn/src.dlm/rposdlm.1.9/rposdlm.c
+++ b/codebase/superdarn/src.dlm/rposdlm.1.9/rposdlm.c
@@ -400,7 +400,7 @@ static IDL_VPTR IDLRadarLoadHardware(int argc,IDL_VPTR *argv,char *argk) {
 
   IDL_KWCleanup(IDL_KW_CLEAN);
 
-  return (IDL_GettmpLong(s));
+  return (IDL_GettmpLong(0));
 
 }
 

--- a/codebase/superdarn/src.idl/app/make_grid.1.0/make_grid.pro
+++ b/codebase/superdarn/src.idl/app/make_grid.1.0/make_grid.pro
@@ -460,7 +460,7 @@ endif
 
 ; Load the hardware information for the radar network
 s = RadarLoadHardware(network, path=envstr)
-if s lt 1 then begin
+if s ne 0 then begin
     print, 'Could not load hardware information.'
     return
 endif

--- a/codebase/superdarn/src.idl/lib/legacy.1.6/rbposlib.pro
+++ b/codebase/superdarn/src.idl/lib/legacy.1.6/rbposlib.pro
@@ -104,8 +104,7 @@ function rbpos,range,height=height,beam=beam,lagfr=first_lag,smsep=smsp, $
       stop
     endif
     s=RadarLoadHardware(network,path=getenv('SD_HDWPATH'))
-;    if (s ne 0) then begin
-    if (s le 0) then begin          ; SGS for DLM
+    if (s ne 0) then begin
       print, 'Could not load hardware information'
       stop
     endif


### PR DESCRIPTION
This pull request addresses issue #34 originally raised last year by @ksterne.  The DLM and IDL versions of RadarLoadHardware now both return zero on success.  The relevant error checks in the IDL rbpos and make_grid routines have been corrected to reflect this change.