### PR TITLE
Add 16-bit png support to fbuffer library

### DIFF
--- a/codebase/base/src.lib/graphic/fbuffer.1.19/src/png.c
+++ b/codebase/base/src.lib/graphic/fbuffer.1.19/src/png.c
@@ -1,4 +1,4 @@
-/* ppm.c
+/* png.c
    ===== 
    Author: R.J.Barnes
 */
@@ -96,7 +96,11 @@ struct FrameBuffer *FrameBufferLoadPNG(FILE *fp,char *name) {
     break;
   }
 
-  if (png_get_color_type(pngptr, infoptr) != 8) {
+  if (png_get_bit_depth(pngptr, infoptr) == 16) {
+    png_set_strip_16(pngptr);
+  }
+
+  if (png_get_bit_depth(pngptr, infoptr) <= 8) {
     png_destroy_read_struct(&pngptr,&infoptr,NULL);
     return NULL;
   }

--- a/codebase/base/src.lib/graphic/fbuffer.1.19/src/png.c
+++ b/codebase/base/src.lib/graphic/fbuffer.1.19/src/png.c
@@ -100,7 +100,7 @@ struct FrameBuffer *FrameBufferLoadPNG(FILE *fp,char *name) {
     png_set_strip_16(pngptr);
   }
 
-  if (png_get_bit_depth(pngptr, infoptr) <= 8) {
+  if (png_get_bit_depth(pngptr, infoptr) < 8) {
     png_destroy_read_struct(&pngptr,&infoptr,NULL);
     return NULL;
   }


### PR DESCRIPTION
This pull request adds support for 16-bit png images to the fbuffer library in png.c by using the png_set_strip_16() to strip pixels down to 8 bit. Have also changed a call to png_get_color_type() to png_get_bit_depth() for determining whether an image is 16 or 8 bit.

This change can be tested using the `pngd` binary for displaying a png-format image on an X-terminal:

`pngd awesome_superdarn_figure.png`

A response to the SuperDARN software survey requesting graphics support for more user-friendly formats such as png or pdf prompted this fix.