### PR TITLE
Fixing more compiler warnings and errors (dmap, zlib, etc)

### DIFF
--- a/codebase/analysis/src.bin/aacgm_v2/aacgm_test.1.0/test_aacgm.c
+++ b/codebase/analysis/src.bin/aacgm_v2/aacgm_test.1.0/test_aacgm.c
@@ -12,7 +12,7 @@ int main(void)
 {
 double lat,lon,hgt;
 double h, mlt_c, mlt_t;
-double rtp[3];
+/*double rtp[3];*/
 double mlat,mlon,r;
 int k, err, npts;
 int yr, mo, dy, hr, mt, sc, dno;

--- a/codebase/general/src.lib/dmap.1.25/include/dmap.h
+++ b/codebase/general/src.lib/dmap.1.25/include/dmap.h
@@ -158,7 +158,7 @@ int DataMapSetFreeArray(struct DataMap *ptr,char *name,int type,int dim);
 
 int DataMapSize(struct DataMap *write);
 
-char *DataMapEncodeBuffer(struct DataMap *ptr,int *size);
+unsigned char *DataMapEncodeBuffer(struct DataMap *ptr,int *size);
 
 int DataMapWrite(int fid,struct DataMap *ptr);
  
@@ -170,7 +170,7 @@ int DataMapFwrite(FILE *fp,struct DataMap *ptr);
 
 struct DataMap *DataMapFread(FILE *fp);
 
-struct DataMap *DataMapDecodeBuffer(char *buf,int size);
+struct DataMap *DataMapDecodeBuffer(unsigned char *buf,int size);
 
 struct DataMap *DataMapReadBlock(int fid,int *s);
 struct DataMap *DataMapFreadBlock(FILE *fp,int *s);

--- a/codebase/general/src.lib/dmap.1.25/include/dmap.h
+++ b/codebase/general/src.lib/dmap.1.25/include/dmap.h
@@ -58,7 +58,7 @@ struct DataMapFp {
   int size;
   union {
     FILE *f;
-    gzFile *z;
+    gzFile z;
   } fp;
 };
 

--- a/codebase/general/src.lib/dmap.1.25/include/dmap.h
+++ b/codebase/general/src.lib/dmap.1.25/include/dmap.h
@@ -151,7 +151,7 @@ void *DataMapStoreArray(struct DataMap *ptr,
 int DataMapRemoveArray(struct DataMap *ptr,char *name,int type,int dim);
 
 void *DataMapFindArray(struct DataMap *ptr,char *name,int type,int dim,
-		       int **rng);
+		       int32 **rng);
 
 
 int DataMapSetFreeArray(struct DataMap *ptr,char *name,int type,int dim);

--- a/codebase/general/src.lib/dmap.1.25/src/dmap.c
+++ b/codebase/general/src.lib/dmap.1.25/src/dmap.c
@@ -647,14 +647,14 @@ void *DataMapFindArray(struct DataMap *ptr,
 
 }
 
-char *DataMapEncodeBuffer(struct DataMap *ptr,int *size) {
+unsigned char *DataMapEncodeBuffer(struct DataMap *ptr,int *size) {
   int c,x,m,n;
   char **tmp;
   void *tbuf;
   int tsze;
   struct DataMapScalar *s=NULL;
   struct DataMapArray *a=NULL;
-  char *buf=NULL;
+  unsigned char *buf=NULL;
   int off=0;
   int sze=0;
 
@@ -864,7 +864,7 @@ char *DataMapEncodeBuffer(struct DataMap *ptr,int *size) {
 
 
 int DataMapWrite(int fid,struct DataMap *ptr) {
-  char *buf=NULL;
+  unsigned char *buf=NULL;
   int sze=0,st=0,cnt=0;
   buf=DataMapEncodeBuffer(ptr,&sze);
   if (buf==NULL) return -1;
@@ -968,7 +968,7 @@ char *DataMapReadString(int fid) {
   return ptr;
 }
 
-struct DataMap *DataMapDecodeBuffer(char *buf,int size) {
+struct DataMap *DataMapDecodeBuffer(unsigned char *buf,int size) {
   int c,x,n,i,e;
   int32 sn,an;
   int32 code,sze;
@@ -1360,7 +1360,7 @@ struct DataMap *DataMapDecodeBuffer(char *buf,int size) {
 
 
 struct DataMap *DataMapReadBlock(int fid,int *s) {
-  char *buf=NULL;
+  unsigned char *buf=NULL;
   struct DataMap *ptr;
   int32 code,sze,*iptr;
   int size=0,cnt=0,num=0,st=0;   
@@ -1407,7 +1407,7 @@ struct DataMap *DataMapFread(FILE *fp) {
 
 
 struct DataMap *DataMapReadBlockZ(gzFile file,int *s) {
-  char *buf=NULL;
+  unsigned char *buf=NULL;
   struct DataMap *ptr;
   int32 code,sze,*iptr;
   int size=0,cnt=0,num=0,st=0;   
@@ -1448,7 +1448,7 @@ struct DataMap *DataMapReadZ(gzFile file) {
 
 
 int DataMapWriteZ(gzFile file,struct DataMap *ptr) {
-  char *buf=NULL;
+  unsigned char *buf=NULL;
   int sze=0,st=0,cnt=0;
   buf=DataMapEncodeBuffer(ptr,&sze);
   if (buf==NULL) return -1;

--- a/codebase/superdarn/src.bin/tk/testing/fitcomp.1.0/fitcomp.c
+++ b/codebase/superdarn/src.bin/tk/testing/fitcomp.1.0/fitcomp.c
@@ -252,13 +252,13 @@ int main(int argc,char *argv[])
 
   double lm_v_err[100000],ex_v_err[100000],acf_v_err[100000];
   long n_acf=0, n_lm=0,n_ex=0;
-  double mean_v_acf,mean_v_lm,mean_v_ex;
+  double mean_v_acf=0.0,mean_v_lm=0.0,mean_v_ex=0.0;
 
   double lm_t_err[100000],ex_t_err[100000],acf_t_err[100000];
-  double mean_t_acf,mean_t_lm,mean_t_ex;
+  double mean_t_acf=0.0,mean_t_lm=0.0,mean_t_ex=0.0;
 
   double lm_f_err[100000],ex_f_err[100000],acf_f_err[100000];
-  double mean_f_acf,mean_f_lm,mean_f_ex;
+  double mean_f_acf=0.0,mean_f_lm=0.0,mean_f_ex=0.0;
 
   if (vb)
       fprintf(stderr,"%d-%d-%d %d:%d:%d beam=%d\n",prm1->time.yr,prm1->time.mo,

--- a/codebase/superdarn/src.bin/tk/testing/fitcomp.1.0/fitcomp.c
+++ b/codebase/superdarn/src.bin/tk/testing/fitcomp.1.0/fitcomp.c
@@ -102,15 +102,10 @@ double calc_acf_err(struct RawData * raw, struct FitData * fit, struct RadarParm
 int main(int argc,char *argv[])
 {
 
-  unsigned char old=0;
-
   char *envstr;
   int status;
-  int arg,i,vel,t_d,amp;
+  int i,vel,t_d,amp;
   int j,k,l,vbin,tbin;
-
-  unsigned char help=0;
-  unsigned char option=0;
 
   unsigned char vb=0;
 

--- a/codebase/superdarn/src.bin/tk/testing/fitcomp.1.0/fitcomp.c
+++ b/codebase/superdarn/src.bin/tk/testing/fitcomp.1.0/fitcomp.c
@@ -76,30 +76,30 @@ struct OptionData opt;
 
 double calc_acf_err(struct RawData * raw, struct FitData * fit, struct RadarParm * prm, int i)
 {
-	double acferr, tau, lag, re, im, ref, imf;
-	int j;
-	double lambda = 3e8/(prm->tfreq*1e3);
-	double t_if = lambda/(fit->rng[i].w_l*2.*3.14159);
-	double f_if = 4.*3.14159*fit->rng[i].v/lambda;
-	double noise = prm->noise.mean;
-	double p0 = noise*pow(10.,fit->rng[i].p_l/10.)-noise;
-	acferr = 0.;
-	for(j=0;j<prm->mplgs;j++)
-	{
-		lag = fabs(prm->lag[0][j]-prm->lag[1][j]);
-		tau = lag*prm->mpinc*1.e-6;
-		re = raw->acfd[0][i*prm->mplgs+j]/(10000.);
-		im = raw->acfd[1][i*prm->mplgs+j]/(10000.);
-		ref = p0*exp(-1.0*tau/t_if)*cos(tau*f_if)/(10000.);
-		imf = p0*exp(-1.0*tau/t_if)*sin(tau*f_if)/(10000.);
-		acferr += (pow(re-ref,2) + pow(im-imf,2));
-	}
-	acferr /= prm->mplgs;
-	acferr = sqrt(acferr);
-	return acferr;
+    double acferr, tau, lag, re, im, ref, imf;
+    int j;
+    double lambda = 3e8/(prm->tfreq*1e3);
+    double t_if = lambda/(fit->rng[i].w_l*2.*3.14159);
+    double f_if = 4.*3.14159*fit->rng[i].v/lambda;
+    double noise = prm->noise.mean;
+    double p0 = noise*pow(10.,fit->rng[i].p_l/10.)-noise;
+    acferr = 0.;
+    for(j=0;j<prm->mplgs;j++)
+    {
+        lag = fabs(prm->lag[0][j]-prm->lag[1][j]);
+        tau = lag*prm->mpinc*1.e-6;
+        re = raw->acfd[0][i*prm->mplgs+j]/(10000.);
+        im = raw->acfd[1][i*prm->mplgs+j]/(10000.);
+        ref = p0*exp(-1.0*tau/t_if)*cos(tau*f_if)/(10000.);
+        imf = p0*exp(-1.0*tau/t_if)*sin(tau*f_if)/(10000.);
+        acferr += (pow(re-ref,2) + pow(im-imf,2));
+    }
+    acferr /= prm->mplgs;
+    acferr = sqrt(acferr);
+    return acferr;
 }
 
-int main(int argc,char *argv[]) 
+int main(int argc,char *argv[])
 {
 
   unsigned char old=0;
@@ -107,7 +107,7 @@ int main(int argc,char *argv[])
   char *envstr;
   int status;
   int arg,i,vel,t_d,amp;
-	int j,k,l,vbin,tbin;
+  int j,k,l,vbin,tbin;
 
   unsigned char help=0;
   unsigned char option=0;
@@ -115,13 +115,13 @@ int main(int argc,char *argv[])
   unsigned char vb=0;
 
   FILE *fpa=NULL;
-	FILE *fpb=NULL;
-	FILE *fpc=NULL;
-	FILE * fp = NULL;
+  FILE *fpb=NULL;
+  FILE *fpc=NULL;
+  FILE * fp = NULL;
 
   int c,n, lag;
   char command[128];
-	double lambda, t_if, f_if, p0, noise, acferr, re, im, ref, imf, tau;
+  double lambda, t_if, f_if, p0, noise, acferr, re, im, ref, imf, tau;
 
   prm1=RadarParmMake();
   raw1=RawMake();
@@ -130,41 +130,41 @@ int main(int argc,char *argv[])
   prm3=RadarParmMake();
   raw3=RawMake();
   fitacf=FitMake();
-	fitex=FitMake();
-	fitlm=FitMake();
+  fitex=FitMake();
+  fitlm=FitMake();
 
-	double **** errors = malloc(20*sizeof(double ***));
-	for(i=0;i<20;i++)
-	{
-		errors[i] = malloc(10*sizeof(double **));
-		for(j=0;j<10;j++)
-		{
-			errors[i][j] = malloc(3*sizeof(double *));
-			for(k=0;k<3;k++)
-			{
-				errors[i][j][k] = malloc(5*sizeof(double));
-				for(l=0;l<5;l++)
-					errors[i][j][k][l] = 0.;
-			}
-		}
-	}
+  double **** errors = malloc(20*sizeof(double ***));
+  for(i=0;i<20;i++)
+  {
+    errors[i] = malloc(10*sizeof(double **));
+    for(j=0;j<10;j++)
+    {
+      errors[i][j] = malloc(3*sizeof(double *));
+      for(k=0;k<3;k++)
+      {
+        errors[i][j][k] = malloc(5*sizeof(double));
+        for(l=0;l<5;l++)
+          errors[i][j][k][l] = 0.;
+      }
+    }
+  }
 
-	double *** num = malloc(20*sizeof(double **));
-	for(i=0;i<20;i++)
-	{
-		num[i] = malloc(10*sizeof(double * ));
-		for(j=0;j<10;j++)
-		{
-			num[i][j] = malloc(3*sizeof(double));
-			for(k=0;k<3;k++)
-				num[i][j][k] = 0.;
-		}
-	}
+  double *** num = malloc(20*sizeof(double **));
+  for(i=0;i<20;i++)
+  {
+    num[i] = malloc(10*sizeof(double * ));
+    for(j=0;j<10;j++)
+    {
+      num[i][j] = malloc(3*sizeof(double));
+      for(k=0;k<3;k++)
+        num[i][j][k] = 0.;
+    }
+  }
 
 
   envstr=getenv("SD_RADAR");
   if (envstr==NULL)
-	{
+  {
     fprintf(stderr,"Environment variable 'SD_RADAR' must be defined.\n");
     exit(-1);
   }
@@ -172,7 +172,7 @@ int main(int argc,char *argv[])
   fp=fopen(envstr,"r");
 
   if (fp==NULL)
-	{
+  {
     fprintf(stderr,"Could not locate radar information file.\n");
     exit(-1);
   }
@@ -180,61 +180,61 @@ int main(int argc,char *argv[])
   network=RadarLoad(fp);
   fclose(fp);
   if (network==NULL)
-	{
+  {
     fprintf(stderr,"Failed to read radar information.\n");
     exit(-1);
   }
 
   envstr=getenv("SD_HDWPATH");
   if (envstr==NULL)
-	{
+  {
     fprintf(stderr,"Environment variable 'SD_HDWPATH' must be defined.\n");
     exit(-1);
   }
   RadarLoadHardware(envstr,network);
 
-	char *filename;
-	filename = argv[argc-1];
-	char * cmd = malloc(snprintf(NULL, 0, "%s %s %s", " cp", filename, " > f1.rawacf") + 2);
-	sprintf(cmd, "%s %s %s", "cp", filename, " f1.rawacf");
-	system(cmd);
+  char *filename;
+  filename = argv[argc-1];
+  char * cmd = malloc(snprintf(NULL, 0, "%s %s %s", " cp", filename, " > f1.rawacf") + 2);
+  sprintf(cmd, "%s %s %s", "cp", filename, " f1.rawacf");
+  system(cmd);
 
-	sprintf(cmd, "%s %s %s", "cp", filename, " f2.rawacf");
-	system(cmd);
+  sprintf(cmd, "%s %s %s", "cp", filename, " f2.rawacf");
+  system(cmd);
 
-	sprintf(cmd, "%s %s %s", "cp", filename, " f3.rawacf");
-	system(cmd);
-	
-	free(cmd);
-	
-	fpa=fopen("f1.rawacf","r");
-	fpb=fopen("f2.rawacf","r");
-	fpc=fopen("f3.rawacf","r");
+  sprintf(cmd, "%s %s %s", "cp", filename, " f3.rawacf");
+  system(cmd);
 
-	if (fpa==NULL || fpb==NULL || fpc==NULL)
-	{
-		fprintf(stderr,"File not found.\n");
-		exit(-1);
-	}
-	status=RawFread(fpa,prm1,raw1);
-	status=RawFread(fpb,prm2,raw2);
-	status=RawFread(fpc,prm3,raw3);
+  free(cmd);
+
+  fpa=fopen("f1.rawacf","r");
+  fpb=fopen("f2.rawacf","r");
+  fpc=fopen("f3.rawacf","r");
+
+  if (fpa==NULL || fpb==NULL || fpc==NULL)
+  {
+    fprintf(stderr,"File not found.\n");
+    exit(-1);
+  }
+  status=RawFread(fpa,prm1,raw1);
+  status=RawFread(fpb,prm2,raw2);
+  status=RawFread(fpc,prm3,raw3);
 
 
   radar=RadarGetRadar(network,prm1->stid);
   if (radar==NULL)
-	{
+  {
     fprintf(stderr,"Failed to get radar information.\n");
     exit(-1);
   }
 
   site=RadarYMDHMSGetSite(radar,prm1->time.yr,prm1->time.mo,
-		          prm1->time.dy,prm1->time.hr,prm1->time.mt,
+                          prm1->time.dy,prm1->time.hr,prm1->time.mt,
                           prm1->time.sc);
 
 
   if (site==NULL)
-	{
+  {
     fprintf(stderr,"Failed to get site information.\n");
     exit(-1);
   }
@@ -243,328 +243,316 @@ int main(int argc,char *argv[])
   command[0]=0;
   n=0;
   for (c=0;c<argc;c++)
-	{
+  {
     n+=strlen(argv[c])+1;
     if (n>127) break; 
     if (c !=0) strcat(command," ");
     strcat(command,argv[c]);
   }
 
-	double lm_v_err[100000],ex_v_err[100000],acf_v_err[100000];
-	long n_acf=0, n_lm=0,n_ex=0;
-	double mean_v_acf,mean_v_lm,mean_v_ex;
+  double lm_v_err[100000],ex_v_err[100000],acf_v_err[100000];
+  long n_acf=0, n_lm=0,n_ex=0;
+  double mean_v_acf,mean_v_lm,mean_v_ex;
 
-	double lm_t_err[100000],ex_t_err[100000],acf_t_err[100000];
-	double mean_t_acf,mean_t_lm,mean_t_ex;
+  double lm_t_err[100000],ex_t_err[100000],acf_t_err[100000];
+  double mean_t_acf,mean_t_lm,mean_t_ex;
 
-	double lm_f_err[100000],ex_f_err[100000],acf_f_err[100000];
-	double mean_f_acf,mean_f_lm,mean_f_ex;
+  double lm_f_err[100000],ex_f_err[100000],acf_f_err[100000];
+  double mean_f_acf,mean_f_lm,mean_f_ex;
 
   if (vb)
       fprintf(stderr,"%d-%d-%d %d:%d:%d beam=%d\n",prm1->time.yr,prm1->time.mo,
-	     prm1->time.dy,prm1->time.hr,prm1->time.mt,prm1->time.sc,prm1->bmnum);
+             prm1->time.dy,prm1->time.hr,prm1->time.mt,prm1->time.sc,prm1->bmnum);
 
-	fblkacf=FitACFMake(site,prm1->time.yr);
-	fblkex=FitACFMake(site,prm2->time.yr);
-	fblklm=FitACFMake(site,prm3->time.yr);
+  fblkacf=FitACFMake(site,prm1->time.yr);
+  fblkex=FitACFMake(site,prm2->time.yr);
+  fblklm=FitACFMake(site,prm3->time.yr);
 
-	FitACF(prm1,raw1,fblkacf,fitacf);
-	fitacfex2(prm2,raw2,fitex,fblkex,0);
-	lmfit(prm3,raw3,fitlm,fblklm,0);
+  FitACF(prm1,raw1,fblkacf,fitacf);
+  fitacfex2(prm2,raw2,fitex,fblkex,0);
+  lmfit(prm3,raw3,fitlm,fblklm,0);
 
-	int ** very_bad = malloc(20*sizeof(int *));
-	for(i=0;i<20;i++)
-	{
-		very_bad[i] = malloc(3*sizeof(int));
-		for(j=0;j<3;j++)
-			very_bad[i][j] = 0;
-	}
+  int ** very_bad = malloc(20*sizeof(int *));
+  for(i=0;i<20;i++)
+  {
+    very_bad[i] = malloc(3*sizeof(int));
+    for(j=0;j<3;j++)
+      very_bad[i][j] = 0;
+  }
 
-	n = 0;
-	int print=0;
-	int one=0, two=0, three=0;
+  n = 0;
+  int print=0;
+  int one=0, two=0, three=0;
   do
   {
-		/*read the simulation params*/
-		sscanf(prm1->combf,"%*c%*c%*c%*c%*c%*c%*c%*c %*c%*c%*c%*c %d %*c%*c%*c%*c %d %*c%*c%*c%*c %d %*s\n",&vel,&t_d,&amp);
-		lambda = 3.e8/(prm1->tfreq*1.e3);
+    /*read the simulation params*/
+    sscanf(prm1->combf,"%*c%*c%*c%*c%*c%*c%*c%*c %*c%*c%*c%*c %d %*c%*c%*c%*c %d %*c%*c%*c%*c %d %*s\n",&vel,&t_d,&amp);
+    lambda = 3.e8/(prm1->tfreq*1.e3);
 
 
-		/*go through all of the range gates*/
-		for(i=0;i<10;i++)
-		{
-			/*fitacf error calculations*/
-			if(fitacf->rng[i].qflg == 1)
-			{
-				vbin = (vel/100);
-				tbin = (t_d/10)-1;
-				num[vbin][tbin][0] += 1.;
+    /*go through all of the range gates*/
+    for(i=0;i<10;i++)
+    {
+      /*fitacf error calculations*/
+      if(fitacf->rng[i].qflg == 1)
+      {
+        vbin = (vel/100);
+        tbin = (t_d/10)-1;
+        num[vbin][tbin][0] += 1.;
 
-				acf_v_err[n_acf] = fabs((double)vel-fitacf->rng[i].v);
-				acf_t_err[n_acf] = fabs((double)t_d*1.e-3-lambda/(fitacf->rng[i].w_l*2.*3.14159))/((double)t_d*1.e-3);
+        acf_v_err[n_acf] = fabs((double)vel-fitacf->rng[i].v);
+        acf_t_err[n_acf] = fabs((double)t_d*1.e-3-lambda/(fitacf->rng[i].w_l*2.*3.14159))/((double)t_d*1.e-3);
 
-				/*rms velocity*/
-				errors[vbin][tbin][0][0] += pow((double)vel-fitacf->rng[i].v,2);
-				/*true velocity*/
-				errors[vbin][tbin][0][1] += fitacf->rng[i].v-(double)vel;
-				errors[vbin][tbin][0][2] += pow((double)t_d*1.e-3-lambda/(fitacf->rng[i].w_l*2.*3.14159),2);
-
-
-				if(pow((double)t_d*1.e-3-lambda/(fitacf->rng[i].w_l*2.*3.14159),2) > 999999.) exit(-1);
-				/*calc ACFERR
-				t_if = lambda/(fitacf->rng[i].w_l*2.*3.14159);
-				f_if = 4.*3.14159*fitacf->rng[i].v/lambda;
-				noise = fitacf->rng[i].phi0_err;
-				p0 = noise*pow(10.,fitacf->rng[i].p_l/10.)-noise;
-				acferr = 0.;
-				for(j=0;j<prm1->mplgs;j++)
-				{
-					lag = fabs(prm1->lag[0][j]-prm1->lag[1][j]);
-					tau = lag*prm1->mpinc*1.e-6;
-					re = raw1->acfd[0][i*prm1->mplgs+j]/(10000./pow(i+1,2));
-					im = raw1->acfd[1][i*prm1->mplgs+j]/(10000./pow(i+1,2));
-					ref = p0*exp(-1.0*tau/t_if)*cos(tau*f_if)/(10000./pow(i+1,2));
-					imf = p0*exp(-1.0*tau/t_if)*sin(tau*f_if)/(10000./pow(i+1,2));
-					acferr += (pow(re-ref,2) + pow(im-imf,2));
-				}
-				acferr /= prm1->mplgs;
-				acferr = sqrt(acferr);*/
-				acferr = calc_acf_err(raw1,fitacf,prm1,i);
-				errors[vbin][tbin][0][4] += acferr;
-				acf_f_err[n_acf] = acferr;
-				n_acf++;
-			}
-			if(fitex->rng[i].qflg)
-			{
-				vbin = (vel/100);
-				tbin = (t_d/10)-1;
-				num[vbin][tbin][1] += 1.;
-
-				ex_v_err[n_ex] = fabs((double)vel-fitex->rng[i].v);
-				ex_t_err[n_ex] = fabs((double)t_d*1.e-3-lambda/(fitex->rng[i].w_l*2.*3.14159))/((double)t_d*1.e-3);
-
-				errors[vbin][tbin][1][0] += pow((double)vel-fitex->rng[i].v,2); /*fitex2*/
-				errors[vbin][tbin][1][1] += fitex->rng[i].v-(double)vel;  /*fitex2*/
-				errors[vbin][tbin][1][2] += pow((double)t_d*1.e-3-lambda/(fitex->rng[i].w_l*2.*3.14159),2); /*fitex2*/
-				errors[vbin][tbin][1][3] += lambda/(fitex->rng[i].w_l*2.*3.14159)-(double)t_d*1.e-3; /*fitex2*/
-
-				/*fitex2*/
-				t_if = lambda/(fitex->rng[i].w_l*2.*3.14159);
-				f_if = 4.*3.14159*fitex->rng[i].v/lambda;
-				noise = prm2->noise.mean;
-				p0 = noise*pow(10.,fitex->rng[i].p_l/10.)-noise;
-				acferr = 0.;
-				for(j=0;j<prm2->mplgs;j++)
-				{
-					lag = fabs(prm2->lag[0][j]-prm2->lag[1][j]);
-					tau = lag*prm2->mpinc*1.e-6;
-					re = raw2->acfd[0][i*prm2->mplgs+j]/(10000./pow(i+1,2));
-					im = raw2->acfd[1][i*prm2->mplgs+j]/(10000./pow(i+1,2));
-					ref = p0*exp(-1.0*tau/t_if)*cos(tau*f_if)/(10000./pow(i+1,2));
-					imf = p0*exp(-1.0*tau/t_if)*sin(tau*f_if)/(10000./pow(i+1,2));
-					acferr += (pow(re-ref,2) + pow(im-imf,2));
-				}
-				acferr /= prm2->mplgs;
-				acferr = sqrt(acferr);
-				acferr = calc_acf_err(raw2,fitex,prm2,i);
-				errors[vbin][tbin][1][4] += acferr;
-
-				ex_f_err[n_ex] = acferr;
-				n_ex++;
-			}
-			if(fitlm->rng[i].qflg)
-			{
-				vbin = (vel/100);
-				tbin = (t_d/10)-1;
-				num[vbin][tbin][2] += 1.;
-
-				lm_v_err[n_lm] = fabs((double)vel-fitlm->rng[i].v);
-				lm_t_err[n_lm] = fabs((double)t_d*1.e-3-lambda/(fitlm->rng[i].w_l*2.*3.14159))/((double)t_d*1.e-3);
-
-				errors[vbin][tbin][2][0] += pow((double)vel-fitlm->rng[i].v,2); /*lmfit*/
-				errors[vbin][tbin][2][1] += fitlm->rng[i].v-(double)vel;  /*lmfit*/
-				errors[vbin][tbin][2][2] += pow((double)t_d*1.e-3-lambda/(fitlm->rng[i].w_l*2.*3.14159),2); /*lmfit*/
-				errors[vbin][tbin][2][3] += lambda/(fitlm->rng[i].w_l*2.*3.14159)-(double)t_d*1.e-3; /*lmfit*/
+        /*rms velocity*/
+        errors[vbin][tbin][0][0] += pow((double)vel-fitacf->rng[i].v,2);
+        /*true velocity*/
+        errors[vbin][tbin][0][1] += fitacf->rng[i].v-(double)vel;
+        errors[vbin][tbin][0][2] += pow((double)t_d*1.e-3-lambda/(fitacf->rng[i].w_l*2.*3.14159),2);
 
 
-				/*lmfit
-				t_if = lambda/(fitlm->rng[i].w_l*2.*3.14159);
-				f_if = 4.*3.14159*fitlm->rng[i].v/lambda;
-				noise = prm3->noise.mean;
-				p0 = noise*pow(10.,fitlm->rng[i].p_l/10.)-noise;
-				acferr = 0.;
-				for(j=0;j<prm3->mplgs;j++)
-				{
-					lag = fabs(prm3->lag[0][j]-prm3->lag[1][j]);
-					tau = lag*prm3->mpinc*1.e-6;
-					re = raw1->acfd[0][i*prm3->mplgs+j]/(10000./pow(i+1,2));
-					im = raw1->acfd[1][i*prm3->mplgs+j]/(10000./pow(i+1,2));
-					ref = p0*exp(-1.0*tau/t_if)*cos(tau*f_if)/(10000./pow(i+1,2));
-					imf = p0*exp(-1.0*tau/t_if)*sin(tau*f_if)/(10000./pow(i+1,2));
-					acferr += (pow(re-ref,2) + pow(im-imf,2));
-				}
-				acferr /= prm3->mplgs;
-				acferr = sqrt(acferr);*/
-				acferr = calc_acf_err(raw3,fitlm,prm3,i);
-				errors[vbin][tbin][2][4] += acferr;
-				lm_f_err[n_lm] = acferr;
-				n_lm++;
-			}
-			/*check for 3 good fits*/
-			if(fitacf->rng[i].qflg && fitex->rng[i].qflg && fitlm->rng[i].qflg )
-			{
-				n++;
-				vbin = (vel/100);
-				tbin = (t_d/10)-1;
+        if(pow((double)t_d*1.e-3-lambda/(fitacf->rng[i].w_l*2.*3.14159),2) > 999999.) exit(-1);
+        /*calc ACFERR
+        t_if = lambda/(fitacf->rng[i].w_l*2.*3.14159);
+        f_if = 4.*3.14159*fitacf->rng[i].v/lambda;
+        noise = fitacf->rng[i].phi0_err;
+        p0 = noise*pow(10.,fitacf->rng[i].p_l/10.)-noise;
+        acferr = 0.;
+        for(j=0;j<prm1->mplgs;j++)
+        {
+          lag = fabs(prm1->lag[0][j]-prm1->lag[1][j]);
+          tau = lag*prm1->mpinc*1.e-6;
+          re = raw1->acfd[0][i*prm1->mplgs+j]/(10000./pow(i+1,2));
+          im = raw1->acfd[1][i*prm1->mplgs+j]/(10000./pow(i+1,2));
+          ref = p0*exp(-1.0*tau/t_if)*cos(tau*f_if)/(10000./pow(i+1,2));
+          imf = p0*exp(-1.0*tau/t_if)*sin(tau*f_if)/(10000./pow(i+1,2));
+          acferr += (pow(re-ref,2) + pow(im-imf,2));
+        }
+        acferr /= prm1->mplgs;
+        acferr = sqrt(acferr);*/
+        acferr = calc_acf_err(raw1,fitacf,prm1,i);
+        errors[vbin][tbin][0][4] += acferr;
+        acf_f_err[n_acf] = acferr;
+        n_acf++;
+      }
+      if(fitex->rng[i].qflg)
+      {
+        vbin = (vel/100);
+        tbin = (t_d/10)-1;
+        num[vbin][tbin][1] += 1.;
 
-				if(fabs(fitacf->rng[i].v-(double)vel) < fabs(fitex->rng[i].v-(double)vel) &&
-					fabs(fitacf->rng[i].v-(double)vel) < fabs(fitlm->rng[i].v-(double)vel))
-					one++;
+        ex_v_err[n_ex] = fabs((double)vel-fitex->rng[i].v);
+        ex_t_err[n_ex] = fabs((double)t_d*1.e-3-lambda/(fitex->rng[i].w_l*2.*3.14159))/((double)t_d*1.e-3);
 
-				else if(fabs(fitex->rng[i].v-(double)vel) < fabs(fitacf->rng[i].v-(double)vel) &&
-					fabs(fitex->rng[i].v-(double)vel) < fabs(fitlm->rng[i].v-(double)vel))
-					two++;
+        errors[vbin][tbin][1][0] += pow((double)vel-fitex->rng[i].v,2); /*fitex2*/
+        errors[vbin][tbin][1][1] += fitex->rng[i].v-(double)vel;  /*fitex2*/
+        errors[vbin][tbin][1][2] += pow((double)t_d*1.e-3-lambda/(fitex->rng[i].w_l*2.*3.14159),2); /*fitex2*/
+        errors[vbin][tbin][1][3] += lambda/(fitex->rng[i].w_l*2.*3.14159)-(double)t_d*1.e-3; /*fitex2*/
 
-				else if(fabs(fitlm->rng[i].v-(double)vel) < fabs(fitacf->rng[i].v-(double)vel) &&
-					fabs(fitlm->rng[i].v-(double)vel) < fabs(fitex->rng[i].v-(double)vel))
-					three++;
-			}
-		}
+        /*fitex2*/
+        t_if = lambda/(fitex->rng[i].w_l*2.*3.14159);
+        f_if = 4.*3.14159*fitex->rng[i].v/lambda;
+        noise = prm2->noise.mean;
+        p0 = noise*pow(10.,fitex->rng[i].p_l/10.)-noise;
+        acferr = 0.;
+        for(j=0;j<prm2->mplgs;j++)
+        {
+          lag = fabs(prm2->lag[0][j]-prm2->lag[1][j]);
+          tau = lag*prm2->mpinc*1.e-6;
+          re = raw2->acfd[0][i*prm2->mplgs+j]/(10000./pow(i+1,2));
+          im = raw2->acfd[1][i*prm2->mplgs+j]/(10000./pow(i+1,2));
+          ref = p0*exp(-1.0*tau/t_if)*cos(tau*f_if)/(10000./pow(i+1,2));
+          imf = p0*exp(-1.0*tau/t_if)*sin(tau*f_if)/(10000./pow(i+1,2));
+          acferr += (pow(re-ref,2) + pow(im-imf,2));
+        }
+        acferr /= prm2->mplgs;
+        acferr = sqrt(acferr);
+        acferr = calc_acf_err(raw2,fitex,prm2,i);
+        errors[vbin][tbin][1][4] += acferr;
+
+        ex_f_err[n_ex] = acferr;
+        n_ex++;
+      }
+      if(fitlm->rng[i].qflg)
+      {
+        vbin = (vel/100);
+        tbin = (t_d/10)-1;
+        num[vbin][tbin][2] += 1.;
+
+        lm_v_err[n_lm] = fabs((double)vel-fitlm->rng[i].v);
+        lm_t_err[n_lm] = fabs((double)t_d*1.e-3-lambda/(fitlm->rng[i].w_l*2.*3.14159))/((double)t_d*1.e-3);
+
+        errors[vbin][tbin][2][0] += pow((double)vel-fitlm->rng[i].v,2); /*lmfit*/
+        errors[vbin][tbin][2][1] += fitlm->rng[i].v-(double)vel;  /*lmfit*/
+        errors[vbin][tbin][2][2] += pow((double)t_d*1.e-3-lambda/(fitlm->rng[i].w_l*2.*3.14159),2); /*lmfit*/
+        errors[vbin][tbin][2][3] += lambda/(fitlm->rng[i].w_l*2.*3.14159)-(double)t_d*1.e-3; /*lmfit*/
+
+
+        /*lmfit
+        t_if = lambda/(fitlm->rng[i].w_l*2.*3.14159);
+        f_if = 4.*3.14159*fitlm->rng[i].v/lambda;
+        noise = prm3->noise.mean;
+        p0 = noise*pow(10.,fitlm->rng[i].p_l/10.)-noise;
+        acferr = 0.;
+        for(j=0;j<prm3->mplgs;j++)
+        {
+          lag = fabs(prm3->lag[0][j]-prm3->lag[1][j]);
+          tau = lag*prm3->mpinc*1.e-6;
+          re = raw1->acfd[0][i*prm3->mplgs+j]/(10000./pow(i+1,2));
+          im = raw1->acfd[1][i*prm3->mplgs+j]/(10000./pow(i+1,2));
+          ref = p0*exp(-1.0*tau/t_if)*cos(tau*f_if)/(10000./pow(i+1,2));
+          imf = p0*exp(-1.0*tau/t_if)*sin(tau*f_if)/(10000./pow(i+1,2));
+          acferr += (pow(re-ref,2) + pow(im-imf,2));
+        }
+        acferr /= prm3->mplgs;
+        acferr = sqrt(acferr);*/
+        acferr = calc_acf_err(raw3,fitlm,prm3,i);
+        errors[vbin][tbin][2][4] += acferr;
+        lm_f_err[n_lm] = acferr;
+        n_lm++;
+      }
+      /*check for 3 good fits*/
+      if(fitacf->rng[i].qflg && fitex->rng[i].qflg && fitlm->rng[i].qflg )
+      {
+        n++;
+        vbin = (vel/100);
+        tbin = (t_d/10)-1;
+
+        if(fabs(fitacf->rng[i].v-(double)vel) < fabs(fitex->rng[i].v-(double)vel) &&
+          fabs(fitacf->rng[i].v-(double)vel) < fabs(fitlm->rng[i].v-(double)vel))
+          one++;
+
+        else if(fabs(fitex->rng[i].v-(double)vel) < fabs(fitacf->rng[i].v-(double)vel) &&
+          fabs(fitex->rng[i].v-(double)vel) < fabs(fitlm->rng[i].v-(double)vel))
+          two++;
+
+        else if(fabs(fitlm->rng[i].v-(double)vel) < fabs(fitacf->rng[i].v-(double)vel) &&
+          fabs(fitlm->rng[i].v-(double)vel) < fabs(fitex->rng[i].v-(double)vel))
+          three++;
+      }
+    }
 
     status=RawFread(fpa,prm1,raw1);
-		status=RawFread(fpb,prm2,raw2);
-		status=RawFread(fpc,prm3,raw3);
+    status=RawFread(fpb,prm2,raw2);
+    status=RawFread(fpc,prm3,raw3);
 
     if (vb)
       fprintf(stderr,"%d-%d-%d %d:%d:%d beam=%d\n",prm1->time.yr,prm1->time.mo,
-	     prm1->time.dy,prm1->time.hr,prm1->time.mt,prm1->time.sc,prm1->bmnum);
+             prm1->time.dy,prm1->time.hr,prm1->time.mt,prm1->time.sc,prm1->bmnum);
 
     if (status==0)
-		{
-			FitACF(prm1,raw1,fblkacf,fitacf);
-			fitacfex2(prm2,raw2,fitex,fblkex,0);
-			lmfit(prm3,raw3,fitlm,fblklm,0);
-		}
+    {
+      FitACF(prm1,raw1,fblkacf,fitacf);
+      fitacfex2(prm2,raw2,fitex,fblkex,0);
+      lmfit(prm3,raw3,fitlm,fblklm,0);
+    }
 
   } while (status==0 && print==0);
-	
 
-	fprintf(stderr,"number of times each had the best vel fit:\nfitacf: %d  fitex2: %d  lmfit: %d  total # of fits: %d\n",one, two, three, n);
 
-	qsort(acf_v_err, n_acf, sizeof(double), lm_dbl_cmp);
-	qsort(ex_v_err, n_ex, sizeof(double), lm_dbl_cmp);
-	qsort(lm_v_err, n_lm, sizeof(double), lm_dbl_cmp);
+  fprintf(stderr,"number of times each had the best vel fit:\nfitacf: %d  fitex2: %d  lmfit: %d  total # of fits: %d\n",one, two, three, n);
 
-	for(i=0;i<n_acf;i++)
-		mean_v_acf += acf_v_err[i];
-	mean_v_acf /= (double)n_acf;
+  qsort(acf_v_err, n_acf, sizeof(double), lm_dbl_cmp);
+  qsort(ex_v_err, n_ex, sizeof(double), lm_dbl_cmp);
+  qsort(lm_v_err, n_lm, sizeof(double), lm_dbl_cmp);
 
-	for(i=0;i<n_ex;i++)
-		mean_v_ex += ex_v_err[i];
-	mean_v_ex /= (double)n_ex;
+  for(i=0;i<n_acf;i++)
+    mean_v_acf += acf_v_err[i];
+  mean_v_acf /= (double)n_acf;
 
-	for(i=0;i<n_lm;i++)
-		mean_v_lm += lm_v_err[i];
-	mean_v_lm /= (double)n_lm;
+  for(i=0;i<n_ex;i++)
+    mean_v_ex += ex_v_err[i];
+  mean_v_ex /= (double)n_ex;
 
-	qsort(acf_t_err, n_acf, sizeof(double), lm_dbl_cmp);
-	qsort(ex_t_err, n_ex, sizeof(double), lm_dbl_cmp);
-	qsort(lm_t_err, n_lm, sizeof(double), lm_dbl_cmp);
+  for(i=0;i<n_lm;i++)
+    mean_v_lm += lm_v_err[i];
+  mean_v_lm /= (double)n_lm;
 
-	for(i=0;i<n_acf;i++)
-		mean_t_acf += acf_t_err[i];
-	mean_t_acf /= (double)n_acf;
+  qsort(acf_t_err, n_acf, sizeof(double), lm_dbl_cmp);
+  qsort(ex_t_err, n_ex, sizeof(double), lm_dbl_cmp);
+  qsort(lm_t_err, n_lm, sizeof(double), lm_dbl_cmp);
 
-	for(i=0;i<n_ex;i++)
-		mean_t_ex += ex_t_err[i];
-	mean_t_ex /= (double)n_ex;
+  for(i=0;i<n_acf;i++)
+    mean_t_acf += acf_t_err[i];
+  mean_t_acf /= (double)n_acf;
 
-	for(i=0;i<n_lm;i++)
-		mean_t_lm += lm_t_err[i];
-	mean_t_lm /= (double)n_lm;
+  for(i=0;i<n_ex;i++)
+    mean_t_ex += ex_t_err[i];
+  mean_t_ex /= (double)n_ex;
 
-	qsort(acf_f_err, n_acf, sizeof(double), lm_dbl_cmp);
-	qsort(ex_f_err, n_ex, sizeof(double), lm_dbl_cmp);
-	qsort(lm_f_err, n_lm, sizeof(double), lm_dbl_cmp);
+  for(i=0;i<n_lm;i++)
+    mean_t_lm += lm_t_err[i];
+  mean_t_lm /= (double)n_lm;
 
-	for(i=0;i<n_acf;i++)
-		mean_f_acf += acf_f_err[i];
-	mean_f_acf /= (double)n_acf;
+  qsort(acf_f_err, n_acf, sizeof(double), lm_dbl_cmp);
+  qsort(ex_f_err, n_ex, sizeof(double), lm_dbl_cmp);
+  qsort(lm_f_err, n_lm, sizeof(double), lm_dbl_cmp);
 
-	for(i=0;i<n_ex;i++)
-		mean_f_ex += ex_f_err[i];
-	mean_f_ex /= (double)n_ex;
+  for(i=0;i<n_acf;i++)
+    mean_f_acf += acf_f_err[i];
+  mean_f_acf /= (double)n_acf;
 
-	for(i=0;i<n_lm;i++)
-		mean_f_lm += lm_f_err[i];
-	mean_f_lm /= (double)n_lm;
+  for(i=0;i<n_ex;i++)
+    mean_f_ex += ex_f_err[i];
+  mean_f_ex /= (double)n_ex;
 
-	fprintf(stderr,"           acf        ex        lm\n");
-	fprintf(stderr,"number:    %ld      %ld      %ld\n",n_acf,n_ex,n_lm);
-	fprintf(stderr,"v median:  %lf   %lf   %lf\n",acf_v_err[(int)(n_acf/2)],ex_v_err[(int)(n_ex/2)],lm_v_err[(int)(n_lm/2)]);
-	fprintf(stderr,"v mean:    %lf   %lf   %lf\n",mean_v_acf,mean_v_ex,mean_v_lm);
-	fprintf(stderr,"t median:  %lf   %lf   %lf\n",acf_t_err[(int)(n_acf/2)],ex_t_err[(int)(n_ex/2)],lm_t_err[(int)(n_lm/2)]);
-	fprintf(stderr,"t mean:    %lf   %lf   %lf\n",mean_t_acf,mean_t_ex,mean_t_lm);
-	fprintf(stderr,"f median:  %lf   %lf   %lf\n",acf_f_err[(int)(n_acf/2)],ex_f_err[(int)(n_ex/2)],lm_f_err[(int)(n_lm/2)]);
-	fprintf(stderr,"f mean:    %lf   %lf   %lf\n",mean_f_acf,mean_f_ex,mean_f_lm);
+  for(i=0;i<n_lm;i++)
+    mean_f_lm += lm_f_err[i];
+  mean_f_lm /= (double)n_lm;
 
-	for(i=0;i<20;i++)
-		for(j=0;j<10;j++)
-			for(k=0;k<5;k++)
-				if(k % 2 == 0)
-					fprintf(stdout,"%f  %f  %d  %lf  %lf  %lf  %lf\n",i*100.+50.,(j+1)*1.e-2,k,
-									sqrt(errors[i][j][0][k]/num[i][j][0]),sqrt(errors[i][j][1][k]/num[i][j][1]),sqrt(errors[i][j][2][k]/num[i][j][2]),num[i][j][2]);
-				else
-					fprintf(stdout,"%f  %f  %d  %lf  %lf  %lf  %lf\n",i*100.+50.,(j+1)*1.e-2,k,
-									errors[i][j][0][k]/num[i][j][0],errors[i][j][1][k]/num[i][j][1],errors[i][j][2][k]/num[i][j][2],num[i][j][2]);
+  fprintf(stderr,"           acf        ex        lm\n");
+  fprintf(stderr,"number:    %ld      %ld      %ld\n",n_acf,n_ex,n_lm);
+  fprintf(stderr,"v median:  %lf   %lf   %lf\n",acf_v_err[(int)(n_acf/2)],ex_v_err[(int)(n_ex/2)],lm_v_err[(int)(n_lm/2)]);
+  fprintf(stderr,"v mean:    %lf   %lf   %lf\n",mean_v_acf,mean_v_ex,mean_v_lm);
+  fprintf(stderr,"t median:  %lf   %lf   %lf\n",acf_t_err[(int)(n_acf/2)],ex_t_err[(int)(n_ex/2)],lm_t_err[(int)(n_lm/2)]);
+  fprintf(stderr,"t mean:    %lf   %lf   %lf\n",mean_t_acf,mean_t_ex,mean_t_lm);
+  fprintf(stderr,"f median:  %lf   %lf   %lf\n",acf_f_err[(int)(n_acf/2)],ex_f_err[(int)(n_ex/2)],lm_f_err[(int)(n_lm/2)]);
+  fprintf(stderr,"f mean:    %lf   %lf   %lf\n",mean_f_acf,mean_f_ex,mean_f_lm);
 
-	/*for(i=0;i<20;i++)
-		fprintf(stderr,"%d  %d  %d  %d\n",i,very_bad[i][0],very_bad[i][1],very_bad[i][2]);
+  for(i=0;i<20;i++)
+    for(j=0;j<10;j++)
+      for(k=0;k<5;k++)
+        if(k % 2 == 0)
+          fprintf(stdout,"%f  %f  %d  %lf  %lf  %lf  %lf\n",i*100.+50.,(j+1)*1.e-2,k,
+                sqrt(errors[i][j][0][k]/num[i][j][0]),sqrt(errors[i][j][1][k]/num[i][j][1]),sqrt(errors[i][j][2][k]/num[i][j][2]),num[i][j][2]);
+        else
+          fprintf(stdout,"%f  %f  %d  %lf  %lf  %lf  %lf\n",i*100.+50.,(j+1)*1.e-2,k,
+                errors[i][j][0][k]/num[i][j][0],errors[i][j][1][k]/num[i][j][1],errors[i][j][2][k]/num[i][j][2],num[i][j][2]);
 
-	fprintf(stderr,"%d  %d\n",n,n2);*/
+  /*for(i=0;i<20;i++)
+    fprintf(stderr,"%d  %d  %d  %d\n",i,very_bad[i][0],very_bad[i][1],very_bad[i][2]);
 
-	for(i=0;i<20;i++)
-	{
-		for(j=0;j<10;j++)
-			free(num[i][j]);
-		free(num[i]);
-	}
-	free(num[i]);
+  fprintf(stderr,"%d  %d\n",n,n2);*/
 
-	for(i=0;i<20;i++)
-	{
-		for(j=0;j<10;j++)
-		{
-			for(k=0;k<3;k++)
-				free(errors[i][j][k]);
-			free(errors[i][j]);
-		}
-		free(errors[i]);
-	}
-	free(errors);
+  for(i=0;i<20;i++)
+  {
+    for(j=0;j<10;j++)
+      free(num[i][j]);
+    free(num[i]);
+  }
+  free(num[i]);
 
-	free(very_bad);
-	FitACFFree(fblkacf);
+  for(i=0;i<20;i++)
+  {
+    for(j=0;j<10;j++)
+    {
+      for(k=0;k<3;k++)
+        free(errors[i][j][k]);
+      free(errors[i][j]);
+    }
+    free(errors[i]);
+  }
+  free(errors);
+
+  free(very_bad);
+  FitACFFree(fblkacf);
   FitACFFree(fblklm);
-	FitACFFree(fblkex);
-	
-	system("rm f1.rawacf");
-	system("rm f2.rawacf");
-	system("rm f3.rawacf");
-	
-	
+  FitACFFree(fblkex);
+
+  system("rm f1.rawacf");
+  system("rm f2.rawacf");
+  system("rm f3.rawacf");
+
+
   return 0;
 }
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/codebase/superdarn/src.bin/tk/testing/fitcomp.1.0/fitcomp.c
+++ b/codebase/superdarn/src.bin/tk/testing/fitcomp.1.0/fitcomp.c
@@ -500,7 +500,7 @@ int main(int argc,char *argv[])
 	mean_f_lm /= (double)n_lm;
 
 	fprintf(stderr,"           acf        ex        lm\n");
-	fprintf(stderr,"number:    %d      %d      %d\n",n_acf,n_ex,n_lm);
+	fprintf(stderr,"number:    %ld      %ld      %ld\n",n_acf,n_ex,n_lm);
 	fprintf(stderr,"v median:  %lf   %lf   %lf\n",acf_v_err[(int)(n_acf/2)],ex_v_err[(int)(n_ex/2)],lm_v_err[(int)(n_lm/2)]);
 	fprintf(stderr,"v mean:    %lf   %lf   %lf\n",mean_v_acf,mean_v_ex,mean_v_lm);
 	fprintf(stderr,"t median:  %lf   %lf   %lf\n",acf_t_err[(int)(n_acf/2)],ex_t_err[(int)(n_ex/2)],lm_t_err[(int)(n_lm/2)]);

--- a/codebase/superdarn/src.bin/tk/tool/lagfr_fix.1.0/lagfr_fix.c
+++ b/codebase/superdarn/src.bin/tk/tool/lagfr_fix.1.0/lagfr_fix.c
@@ -64,10 +64,10 @@ int main(int argc,char *argv[])
   unsigned char vb=0;
 
   FILE *fp=NULL;
-  struct OldRawFp *rawfp=NULL;
+/*  struct OldRawFp *rawfp=NULL;
   int irec=1;
   int drec=2;
-  int dnum=0;
+  int dnum=0; */
 
   time_t ctime;
   int c,n,samps=0;

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
@@ -199,7 +199,7 @@ int main(int argc,char *argv[])
 
   /*other variables*/
   long i,j;
-  int output = 0;
+  /*int output = 0;*/
   double taus;
 
   char helpstr[] =
@@ -560,7 +560,7 @@ int main(int argc,char *argv[])
       }
     }
 
-    int * badtr = malloc(nave*n_pul*2*sizeof(int));
+    unsigned int * badtr = malloc(nave*n_pul*2*sizeof(int));
 
     IQFwrite(stdout,prm,iq,badtr,samples);
     free(samples);
@@ -582,7 +582,7 @@ int main(int argc,char *argv[])
   {
     fprintf(stdout,"%lf  %lf\n",creal(raw_samples[i]),cimag(raw_samples[i]));
   }
-  /*print the ACFs
+  print the ACFs
   for(r=0;r<nrang;r++)
   {
     fprintf(stdout,"%d  %d\n",r,qflg[r]);

--- a/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
+++ b/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
@@ -450,7 +450,7 @@ int main(int argc,char *argv[])
 				}
 			}
 
-			int * badtr = malloc(nave*n_pul*2*sizeof(int));
+			unsigned int * badtr = malloc(nave*n_pul*2*sizeof(int));
 
 			IQFwrite(stdout,prm,iq,badtr,samples);
 			free(samples);

--- a/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
+++ b/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
@@ -260,9 +260,9 @@ int main(int argc,char *argv[])
 	do
 	{
 
-		rt = fscanf(fitfp,"%d  %d  %d  %d  %d  %d\n",&prm->time.yr,&prm->time.mo,&prm->time.dy,&prm->time.hr,&prm->time.mt,&prm->time.sc);
+		rt = fscanf(fitfp,"%hd  %hd  %hd  %hd  %hd  %hd\n",&prm->time.yr,&prm->time.mo,&prm->time.dy,&prm->time.hr,&prm->time.mt,&prm->time.sc);
 		fprintf(stderr,"%d  %d  %d  %d  %d  %d\n",prm->time.yr,prm->time.mo,prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc);
-		rt = fscanf(fitfp,"%d  %lf  %d  %lf  %d  %d  %lf  %lf  %lf  %d\n",&cpid,&freq,&prm->bmnum,&noise_lev,&nave,&lagfr,&dt,&smsep,&rngsep,&nrang);
+		rt = fscanf(fitfp,"%d  %lf  %hd  %lf  %d  %d  %lf  %lf  %lf  %d\n",&cpid,&freq,&prm->bmnum,&noise_lev,&nave,&lagfr,&dt,&smsep,&rngsep,&nrang);
 		lagfr /= smsep;
 		rngsep *= 1.e3;
 		smsep *= 1.e-6;

--- a/codebase/superdarn/src.dlm/iqdlm.1.6/iqidl.c
+++ b/codebase/superdarn/src.dlm/iqdlm.1.6/iqidl.c
@@ -127,7 +127,7 @@ struct IQIDL *IDLMakeIQ(IDL_VPTR *vptr) {
            
   ilDims[0]=1;
   
-  return (struct IQIDLData *) IDL_MakeTempStruct(s,1,ilDims,vptr,TRUE);
+  return (struct IQIDL *) IDL_MakeTempStruct(s,1,ilDims,vptr,TRUE);
   
 }
 

--- a/codebase/superdarn/src.lib/tk/cfit.1.19/src/cfitwrite.c
+++ b/codebase/superdarn/src.lib/tk/cfit.1.19/src/cfitwrite.c
@@ -41,7 +41,7 @@
 #include "cfitdata.h"
 #include "cfitread.h"
 
-int CFitWrite(gzFile *fp,struct CFitdata *ptr) {
+int CFitWrite(gzFile fp,struct CFitdata *ptr) {
   int i=0;
   unsigned char gsct;
   if (ConvertWriteIntZ(fp,ptr->version.major) !=0) return -1;

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.c
@@ -716,7 +716,7 @@ double ACF_cutoff_pwr(FITPRMS *fit_prms){
 Removes ACFs entirely from analysis if they are deemed to be pure noise
 */
 void Filter_Bad_ACFs(FITPRMS *fit_prms, llist ranges, double noise_pwr){
-	int i=0;
+/*	int i=0;*/
 	RANGENODE* range_node = NULL;
 	PWRNODE* pwr_node = NULL;
 	double tmp_pwr = 0.0;
@@ -995,7 +995,7 @@ the phase for fitting.
 void ACF_Phase_Unwrap(llist_node range, FITPRMS* fit_prms){
 	RANGENODE* range_node;
 	PHASENODE* phase_curr;
-	PHASENODE* phase_prev;
+/*	PHASENODE* phase_prev;*/
 	PHASENODE* local_copy;
 
 	double d_phi,sigma_bar,d_tau;

--- a/codebase/superdarn/src.lib/tk/fitacfex2.1.0/src/fitacfex2.c
+++ b/codebase/superdarn/src.lib/tk/fitacfex2.1.0/src/fitacfex2.c
@@ -10,9 +10,11 @@
 #include <stdlib.h>
 #include <time.h>
 #include <math.h>
+#include <zlib.h>
 #include "rtypes.h"
 #include "rmath.h"
 #include "nrfit.h"
+#include "dmap.h"
 #include "rprm.h"
 #include "rawdata.h"
 #include "fitdata.h"

--- a/codebase/superdarn/src.lib/tk/idl/cnvmapidl.1.3/src/cnvmapidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/cnvmapidl.1.3/src/cnvmapidl.c
@@ -419,7 +419,7 @@ struct CnvMapIDLBnd *IDLMakeCnvMapBnd(int num,IDL_VPTR *vptr) {
    s=IDL_MakeStruct("CNVMAPBND",cnvmapbnd);  
    idim[0]=num;
 
-   return (struct CnvMapyIDLBnd *) IDL_MakeTempStruct(s,1,idim,vptr,TRUE);
+   return (struct CnvMapIDLBnd *) IDL_MakeTempStruct(s,1,idim,vptr,TRUE);
 }
   
 

--- a/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
+++ b/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
@@ -224,7 +224,7 @@ int singlefit(int m, int n, double *p, double *deviates,
 {
 
   int i;
-  double tau,re,im,sig,wi,ti;
+  double tau,re,sig,wi,ti;
 
   struct datapoints *v = (struct datapoints *) private;
   double lag0mag = v->mag;

--- a/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
+++ b/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
@@ -13,6 +13,7 @@
 #include "rtypes.h"
 #include "rmath.h" 
 #include "nrfit.h" 
+#include "dmap.h"
 #include "rprm.h"
 #include "rawdata.h" 
 #include "fitdata.h"


### PR DESCRIPTION
This pull request reduces the total number of compiler warning messages on the develop branch from 285 to ~~191~~ 150 by fixing numerous typos and pointer issues, particularly within the dmap library and functions using zlib.  This pull request also clears up 87 `note: expected ... but argument is of type ...` messages associated with some of those compiler warnings.

Of the ~~191~~ 150 remaining compiler warnings, here is the breakdown:

- 83: variable ... set but not used
- 33: ignoring return value of ...
- 24: ... defined but not used
- ~~12~~ ~~3: ... may be used uninitialized in this function~~ (fixed in #149)
- ~~12: unused variable ...~~
- 10: dereferencing type-punned pointer will break strict aliasing rules
- ~~10: format '%X' expects argument of type 'Y', but argument Z has type ...~~
-  ~~4: ... declared inside parameter list~~
-  ~~2: its scope is only this definition or declaration, which is probably not what you want~~