### PR TITLE
Cleaning up documentation and command line help for routines affected by old/new flag switch

### DIFF
--- a/codebase/superdarn/src.bin/tk/reformat/maptoefield.1.8/doc/maptoefield.doc.xml
+++ b/codebase/superdarn/src.bin/tk/reformat/maptoefield.1.8/doc/maptoefield.doc.xml
@@ -3,8 +3,10 @@
 <project>superdarn</project>
 <name>maptoefield</name>
 <location>src.bin/tk/reformat/maptoefield</location>
+
 <syntax>maptoefield --help</syntax>
-<syntax>maptoefield [-vb] [-old] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>] [-s <ar>step</ar>] [-l <ar>latmin</ar> [-mlt] [-p] [-v] <ar>name</ar></syntax>
+<syntax>maptoefield [-vb] [-old] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>] [-s <ar>step</ar>] [-l <ar>latmin</ar> [-mlt] [-p] [-v] [<ar>name</ar>]</syntax>
+
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
 <option><on>-vb</on><od>verbose. Log information to the console.</od>
@@ -33,7 +35,7 @@
 </option>
 <option><on>-v</on><od>include the derived velocity int the output.</od>
 </option>
-<option><on><ar>name</ar></on><od>filename of the convection map file to process. If this is omitted, the file is read from standard input.</od>
+<option><on><ar>name</ar></on><od>filename of the <code>cnvmap</code> format file to process. If this is omitted, the file is read from standard input.</od>
 </option>
 <synopsis><p>Calculate the electric field and other parameters from convection map data.</p></synopsis>
 
@@ -52,9 +54,5 @@
 <command>maptoefield -p 20040830.cnvmap &gt; 20040830.efield</command>
 <description>Calculate the electric field and potential from the file "<code>20040830.cnvmapmap</code>". The electric field data is stored in the file "<code>20040830.efield</code>".</description>
 </example>
-
-
-
-
 
 </binary>

--- a/codebase/superdarn/src.bin/tk/testing/test_fit.1.17/doc/test_fit.doc.xml
+++ b/codebase/superdarn/src.bin/tk/testing/test_fit.1.17/doc/test_fit.doc.xml
@@ -5,16 +5,16 @@
 <location>src.bin/tk/testing/test_fit</location>
 
 <syntax>test_fit --help</syntax>
-<syntax>test_fit <ar>fitacfnames...</ar></syntax>
-<syntax>test_fit -old [<ar>fitname</ar>]</syntax>
+<syntax>test_fit [<ar>fitacfnames...</ar>]</syntax>
+<syntax>test_fit -old <ar>fitname</ar></syntax>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
-<option><on><ar>fitacfnames</ar></on><od>filenames of the <code>fitacf</code> format files.</od>
+<option><on><ar>fitacfnames</ar></on><od>filenames of the <code>fitacf</code> format files. If this is omitted the file is read from standard input.</od>
 </option>
 <option><on>-old</on><od>files are in the <code>fit</code> format.</od>
 </option>
-<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> format file. If this is omitted the file is read from standard input.</od>
+<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> format file.</od>
 </option>
 <synopsis><p>Tests the integrity of <code>fit</code> or <code>fitacf</code> format files by reading them and printing the contents.</p></synopsis>
 <description><p>Tests the integrity of <code>fit</code> or <code>fitacf</code> format files by reading them and printing the contents.</p>

--- a/codebase/superdarn/src.bin/tk/testing/test_raw.1.12/doc/test_raw.doc.xml
+++ b/codebase/superdarn/src.bin/tk/testing/test_raw.1.12/doc/test_raw.doc.xml
@@ -5,16 +5,16 @@
 <location>src.bin/tk/testing/test_raw</location>
 
 <syntax>test_raw --help</syntax>
-<syntax>test_raw <ar>rawacfnames...</ar></syntax>
-<syntax>test_raw -old [<ar>rawname</ar>]</syntax>
+<syntax>test_raw [<ar>rawacfnames...]</ar></syntax>
+<syntax>test_raw -old <ar>rawname</ar></syntax>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
-<option><on><ar>rawacfnames</ar></on><od>filenames of the <code>rawacf</code> format files.</od>
+<option><on><ar>rawacfnames</ar></on><od>filenames of the <code>rawacf</code> format files. If this is omitted the file is read from standard input.</od>
 </option>
 <option><on>-old</on><od>files are in the <code>raw</code> (<code>dat</code> format.</od>
 </option>
-<option><on><ar>rawname</ar></on><od>filename of the <code>raw</code> (<code>dat</code>) format file. If this is omitted the file is read from standard input.</od>
+<option><on><ar>rawname</ar></on><od>filename of the <code>raw</code> (<code>dat</code>) format file.</od>
 </option>
 <synopsis><p>Tests the integrity of <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format files by reading them and printing the contents.</p></synopsis>
 <description><p>Tests the integrity of <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format files by reading them and printing the contents.</p>

--- a/codebase/superdarn/src.bin/tk/tool/extract_map.1.13/doc/extract_map.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/extract_map.1.13/doc/extract_map.doc.xml
@@ -3,29 +3,31 @@
 <project>superdarn</project>
 <name>extract_map</name>
 <location>src.bin/tk/tool/extract_map</location>
+
 <syntax>extract_map --help</syntax>
 <syntax>extract_map [-old] [-mid] [<ar>name</ar>]</syntax>
 <syntax>extract_map -p [-old] [-mid] [<ar>name</ar>]</syntax>
 <syntax>extract_map -s [-old] [-mid] [<ar>name</ar>]</syntax>
 <syntax>extract_map -l [-old] [-mid] [<ar>name</ar>]</syntax>
+
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
 <option><on>-old</on><od>the input file is a <code>map</code> format file.</od>
 </option>
 <option><on>-mid</on><od>record the time in the middle of the map data, not the start and end times.</od>
 </option>
-<option><on><ar>name</ar></on><od>filename of the <code>map</code> format file. If this is omitted, the file will be read from standard input.</od>
+<option><on><ar>name</ar></on><od>filename of the <code>cnvmap</code> format file. If this is omitted, the file will be read from standard input.</od>
 </option>
-<option><on>-p</on><od>extract the cross polar cap potential, the IMF, the statistical model, and the scatter and error statistics.</od></option>
-<option><on>-s</on><od>extract the scatter statistics.</od></option>
-<option><on>-l</on><od>extract the lower latitude boundary.</od></option>
+<option><on>-p</on><od>extract the cross polar cap potential, the IMF, the statistical model, and the scatter and error statistics.</od>
+</option>
+<option><on>-s</on><od>extract the scatter statistics.</od>
+</option>
+<option><on>-l</on><od>extract the lower latitude boundary.</od>
+</option>
+
 <synopsis><p>Extract statistics or the original grid file from a convection map data file.</p></synopsis>
-
-
 <description><p>Extract statistics or the original grid file from a convection map data file.</p>
 <p>The extracted statistics are written to standard output.</p></description>
-
-
 
 <example>
 <command>extract_map -s -old 19981020.map</command>
@@ -36,6 +38,5 @@
 <command>extract_map -s -mid 19991120.cnvmap &gt; 19991120.sct</command>
 <description>Extract the scatter statistics from the <code>cnvmap</code> file "<code>19991120.cnvmap</code>" to produce the output file "<code>19991120.sct</code>". The middle time of each record is recorded in the file.</description>
 </example>
-
 
 </binary>

--- a/codebase/superdarn/src.bin/tk/tool/fit_cp.1.13/doc/fit_cp.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/fit_cp.1.13/doc/fit_cp.doc.xml
@@ -5,19 +5,19 @@
 <location>src.bin/tk/tool/fit_cp</location>
 
 <syntax>fit_cp --help</syntax>
-<syntax>fit_cp <ar>fitacfnames...</ar></syntax>
-<syntax>fit_cp -old [<ar>fitname</ar>]</syntax>
+<syntax>fit_cp [<ar>fitacfnames...]</ar></syntax>
+<syntax>fit_cp -old <ar>fitname</ar></syntax>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
-<option><on><ar>fitacfnames</ar></on><od>filenames of the <code>fitacf</code> format files.</od>
+<option><on><ar>fitacfnames</ar></on><od>filenames of the <code>fitacf</code> format files. If this is omitted the file is read from standard input.</od>
 </option>
 <option><on>-old</on><od>files are in the <code>fit</code> format.</od>
 </option>
-<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> format file. If this is omitted the file is read from standard input.</od>
+<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> format file.</od>
 </option>
-<synopsis><p>Determines the program identifier numbers in <code>fit</code> or <code>fitacf</code> format files.</p></synopsis>
-<description><p>Determines the program identifier numbers in <code>fit</code> or <code>fitacf</code> format files.</p>
+<synopsis><p>Determines the program identifier numbers in <code>fitacf</code> or <code>fit</code> format files.</p></synopsis>
+<description><p>Determines the program identifier numbers in <code>fitacf</code> or <code>fit</code> format files.</p>
 <p>The total number of program identifiers followed by a list of the identifier numbers is written to standard output.</p></description>
 
 <example>

--- a/codebase/superdarn/src.bin/tk/tool/make_efieldinx.1.6/doc/make_efieldinx.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_efieldinx.1.6/doc/make_efieldinx.doc.xml
@@ -13,8 +13,6 @@
 
 <synopsis><p>Creates an index of a electric field data.</p></synopsis>
 
-
-
 <description><p>Creates an index of eletric field data.</p>
 <p>The index is written to standard output.</p>
 </description>
@@ -23,6 +21,5 @@
 <command>make_efieldinx 20040830.efield &gt; 20040830.efieldinx</command>
 <description>Create an index file for the electric field data file "<code>20040830.efield</code>". The index is writen to the file "<code>20040830.efieldinx</code>".</description>
 </example>
-
 
 </binary>

--- a/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/doc/make_fit.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/doc/make_fit.doc.xml
@@ -5,27 +5,26 @@
 <location>src.bin/tk/tool/make_fit</location>
 
 <syntax>make_fit --help</syntax>
-<syntax>make_fit -fitacf-version [<ar>version number</ar>]</syntax>
-<syntax>make_fit <ar>rawname</ar> <ar>fitname</ar> [<ar>inxname</ar>]</syntax>
-<syntax>make_fit -old [<ar>rawname</ar>]</syntax>
+<syntax>make_fit [<ar>rawacfname</ar>]</syntax>
+<syntax>make_fit [-fitacf-version <ar>version_number</ar>] [<ar>rawacfname</ar>]</syntax>
+<syntax>make_fit -old <ar>rawname</ar> <ar>fitname</ar> [<ar>inxname</ar>]</syntax>
+<syntax>make_fit -old [-fitacf-version <ar>version_number</ar>] <ar>rawname</ar> <ar>fitname</ar> [<ar>inxname</ar>]</syntax>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
+<option><on><ar>rawacfname</ar></on><od>filename of the <code>rawacf</code> format file. If this is omitted the file is read from standard input.</od>
+</option>
 <option><on>-fitacf-version</on><od>Select fitacf version.</od>
 </option>
-<option><on>--h</on><od>print the help message and exit.</od>
-</option>
-<option><on><ar>rawacfname</ar></on><od>filename of the <code>rawacf</code> format file.</od>
-</option>
-<option><on><ar>fitacfname</ar></on><od>filename of the <code>fitacf</code> format file to create.</od>
-</option>
-<option><on>[<ar>inxname</ar>]</on><od>filename of the associated index file to create.</od>
-</option>
-<option><on>[<ar>version number</ar>]</on><od>Valid choices are 3.0 or 2.5.</od>
+<option><on><ar>version_number</ar></on><od>Valid choices are 3.0 or 2.5.</od>
 </option>
 <option><on>-old</on><od>input file is in <code>raw</code> (<code>dat</code>) file format and the output should be in <code>fit</code> file format.</od>
 </option>
-<option><on><ar>rawname</ar></on><od>filename of the <code>raw</code> (<code>dat</code>) format file. If this is omitted the file is read from standard input.</od>
+<option><on><ar>rawname</ar></on><od>filename of the <code>raw</code> (<code>dat</code>) format file.</od>
+</option>
+<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> format file to create.</od>
+</option>
+<option><on>[<ar>inxname</ar>]</on><od>filename of the associated index file to create.</od>
 </option>
 <synopsis><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p></synopsis>
 <description><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p>
@@ -33,13 +32,13 @@
 </description>
 
 <example>
-<command>make_fit -old 19971020.gbr.dat 19971020gbr.fit 19971020.gbr.inx</command>
-<description>Generates a <code>fit</code> file from the <code>dat</code> file "<code>19971020.gbr.dat</code>" to produce a file called "<code>19971020.gbr.fit</code>" and an index file called "<code>19971020.gbr.inx</code>".</description>
+<command>make_fit -vb 19981105.kap.rawacf &gt; 19981105.kap.fitacf</command>
+<description>Generates a fitacf file from the <code>rawacf</code> file "<code>19981105.kap.rawacf</code>" to produce a file called "<code>19981105.kap.fitacf</code>". Status is logged on standard error.</description>
 </example>
 
 <example>
-<command>make_fit -vb 19981105.kap.rawacf &gt; 19981105.kap.fitacf</command>
-<description>Generates a fitacf file from the <code>rawacf</code> file "<code>19981105.kap.rawacf</code>" to produce a file called "<code>19981105.kap.fitacf</code>". Status is logged on standard error.</description>
+<command>make_fit -old 19971020.gbr.dat 19971020gbr.fit 19971020.gbr.inx</command>
+<description>Generates a <code>fit</code> file from the <code>dat</code> file "<code>19971020.gbr.dat</code>" to produce a file called "<code>19971020.gbr.fit</code>" and an index file called "<code>19971020.gbr.inx</code>".</description>
 </example>
 
 </binary>

--- a/codebase/superdarn/src.bin/tk/tool/make_fitinx.1.9/doc/make_fitinx.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_fitinx.1.9/doc/make_fitinx.doc.xml
@@ -5,20 +5,20 @@
 <location>src.bin/tk/tool/make_fitinx</location>
 
 <syntax>make_fitinx --help</syntax>
-<syntax>make_fitinx [-vb] <ar>fitacfname</ar> <ar>inxname</ar></syntax>
-<syntax>make_fitinx -old [-vb] [<ar>fitname</ar>]</syntax>
+<syntax>make_fitinx [-vb] [<ar>fitacfname</ar>]</syntax>
+<syntax>make_fitinx -old [-vb] <ar>fitname</ar> <ar>inxname</ar></syntax>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
 <option><on>-vb</on><od>verbose. Log information to the console.</od>
 </option>
-<option><on><ar>fitacfname</ar></on><od>filename of the <code>fitacf</code> format file.</od>
-</option>
-<option><on><ar>inxname</ar></on><od>filename of the index file to create.</od>
+<option><on><ar>fitacfname</ar></on><od>filename of the <code>fitacf</code> format file. If this is omitted the file is read from standard input.</od>
 </option>
 <option><on>-old</on><od>files are in the <code>fit</code> format.</od>
 </option>
-<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> format file. If this is omitted the file is read from standard input.</od>
+<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> format file.</od>
+</option>
+<option><on><ar>inxname</ar></on><od>filename of the index file to create.</od>
 </option>
 <synopsis><p>Creates an index of a <code>fitacf</code> format file.</p></synopsis>
 <description><p>Creates an index of a <code>fitacf</code> format file.</p>
@@ -26,13 +26,13 @@
 </description>
 
 <example>
-<command>make_fitinx -old 20040830.gbr.fit 20040830.gbr.inx</command>
-<description>Create an index file for the <code>fit</code> format file "<code>20040830.gbr.fit</code>". The index is writen to the file "<code>20040830.gbr.inx</code>".</description>
+<command>make_fitinx 20040830.gbr.fitacf &gt; 20040830.gbr.fitinx</command>
+<description>Create an index file for the <code>fitacf</code> format file "<code>20040830.gbr.fitacf</code>". The index is writen to the file "<code>20040830.gbr.fitinx</code>".</description>
 </example>
 
 <example>
-<command>make_fitinx 20040830.gbr.fitacf &gt; 20040830.gbr.fitinx</command>
-<description>Create an index file for the <code>fitacf</code> format file "<code>20040830.gbr.fitacf</code>". The index is writen to the file "<code>20040830.gbr.fitinx</code>".</description>
+<command>make_fitinx -old 20040830.gbr.fit 20040830.gbr.inx</command>
+<description>Create an index file for the <code>fit</code> format file "<code>20040830.gbr.fit</code>". The index is writen to the file "<code>20040830.gbr.inx</code>".</description>
 </example>
 
 </binary>

--- a/codebase/superdarn/src.bin/tk/tool/make_info.1.13/doc/make_info.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_info.1.13/doc/make_info.doc.xml
@@ -5,17 +5,17 @@
 <location>src.bin/tk/tool/make_info</location>
 
 <syntax>make_info --help</syntax>
-<syntax>make_info <ar>fitacfnames...</ar></syntax>
-<syntax>make_info -old [<ar>fitname</ar>]</syntax>
+<syntax>make_info [<ar>fitacfnames...]</ar></syntax>
+<syntax>make_info -old <ar>fitname</ar></syntax>
 <syntax>make_info -cfit <ar>cfitnames...</ar></syntax>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
-<option><on><ar>fitacfnames</ar></on><od>filenames of the <code>fitacf</code> format files.</od>
+<option><on><ar>fitacfnames</ar></on><od>filenames of the <code>fitacf</code> format files. If this is omitted the file is read from standard input.</od>
 </option>
 <option><on>-old</on><od>files are in the <code>fit</code> format.</od>
 </option>
-<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> format file. If this is omitted the file is read from standard input.</od>
+<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> format file.</od>
 </option>
 <option><on>-cfit</on><od>files are in the <code>cfit</code> format.</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/tool/make_rawinx.1.7/doc/make_rawinx.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_rawinx.1.7/doc/make_rawinx.doc.xml
@@ -5,15 +5,13 @@
 <location>src.bin/tk/tool/make_rawinx</location>
 
 <syntax>make_rawinx --help</syntax>
-<syntax>make_rawinx -old [-vb] [<ar>rawname</ar>]</syntax>
+<syntax>make_rawinx [-vb] [<ar>rawacfname</ar>]</syntax>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
 <option><on>-vb</on><od>verbose. Log information to the console.</od>
 </option>
-<option><on>-old</on><od>files are in the <code>fit</code> format.</od>
-</option>
-<option><on><ar>rawname</ar></on><od>filename of the <code>raw</code> format file. If this is omitted the file is read from standard input.</od>
+<option><on><ar>rawacfname</ar></on><od>filename of the <code>rawacf</code> format file. If this is omitted the file is read from standard input.</od>
 </option>
 <synopsis><p>Creates an index of a <code>rawacf</code> format file.</p></synopsis>
 <description><p>Creates an index of a <code>rawacf</code> format file.</p>

--- a/codebase/superdarn/src.bin/tk/tool/map_addhmb.1.17/doc/map_addhmb.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_addhmb.1.17/doc/map_addhmb.doc.xml
@@ -16,7 +16,8 @@
 </option>
 <option><on>-vb</on><od>verbose. Log information to the console.</od>
 </option>
-<option><on>-old</on><od>the input file is a <code>map</code> format file.</od></option>
+<option><on>-old</on><od>the input file is a <code>map</code> format file.</od>
+</option>
 <option><on>-old_aacgm</on><od>uses the older AACGM software and coefficients. The default</od></option>
 <option><on></on><od>  is to use AACGM-v2.</od></option>
 <option><on>-cnt <ar>count</ar></on><od>set the number of scatter points to get a match to be <ar>count</ar>.</od>
@@ -25,7 +26,7 @@
 </option>
 <option><on>-ex <ar>exlist</ar></on><od>exclude data from the stations listed in <ar>exlist</ar>, which is a</od></option>
 <option><on></on><od>  comma separated list of radar station numbers.</od></option>
-<option><on><ar>mapname</ar></on><od>filename of the <code>map</code> format file. If this is omitted, the file will</od></option>
+<option><on><ar>mapname</ar></on><od>filename of the <code>cnvmap</code> format file. If this is omitted, the file will</od></option>
 <option><on></on><od>  be read from standard input.</od></option>
 <option><on>-t</on><od>instead of adding the calculated boundary to the map file,</od></option>
 <option><on></on><od>  write the record time and the calculated location as ASCII text to standard</od></option>
@@ -37,8 +38,7 @@
 <option><on>-nodef</on><od>do not use the default latmin if no data is available (ie use latmin from the statistical model).</od>
 </option>
 
-<synopsis><p>Calculates the position of the Heppner Maynard Boundary and adds it to a <code>map</code> format file.</p></synopsis>
-
+<synopsis><p>Calculates the position of the Heppner Maynard Boundary and adds it to a <code>cnvmap</code> format file.</p></synopsis>
 
 <description><p>Adds a Heppner-Maynard boundary to a convection map file, or generates a data file containing the latitudes of the boundary at magnetic local midnight for each record in the file.</p>
 <p>The file is written to standard output.</p>
@@ -54,27 +54,23 @@
 </description>
 
 <example>
-<command>map_addhmb -vb 19980410.map &gt; 19980410.hmb.map</command>
+<command>map_addhmb -vb -old 19980410.map &gt; 19980410.hmb.map</command>
 <description>Locate the Heppner-Maynard boundary for the map file "<code>19980410.map</code>". The output is written to the file "<code>19980410.hmb.map</code>" and status is logged to standard error.</description>
 </example>
+
 <example>
-<command>map_addhmb -lat 64 19970415.map &gt; 19970415.hmb.map</command>
+<command>map_addhmb -old -lat 64 19970415.map &gt; 19970415.hmb.map</command>
 <description>Add vectors to the map file "<code>19970415.map</code>" for a Heppner-Maynard boundary that crosses 64 degrees at magnetic local midnight. The output is written to the file "<code>19970415.hmb.map</code>".</description>
 </example>
 
 <example>
-<command>map_addhmb -lf lat.dat 19990830.map &gt; 19980830.hmb.map</command>
+<command>map_addhmb -old -lf lat.dat 19990830.map &gt; 19980830.hmb.map</command>
 <description>Add vectors to the map file "<code>19990830.map</code>" taking latitudes for the Heppner-Maynard boundary from the file "<code>lat.dat</code>". The output is written to the file "<code>19990830.map</code>"</description>
 </example>
 
 <example>
-<command>map_addhmb -t -vel 150 -cnt 4 20000410.map &gt; lat.dat</command>
+<command>map_addhmb -old -t -vel 150 -cnt 4 20000410.map &gt; lat.dat</command>
 <description>Generate a list of latitudes from the map file "<code>20000410.map</code>". Set the minimum velocity magnitude to 150 m/s and the minimum number of points to 4. The output is written to "<code>lat.dat</code>".</description>
 </example>
-
-
-
-
-
 
 </binary>

--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
@@ -3,6 +3,7 @@
 <project>superdarn</project>
 <name>map_addimf</name>
 <location>src.bin/tk/tool/map_addimf</location>
+
 <syntax></syntax>
 <syntax>map_addimf --help</syntax>
 <syntax>map_addimf [-vb] [-old] [-ace|-wind|-omni] [-p <ar>path</ar>] [-d <ar>hr:mn</ar>] [-ex hr:mn]</syntax>
@@ -14,6 +15,7 @@
 <syntax>map_addimf [-vb] [-old] [-bx <ar>bx</ar>] [-by <ar>by</ar>] [-bz <ar>bz</ar>] [-vx <ar>vx</ar>] [-tilt <ar>tilt</ar>]</syntax>
 <syntax>           [<ar>mapname</ar>]</syntax>
 <syntax></syntax>
+
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
 <option><on>-vb</on><od>verbose. Log information to the console.</od>
@@ -31,7 +33,7 @@
 </option>
 <option><on>-ex <ar>hr:mn</ar></on><od>read <ar>hr</ar> hours and <ar>mn</ar> minutes of IMF data. By default, 24 hours</od></option>
 <option><on></on><od>  of data is read.</od></option>
-<option><on><ar>mapname</ar></on><od>filename of the <code>map</code> format file. If this is omitted, the file will</od></option>
+<option><on><ar>mapname</ar></on><od>filename of the <code>cnvmap</code> format file. If this is omitted, the file will</od></option>
 <option><on></on><od>  be read from standard input.</od></option>
 <option><on>-df <ar>delayname</ar></on><od>read the delay times from the ASCII text file <ar>delayname</ar>.</od>
 </option>
@@ -49,7 +51,6 @@
 </option>
 <synopsis><p>Adds IMF and solar wind data to a convection map file.</p></synopsis>
 
-
 <description><p>Adds IMF and solar wind data to a convection map file.</p>
 <p>The IMF applied to the map file can be fixed, taken from the ACE or Wind spacecraft, or read from a plain text file. The processed file is written to standard output.</p>
 <p>If the "<code>-ace</code>" or "<code>-wind</code>" options are specified, the IMF data is taken from the appropriate CDF files for each spacecraft. The files are read from the "ace" and "wind" sub-directories of the path given by given by the "-path" option or by the environment variable "<code>ISTP_PATH</code>".  The argument "<code>-ex</code>" is used to specify how much IMF data should be loaded. By default only 24 hours of data is read.</p>
@@ -65,22 +66,23 @@
 <p>The IMF will be fixed at this value and will only change if a subsequent entry the IMF file alters it.</p>
 </description>
 
-
 <example>
-<command>map_addimf -vb -bx 1.5 -by -1.2 -bx 0.4 19970406.map &gt; 19970406.imf.map</command>
+<command>map_addimf -vb -old -bx 1.5 -by -1.2 -bx 0.4 19970406.map &gt; 19970406.imf.map</command>
 <description>Adds a fixed IMF of Bx=-15, By=-1.2 and Bz=0.4 to the map file "<coode>19970406.map</code>". The output is stored in the file "<code>19970406.imf.map</code>" and status is logged to standard error.</description>
 </example>
-<example>
-<command>map_addimf -ace -d 0:30 -ex 48:00 19981104.map &gt; 19981104.imf.map</command>
 
+<example>
+<command>map_addimf -old -ace -d 0:30 -ex 48:00 19981104.map &gt; 19981104.imf.map</command>
 <description>Adds IMF data from the ACE spacecraft to the map file "<code>19981104.map</code>". A delay of 30 minutes is applied to the data and the map file is expected to be 48 hours in length. The output is stored in the file "<code>19981104.imf.map</code>".</description>
 </example>
+
 <example>
-<command>map_addimf -ace -df delay.txt  19990712.map &gt; 19990712.imf.map</command>
+<command>map_addimf -old -ace -df delay.txt 19990712.map &gt; 19990712.imf.map</command>
 <description>Adds IMF data from the ACE spacecraft to the map file "<code>19990712.map</code>". The IMF delays are read from the file "<code>delay.txt</code>". The output is stored in the file "<code>19990712.imf.map</code>".</description>
 </example>
+
 <example>
-<command>map_addimf -if imf.txt -df delay.txt 2000312.map &gt; 20000312.map</command>
+<command>map_addimf -old -if imf.txt -df delay.txt 2000312.map &gt; 20000312.map</command>
 <description>Adds IMF data from the text file "<code>imf.txt</code>" to the map file "<code>2000312.map</code>". The IMF delays are taken from the file "<code>delay.txt</code>". The output is stored in the file "<code>19990712.imf.map</code>".</description>
 </example>
 

--- a/codebase/superdarn/src.bin/tk/tool/map_addmodel.1.14/doc/map_addmodel.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_addmodel.1.14/doc/map_addmodel.doc.xml
@@ -3,30 +3,38 @@
 <project>superdarn</project>
 <name>map_addmodel</name>
 <location>src.bin/tk/tool/map_addmodel</location>
+
 <syntax></syntax>
 <syntax>map_addmodel --help</syntax>
 <syntax>map_addmodel [-vb] [-old] [-nointerp] [-noigrf] [-cs10|-rg96|-psr10|-ts18]</syntax>
 <syntax>             [-o <ar>order</ar>] [-d <ar>doping</ar>] [<ar>mapname</ar>]</syntax>
 <syntax></syntax>
+
 <option><on>--help</on><od>print the help message and exits.</od>
 </option>
 <option><on>-vb</on><od>verbose. Log information to the console.</od>
 </option>
-<option><on>-old</on><od>the input file is a <code>map</code> format file.</od></option>
+<option><on>-old</on><od>the input file is a <code>map</code> format file.</od>
+</option>
 <option><on>-old_aacgm</on><od>uses the older AACGM software and coefficients. The default</od></option>
 <option><on></on><od>  is to use AACGM-v2.</od></option>
-<option><on>-cs10</on><od>uses the CS10 statistical model [default].</od></option>
-<option><on>-rg96</on><od>uses the RG96 statistical model.</od></option>
-<option><on>-psr10</on><od>uses the PSR10 statistical model (equivalent to the RG05 model.)</od></option>
-<option><on>-ts18</on><od>uses the TS18 statistical model.</od></option>
-<option><on>-nointerp</on><od>Do not interpolate coeffiecients, instead use discrete models.</od></option>
+<option><on>-cs10</on><od>uses the CS10 statistical model [default].</od>
+</option>
+<option><on>-rg96</on><od>uses the RG96 statistical model.</od>
+</option>
+<option><on>-psr10</on><od>uses the PSR10 statistical model (equivalent to the RG05 model.)</od>
+</option>
+<option><on>-ts18</on><od>uses the TS18 statistical model.</od>
+</option>
+<option><on>-nointerp</on><od>Do not interpolate coeffiecients, instead use discrete models.</od>
+</option>
 <option><on>-noigrf</on><od>Do not use IGRF model to convert potential to velocities,</od></option>
 <option><on></on><od> instead use constant values.</od></option>
 <option><on>-o <ar>order</ar></on><od>set the order of fit to be <ar>order</ar>.</od>
 </option>
 <option><on>-d <ar>doping</ar></on><od>set the doping level to <ar>dp</ar>. Possible values are low, medium, or high.</od>
 </option>
-<option><on><ar>mapname</ar></on><od>filename of the <code>map</code> format file. If this is omitted, the file will</od></option>
+<option><on><ar>mapname</ar></on><od>filename of the <code>cnvmap</code> format file. If this is omitted, the file will</od></option>
 <option><on></on><od>  be read from standard input.</od></option>
 
 <synopsis><p>Calculates the statistical model and adds it to a convection map file.</p></synopsis>

--- a/codebase/superdarn/src.bin/tk/tool/map_ascii.1.8/doc/map_ascii.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_ascii.1.8/doc/map_ascii.doc.xml
@@ -23,7 +23,7 @@
 </option>
 <option><on>-ex <ar>hr:mn</ar></on><od>extract an interval whose extent is <ar>hr:mn</ar>.</od>
 </option>
-<option><on><ar>name</ar></on><od>filename of the <code>map</code> format file to trim. If this is omitted, the file is read from standard input.</od>
+<option><on><ar>name</ar></on><od>filename of the <code>cnvmap</code> format file to trim. If this is omitted, the file is read from standard input.</od>
 </option>
 <synopsis><p>Calculate the derived potential from a section of a <code>map</code> format file and produce a plain ASCII text file as output.\n</p>
 <p>The output format header is: <code>(start timestamp) (end timestamp) (minimum magnetic lat)\n</p>

--- a/codebase/superdarn/src.bin/tk/tool/map_filter.1.8/doc/map_filter.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_filter.1.8/doc/map_filter.doc.xml
@@ -8,19 +8,16 @@
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
 <option><on>-old</on><od>the input file is a <code>map</code> format file.</od></option>
-<option><on><ar>mapname</ar></on><od>filename of the <code>map</code> format file. If this is omitted, the file will be read from standard input.</od>
+<option><on><ar>mapname</ar></on><od>filename of the <code>cnvmap</code> format file. If this is omitted, the file will be read from standard input.</od>
 </option>
-
 
 <synopsis><p>Supersample a convection map file in time.</p></synopsis>
 <description><p>Supersample a convection map file in time.</p>
 <p>The task supersamples by skipping over records in the output file for a fixed length of time. By default the task will write a record every 10 minutes</p></description>
+
 <example>
 <command>map_filter -old 20040830.map &gt; 20040830.map.s</command>
 <description>Supersample the <code>map</code> format file "<code>20040830.map</code>" to produce the file "<code>20040830.map.s</code>".</description>
 </example>
-
-
-
 
 </binary>

--- a/codebase/superdarn/src.bin/tk/tool/map_fit.1.13/doc/map_fit.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_fit.1.13/doc/map_fit.doc.xml
@@ -3,10 +3,12 @@
 <project>superdarn</project>
 <name>map_fit</name>
 <location>src.bin/tk/tool/map_fit</location>
+
 <syntax></syntax>
 <syntax>map_fit --help</syntax>
 <syntax>map_fit [-vb] [-old] [-ew <ar>errwgt</ar>] [-mw <ar>modelwgt</ar>] [-s <ar>source</ar>] [<ar>mapname</ar>]</syntax>
 <syntax></syntax>
+
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
 <option><on>-vb</on><od>verbose. Log information to the console.</od>
@@ -23,7 +25,7 @@
 </option>
 <option><on>-s <ar>source</ar></on><od>set the text string indicating the data source  to <ar>source</ar>.</od>
 </option>
-<option><on><ar>mapname</ar></on><od>filename of the <code>map</code> format file. If this is omitted, the file will</od></option>
+<option><on><ar>mapname</ar></on><od>filename of the <code>cnvmap</code> format file. If this is omitted, the file will</od></option>
 <option><on></on><od>  be read from standard input.</od></option>
 <synopsis><p>Perform the Spherical Harmonic Fitting on a convection map file.</p></synopsis>
 
@@ -31,6 +33,7 @@
 <p>The file created is written to standard output.</p>
 <p>The input map file must contain valid model data to ensure that the fit converges.</p>
 </description>
+
 <example>
 <command>map_fit -old -ew y -mw n 19981020.map &gt; 19981020.shf.map</command>
 <description>Performs spherical harmonic fitting on the map file called  "<code>19981020.map</code>". Errors are weighted and model weighting is set to normalized. The file created is called "<code>19981020.shf.map</code>" and status is logged to standard error.</description>

--- a/codebase/superdarn/src.bin/tk/tool/map_grd.1.16/doc/map_grd.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_grd.1.16/doc/map_grd.doc.xml
@@ -3,16 +3,18 @@
 <project>superdarn</project>
 <name>map_grd</name>
 <location>src.bin/tk/tool/map_grd</location>
+
 <syntax></syntax>
 <syntax>map_grd --help</syntax>
 <syntax>map_grd [-vb] [-old] [-old_aacgm] [-sh] [-l <ar>latmin</ar>] [<ar>gridname</ar>]</syntax>
 <syntax></syntax>
+
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
 <option><on>-vb</on><od>verbose. Log information to the console.</od>
 </option>
 <option><on>-old</on><od>the input file is a <code>grd</code> format file and the output is a</od></option>
-<option><on></on><od>  <code>cnvmap</code> format file.</od></option>
+<option><on></on><od>  <code>map</code> format file.</od></option>
 <option><on>-old_aacgm</on><od>uses the older AACGM software and coefficients. The default</od></option>
 <option><on></on><od>  is to use AACGM-v2.</od></option>
 <option><on>-sh</on><od>the map file is for southern hemisphere data.</od>
@@ -33,14 +35,15 @@
 </option>
 <option><on>-tl <ar>tlen</ar></on><od>create empty records of length <ar>tlen</ar> seconds.</od>
 </option>
-<option><on><ar>gridname</ar></on><od>filename of the <code>grd</code> format file. If this is omitted, the file will</od></option>
+<option><on><ar>gridname</ar></on><od>filename of the <code>grdmap</code> format file. If this is omitted, the file will</od></option>
 <option><on></on><od>  be read from standard input.</od></option>
-<synopsis><p>Reformats a grid file into an empty <code>map</code> format file.</p></synopsis>
+<synopsis><p>Reformats a grid file into an empty <code>cnvmap</code> format file.</p></synopsis>
 
 <description><p>Creates an empty convection map file from a grid file.</p>
 <p>The file created is written to standard output.</p>
 <p>The output is in the map file format but most of the data fields are empty. Subsequent processing is required to add such things as the IMF data, Model vectors and coefficients of the spherical harmonic fit.</p>
 </description> 
+
 <example>
 <command>map_grd -l 60 -vb 19981020.grd &gt; 19981020.map</command>
 <description>Creates an empty map file from the grid file called  "<code>19981020.grd</code>". The lower latitude limit is set to 60 degrees. The file created is called "<code>19981020.map</code>" and status is logged to standard error.</description>

--- a/codebase/superdarn/src.bin/tk/tool/raw_cp.1.5/doc/raw_cp.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/raw_cp.1.5/doc/raw_cp.doc.xml
@@ -6,18 +6,18 @@
 
 <syntax>raw_cp --help</syntax>
 <syntax>raw_cp <ar>rawacfnames...</ar></syntax>
-<syntax>raw_cp -old [<ar>rawname</ar>]</syntax>
+<syntax>raw_cp -old <ar>rawname</ar></syntax>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
-<option><on><ar>rawacfnames</ar></on><od>filenames of the <code>rawacf</code> format files.</od>
+<option><on><ar>rawacfnames</ar></on><od>filenames of the <code>rawacf</code> format files. If this is omitted the file is read from standard input.</od>
 </option>
-<option><on>-old</on><od>files are in the <code>raw</code> format.</od>
+<option><on>-old</on><od>files are in the <code>raw</code> (<code>dat</code>) format.</od>
 </option>
-<option><on><ar>rawname</ar></on><od>filename of the <code>raw</code> format file. If this is omitted the file is read from standard input.</od>
+<option><on><ar>rawname</ar></on><od>filename of the <code>raw</code> (<code>dat</code>) format file.</od>
 </option>
-<synopsis><p>Determines the program identifier numbers in <code>raw</code> or <code>rawacf</code> format files.</p></synopsis>
-<description><p>Determines the program identifier numbers in <code>raw</code> or <code>rawacf</code> format files.</p>
+<synopsis><p>Determines the program identifier numbers in <code>rawacf</code> or <code>raw</code> (<code>dat</code>) format files.</p></synopsis>
+<description><p>Determines the program identifier numbers in <code>rawacf</code> or <code>raw</code> (<code>dat</code>) format files.</p>
 <p>The total number of program identifiers followed by a list of the identifier numbers is written to standard output.</p></description>
 
 <example>

--- a/codebase/superdarn/src.bin/tk/tool/trim_fit.1.20/doc/trim_fit.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/trim_fit.1.20/doc/trim_fit.doc.xml
@@ -5,10 +5,10 @@
 <location>src.bin/tk/tool/trim_fit</location>
 
 <syntax>trim_fit --help</syntax>
-<syntax>trim_fit [-vb] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>]  [-cp <ar>cpid</ar>] [-cn <ar>channel</ar>] <ar>fitacfinput</ar> <ar>fitacfoutput</ar></syntax>
-<syntax>trim_fit -i [-vb] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>]  [-cp <ar>cpid</ar>] [-cn <ar>channel</ar>] <ar>fitacfinput</ar> <ar>inxinput</ar> <ar>fitacfoutput</ar> <ar>inxoutput</ar></syntax>
-<syntax>trim_fit -old [-vb] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>]  [-cp <ar>cpid</ar>] [-cn <ar>channel</ar>] [<ar>fitname</ar>]</syntax>
-<syntax>trim_fit -i -old [-vb] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>]  [-cp <ar>cpid</ar>] [-cn <ar>channel</ar>] <ar>fitname</ar> <ar>inxname</ar> </syntax>
+<syntax>trim_fit [-vb] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>]  [-cp <ar>cpid</ar>] [-cn <ar>channel</ar>] [<ar>fitacfname</ar>]</syntax>
+<syntax>trim_fit -i [-vb] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>]  [-cp <ar>cpid</ar>] [-cn <ar>channel</ar>] <ar>fitacfname</ar> <ar>inxinput</ar></syntax>
+<syntax>trim_fit -old [-vb] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>]  [-cp <ar>cpid</ar>] [-cn <ar>channel</ar>] <ar>fitinput</ar> <ar>fitoutput</ar></syntax>
+<syntax>trim_fit -i -old [-vb] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>]  [-cp <ar>cpid</ar>] [-cn <ar>channel</ar>] <ar>fitinput</ar> <ar>fitoutput</ar> <ar>inxinput</ar> <ar>inxoutput</ar></syntax>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
@@ -28,9 +28,7 @@
 </option>
 <option><on>-cn <ar>channel</ar></on><od>extract only those records from channel <ar>channel</ar>.</od>
 </option>
-<option><on><ar>fitacfinput</ar></on><od>filename of the <code>fitacf</code> format file to trim.</od>
-</option>
-<option><on><ar>fitacfoutput</ar></on><od>filename of the <code>fitacf</code> format file to create.</od>
+<option><on><ar>fitacfname</ar></on><od>filename of the <code>fitacf</code> format file to trim. If this is omitted, the file will be read from standard input</od>
 </option>
 <option><on>-i</on><od>index files are available, for <code>fit</code> format files, an index file is created for the ouput file.</od>
 </option>
@@ -40,7 +38,9 @@
 </option>
 <option><on>-old</on><od>the input file is a <code>fit</code> format file.</od>
 </option>
-<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> (<code>dat</code>) format file to trim. If this is omitted, the file will be read from standard input</od>
+<option><on><ar>fitinput</ar></on><od>filename of the <code>fit</code> format file to trim.</od>
+</option>
+<option><on><ar>fitoutput</ar></on><od>filename of the <code>fit</code> format file to create.</od>
 </option>
 <synopsis><p>Extracts a section from a <code>fit</code> or <code>fitacf</code> format file.</p></synopsis>
 <description><p>Extracts a section from a <code>fit</code> or <code>fitacf</code> format file.</p>

--- a/codebase/superdarn/src.bin/tk/tool/trim_map.1.11/doc/trim_map.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/trim_map.1.11/doc/trim_map.doc.xml
@@ -3,8 +3,10 @@
 <project>superdarn</project>
 <name>trim_map</name>
 <location>src.bin/tk/tool/trim_map</location>
+
 <syntax>trim_map --help</syntax>
-<syntax>trim_map [-vb] [-old] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>] <ar>name</ar></syntax>
+<syntax>trim_map [-vb] [-old] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>] [<ar>name</ar>]</syntax>
+
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
 <option><on>-vb</on><od>verbose. Log information to the console.</od>
@@ -21,7 +23,7 @@
 </option>
 <option><on>-ex <ar>hr:mn</ar></on><od>extract an interval whose extent is <ar>hr:mn</ar>.</od>
 </option>
-<option><on><ar>name</ar></on><od>filename of the <code>map</code> format file to trim. If this is omitted, the file is read from standard input.</od>
+<option><on><ar>name</ar></on><od>filename of the <code>cnvmap</code> format file to trim. If this is omitted, the file is read from standard input.</od>
 </option>
 <synopsis><p>Extracts a section from a <code>map</code> or <code>cnvmap</code> format file.</p></synopsis>
 
@@ -33,8 +35,10 @@
 <command>trim_map -vb -old -st 11:00 -et 14:00 19981020.map &gt; 19981020.1100.map</command>
 <description>Extracts a 3 hour period starting at 11:00UT from the file called "<code>19981020.map</code>" to produce a file called "<code>19981020.1100.map</code>". The status is logged to standard error.</description>
 </example>
+
 <example>
 <command>trim_map -sd 19991121 -st 22:00 -ex 4:00 -i 240 199911.cnvmap &gt; 199911.2100.cnvmap</command>
 <description>Extracts a 4 hour period starting at 22:00UT on November 21, 1999 from the file "<code>199911.cnvmap</code>" to produce the output file "<code>199911.2100.cnvmap</code>". The records are re-integrated to produce records at 4-minute intervals.</description>
 </example>
+
 </binary>

--- a/codebase/superdarn/src.bin/tk/tool/trim_raw.1.15/doc/trim_raw.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/trim_raw.1.15/doc/trim_raw.doc.xml
@@ -5,8 +5,8 @@
 <location>src.bin/tk/tool/trim_raw</location>
 
 <syntax>trim_raw --help</syntax>
-<syntax>trim_raw [-vb] [-t <ar>thr</ar>] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>] <ar>rawacfinput</ar> <ar>rawacfoutput</ar></syntax>
-<syntax>trim_raw -old [-vb] [-t <ar>thr</ar>] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>] [<ar>rawname</ar>]</syntax>
+<syntax>trim_raw [-vb] [-t <ar>thr</ar>] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>] [<ar>rawacfname</ar>]</syntax>
+<syntax>trim_raw -old [-vb] [-t <ar>thr</ar>] [-sd <ar>yyyymmdd</ar>] [-st <ar>hr:mn</ar>] [-ed <ar>yyyymmdd</ar>] [-et <ar>hr:mn</ar>] [-ex <ar>hr:mn</ar>] <ar>rawinput</ar> <ar>rawoutput</ar></syntax>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
@@ -24,13 +24,13 @@
 </option>
 <option><on>-ex <ar>hr:mn</ar></on><od>extract an interval whose extent is <ar>hr:mn</ar>.</od>
 </option>
-<option><on><ar>rawacfinput</ar></on><od>filename of the <code>rawacf</code> format file to trim.</od>
-</option>
-<option><on><ar>rawacfoutput</ar></on><od>filename of the <code>raw</code> format file to create.</od>
+<option><on><ar>rawacfname</ar></on><od>filename of the <code>rawacf</code> format file to trim. If this is omitted, the file will be read from standard input</od>
 </option>
 <option><on>-old</on><od>the input file is a <code>raw</code> (<code>dat</code>) format file.</od>
 </option>
-<option><on><ar>rawname</ar></on><od>filename of the <code>raw</code> (<code>dat</code>) format file to trim. If this is omitted, the file will be read from standard input</od>
+<option><on><ar>rawinput</ar></on><od>filename of the <code>raw</code> (<code>dat</code>) format file to trim.</od>
+</option>
+<option><on><ar>rawoutput</ar></on><od>filename of the <code>raw</code> (<code>dat</code>) format file to create.</od>
 </option>
 <synopsis><p>Extracts a section from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p></synopsis>
 <description><p>Extracts a section from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p>


### PR DESCRIPTION
This pull request addresses the side issue raised in #116 about the documentation of several binaries no longer being correct after the new/old flag transition.  I've gone through and tried to fix those up for both accuracy and in some cases readability/formatting.  No software binaries or libraries are modified by this pull request.