### PR TITLE
Check for zero-length records in dat files

### DIFF
--- a/codebase/superdarn/src.bin/tk/testing/cmpraw.1.6/raw_open.c
+++ b/codebase/superdarn/src.bin/tk/testing/cmpraw.1.6/raw_open.c
@@ -75,7 +75,7 @@ struct rawfp *raw_open(char *rawfile,char *inxfile) {
   }
   fstat(ptr->rawfp,&ptr->rstat);
 
-  if (ConvertReadShort(ptr->rawfp,&num_byte) !=0) {
+  if (ConvertReadShort(ptr->rawfp,&num_byte) !=0 || num_byte <= 0) {
     close(ptr->rawfp);
     free(ptr);
     free(inbuf);
@@ -105,7 +105,7 @@ struct rawfp *raw_open(char *rawfile,char *inxfile) {
      the file */
 
   
- if (ConvertReadShort(ptr->rawfp,&num_byte) !=0) {
+ if (ConvertReadShort(ptr->rawfp,&num_byte) !=0 || num_byte <= 0) {
     close(ptr->rawfp);
     free(ptr);
     free(inbuf);

--- a/codebase/superdarn/src.bin/tk/testing/cmpraw.1.6/raw_read_current.c
+++ b/codebase/superdarn/src.bin/tk/testing/cmpraw.1.6/raw_read_current.c
@@ -85,7 +85,7 @@ int raw_read_current(struct rawfp *fp,struct rawdata *raw_data) {
    memset(raw_data,0,sizeof(struct rawdata));
    fp->rlen=0;
    do {
-     if (ConvertReadShort(fp->rawfp,&num_byte) !=0) {
+     if (ConvertReadShort(fp->rawfp,&num_byte) !=0 || num_byte <= 0) {
        free(inbuf);
        return -1;
      }

--- a/codebase/superdarn/src.idl/lib/main.1.25/oldraw.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/oldraw.pro
@@ -438,7 +438,7 @@ ON_IOERROR,iofail
   readu,rawfp.rawunit,rechdr
 
   ; Make sure the record size is non-zero
-  if rechdr.size eq 0 then return,-1
+  if rechdr.size le 0 then return,-1
 
   num_byte=rechdr.size
   rawfp.rlen=rechdr.size

--- a/codebase/superdarn/src.idl/lib/main.1.25/oldraw.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/oldraw.pro
@@ -436,7 +436,10 @@ ON_IOERROR,iofail
   OldRawMakeOldRawRadarParm,rparm
 
   readu,rawfp.rawunit,rechdr
- 
+
+  ; Make sure the record size is non-zero
+  if rechdr.size eq 0 then return,-1
+
   num_byte=rechdr.size
   rawfp.rlen=rechdr.size
   rawfp.ptr+=rechdr.size

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/src/rawopen.c
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/src/rawopen.c
@@ -84,7 +84,7 @@ struct OldRawFp *OldRawOpenFd(int rawfd,int inxfd) {
 
   fstat(ptr->rawfp,&ptr->rstat);
 
-  if (ConvertReadShort(ptr->rawfp,&num_byte) !=0) {
+  if (ConvertReadShort(ptr->rawfp,&num_byte) !=0 || num_byte <= 0) {
     close(ptr->rawfp);
     free(ptr);
     free(inbuf);
@@ -140,7 +140,7 @@ struct OldRawFp *OldRawOpenFd(int rawfd,int inxfd) {
      the file */
 
   
- if (ConvertReadShort(ptr->rawfp,&num_byte) !=0) {
+  if (ConvertReadShort(ptr->rawfp,&num_byte) !=0 || num_byte <= 0) {
     close(ptr->rawfp);
     free(ptr);
     free(inbuf);

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/src/rawreadcurrent.c
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/src/rawreadcurrent.c
@@ -100,7 +100,8 @@ int OldRawReadCurrent(struct OldRawFp *fp,struct RadarParm *prm,
    memset(rptr,0,sizeof(struct rawdata));
    fp->rlen=0;
    do {
-     if (ConvertReadShort(fp->rawfp,&num_byte) !=0) {
+     stat = ConvertReadShort(fp->rawfp,&num_byte);
+     if (stat != 0 || num_byte == 0) {
        free(inbuf);
        return -1;
      }

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/src/rawreadcurrent.c
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/src/rawreadcurrent.c
@@ -100,8 +100,7 @@ int OldRawReadCurrent(struct OldRawFp *fp,struct RadarParm *prm,
    memset(rptr,0,sizeof(struct rawdata));
    fp->rlen=0;
    do {
-     stat = ConvertReadShort(fp->rawfp,&num_byte);
-     if (stat != 0 || num_byte == 0) {
+     if (ConvertReadShort(fp->rawfp,&num_byte) != 0 || num_byte <= 0) {
        free(inbuf);
        return -1;
      }


### PR DESCRIPTION
This pull request addresses issue #116 where early dat files caused buffer overflows due to zero-length records at the end of the files.  Fixes are made to `OldRawRead` in the IDL `oldraw.pro` file and `OldRawReadCurrent` in the C oldraw library.  As noted in #116, we may also need to add similar checks to the `cmpraw` binary and `OldRawOpenFd` in the oldraw library.

Strangely, the rawfp structures returned by the native IDL and DLM versions of OldRawRead do not match.  Not sure that it's worth focusing any time/resources on addressing but thought it should at least be pointed out.