### PR TITLE
Check absolute value of scan flag in various C routines

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
@@ -1016,7 +1016,7 @@ int main(int argc,char *argv[]) {
         }
         if (tlen==0) {
           while ((s=OldFitRead(oldfitfp,prm,fit)) !=-1) {
-            if (prm->scan==1) break;
+            if (abs(prm->scan)==1) break;
           }
         } else state=0;
         s=OldFitReadRadarScan(oldfitfp,&state,scn,prm,
@@ -1029,7 +1029,7 @@ int main(int argc,char *argv[]) {
 	}
         if (tlen==0) {
           while ((s=FitFread(fitfp,prm,fit)) !=-1) {
-            if (prm->scan==1) break;
+            if (abs(prm->scan)==1) break;
           }
         } else state=0;
         s=FitFreadRadarScan(fitfp,&state,scn,prm,
@@ -1045,7 +1045,7 @@ int main(int argc,char *argv[]) {
       }
       if (tlen==0) {
         while ((s=CFitRead(cfitfp,cfit)) !=-1) {
-          if (cfit->scan==1) break;
+          if (abs(cfit->scan)==1) break;
         }
       } else state=0;
       s=CFitReadRadarScan(cfitfp,&state,scn,cfit,tlen,syncflg,channel);

--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfserver.1.17/fitacfserver.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfserver.1.17/fitacfserver.c
@@ -268,7 +268,7 @@ int main(int argc,char *argv[]) {
   if (old) status=OldFitRead(fitfp,prm,fit);
   else status=FitFread(fp,prm,fit);
 
-  if ((aflg==1) && (prm->scan==1)) wait_boundary(bnd);
+  if ((aflg==1) && (abs(prm->scan)==1)) wait_boundary(bnd);
   if (sync==1) {
     TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
     if (old) {
@@ -334,7 +334,7 @@ int main(int argc,char *argv[]) {
     else status=FitFread(fp,prm,fit);
 
     if ((status==0) && (aflg==1)) {
-      if (prm->scan==1) wait_boundary(bnd);
+      if (abs(prm->scan)==1) wait_boundary(bnd);
       TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
       prm->time.yr=yr;
       prm->time.mo=mo;
@@ -357,7 +357,7 @@ int main(int argc,char *argv[]) {
         else fitfp=OldFitOpen(argv[arg],NULL);
         status=OldFitRead(fitfp,prm,fit);
         
-        if ((aflg==1) && (prm->scan==1)) wait_boundary(bnd);
+        if ((aflg==1) && (abs(prm->scan)==1)) wait_boundary(bnd);
         if (sync==1) {
           TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
           status=OldFitSeek(fitfp,prm->time.yr,prm->time.mo,prm->time.dy,
@@ -372,7 +372,7 @@ int main(int argc,char *argv[]) {
       } else {
         fclose(fp);
         fp=fopen(argv[arg],"r");
-        if ((aflg==1) && (prm->scan==1)) wait_boundary(bnd);
+        if ((aflg==1) && (abs(prm->scan)==1)) wait_boundary(bnd);
         if (sync==1) {
           TimeReadClock(&yr,&mo,&dy,&hr,&mt,&sc,&us);
           status=FitFseek(fp,prm->time.yr,prm->time.mo,prm->time.dy,

--- a/codebase/superdarn/src.bin/tk/tool/fitfilter.1.4/fitfilter.c
+++ b/codebase/superdarn/src.bin/tk/tool/fitfilter.1.4/fitfilter.c
@@ -405,11 +405,11 @@ int main(int argc,char *argv[]) {
         if (tlen==0) {
           if (old) {
             while ((s=OldFitRead(fitfp,prm,fit)) !=-1) {
-              if (prm->scan==1) break;
+              if (abs(prm->scan)==1) break;
 	    }
 	  } else {
             while ((s=FitFread(fp,prm,fit)) !=-1) {
-              if (prm->scan==1) break;
+              if (abs(prm->scan)==1) break;
 	    }
 	  }
         } else state=0;
@@ -425,7 +425,7 @@ int main(int argc,char *argv[]) {
         }
         if (tlen==0) {
           while ((s=CFitRead(cfitfp,cfit)) !=-1) {
-            if (cfit->scan==1) break;
+            if (abs(cfit->scan)==1) break;
 	  }
         } else state=0;
         s=CFitReadRadarScan(cfitfp,&state,src[0],cfit,tlen,syncflg,channel);

--- a/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/make_grid.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/make_grid.c
@@ -704,11 +704,11 @@ int main(int argc,char *argv[]) {
                 if (tlen==0) {
                     if (old) {
                         while ((s=OldFitRead(oldfitfp,prm,fit)) !=-1) {
-                            if (prm->scan==1) break;
+                            if (abs(prm->scan)==1) break;
                         }
                     } else {
                         while ((s=FitFread(fitfp,prm,fit)) !=-1) {
-                            if (prm->scan==1) break;
+                            if (abs(prm->scan)==1) break;
                         }
                     }
                 } else state=0;

--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fitscan.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fitscan.c
@@ -215,7 +215,7 @@ int FitReadRadarScan(int fid, int *state,
 
                 /* Set flg equal to 1 if scan data according to scan flag
                  * was successfully stored in RadarScan structure */
-                if (prm->scan==1) flg=1;
+                if (abs(prm->scan)==1) flg=1;
 
                 /* Set flg equal to 1 if scan data of length tlen was
                  * successfully stored in RadarScan structure */

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/src/fitscan.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/src/fitscan.c
@@ -159,7 +159,7 @@ int OldFitReadRadarScan(struct OldFitFp *fp,int *state,
     if (fstatus==-1) flg=2;
     else {
       if (tlen==0) {
-        if (prm->scan==1) flg=1;
+        if (abs(prm->scan)==1) flg=1;
       } else if (ptr->ed_time-ptr->st_time>=tlen) flg=1;
     }
   } while (flg==0);

--- a/codebase/superdarn/src.lib/tk/smr.1.7/src/smrscan.c
+++ b/codebase/superdarn/src.lib/tk/smr.1.7/src/smrscan.c
@@ -152,7 +152,7 @@ int SmrRadarScan(FILE *fp,int *state,
     if (fstatus==-1) flg=2;
     else {
       if (tlen==0) {
-        if (prm->scan==1) flg=1;
+        if (abs(prm->scan)==1) flg=1;
       } else if (ptr->ed_time-ptr->st_time>=tlen) flg=1;
     }
   } while (flg==0);


### PR DESCRIPTION
As originally identified by @mts299 in #131, this pull request modifies several binaries and libraries to check against the absolute value of the `prm->scan` flag for values of 1 to handle cases where the scan flag has been set to -1 (for backwards scanning sequences) rather than the usual value of 1. This should fix the behavior where make_grid never finds a scan flag of 1 and eventually 1000 beam soundings are read, causing the code to stop and display an error message.