### PR TITLE
Adding documentation for make_fitex, make_fitex2, and make_lmfit binaries

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_fitex.1.4/doc/make_fitex.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_fitex.1.4/doc/make_fitex.doc.xml
@@ -20,7 +20,8 @@
 </option>
 <option><on>[<ar>inxname</ar>]</on><od>filename of the associated index file to create.</od>
 </option>
-<synopsis><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.  Phase fitting performed with 120 phase variation models.</p></synopsis>
+<synopsis><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p></synopsis>
+<synopsis><p>Phase fitting performed with 120 phase variation models.</p></synopsis>
 <description><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p>
 <p>If the "<code>-old</code>" option is not specified then the <code>fitacf</code> format file is written to standard output.</p>
 </description>

--- a/codebase/superdarn/src.bin/tk/tool/make_fitex.1.4/doc/make_fitex.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_fitex.1.4/doc/make_fitex.doc.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<binary>
+<project>superdarn</project>
+<name>make_fitex</name>
+<location>src.bin/tk/tool/make_fitex</location>
+
+<syntax>make_fitex --help</syntax>
+<syntax>make_fitex [<ar>rawacfname</ar>]</syntax>
+<syntax>make_fitex -old <ar>rawname</ar> <ar>fitname</ar> [<ar>inxname</ar>]</syntax>
+
+<option><on>--help</on><od>print the help message and exit.</od>
+</option>
+<option><on><ar>rawacfname</ar></on><od>filename of the <code>rawacf</code> format file. If this is omitted the file is read from standard input.</od>
+</option>
+<option><on>-old</on><od>input file is in <code>raw</code> (<code>dat</code>) file format and the output should be in <code>fit</code> file format.</od>
+</option>
+<option><on><ar>rawname</ar></on><od>filename of the <code>raw</code> (<code>dat</code>) format file.</od>
+</option>
+<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> format file to create.</od>
+</option>
+<option><on>[<ar>inxname</ar>]</on><od>filename of the associated index file to create.</od>
+</option>
+<synopsis><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p></synopsis>
+<description><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p>
+<p>If the "<code>-old</code>" option is not specified then the <code>fitacf</code> format file is written to standard output.</p>
+</description>
+
+<example>
+<command>make_fitex -vb 19981105.kap.rawacf &gt; 19981105.kap.fitacf</command>
+<description>Generates a fitacf file from the <code>rawacf</code> file "<code>19981105.kap.rawacf</code>" to produce a file called "<code>19981105.kap.fitacf</code>". Status is logged on standard error.</description>
+</example>
+
+<example>
+<command>make_fitex -old 19971020.gbr.dat 19971020gbr.fit 19971020.gbr.inx</command>
+<description>Generates a <code>fit</code> file from the <code>dat</code> file "<code>19971020.gbr.dat</code>" to produce a file called "<code>19971020.gbr.fit</code>" and an index file called "<code>19971020.gbr.inx</code>".</description>
+</example>
+
+</binary>

--- a/codebase/superdarn/src.bin/tk/tool/make_fitex.1.4/doc/make_fitex.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_fitex.1.4/doc/make_fitex.doc.xml
@@ -21,6 +21,7 @@
 <option><on>[<ar>inxname</ar>]</on><od>filename of the associated index file to create.</od>
 </option>
 <synopsis><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p></synopsis>
+<synopsis><p>\nPhase fitting performed with 120 phase variation models.</p></synopsis>
 <description><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p>
 <p>If the "<code>-old</code>" option is not specified then the <code>fitacf</code> format file is written to standard output.</p>
 </description>

--- a/codebase/superdarn/src.bin/tk/tool/make_fitex.1.4/doc/make_fitex.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_fitex.1.4/doc/make_fitex.doc.xml
@@ -20,8 +20,7 @@
 </option>
 <option><on>[<ar>inxname</ar>]</on><od>filename of the associated index file to create.</od>
 </option>
-<synopsis><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p></synopsis>
-<synopsis><p>\nPhase fitting performed with 120 phase variation models.</p></synopsis>
+<synopsis><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.  Phase fitting performed with 120 phase variation models.</p></synopsis>
 <description><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p>
 <p>If the "<code>-old</code>" option is not specified then the <code>fitacf</code> format file is written to standard output.</p>
 </description>

--- a/codebase/superdarn/src.bin/tk/tool/make_fitex2.1.0/doc/make_fitex2.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_fitex2.1.0/doc/make_fitex2.doc.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<binary>
+<project>superdarn</project>
+<name>make_fitex2</name>
+<location>src.bin/tk/tool/make_fitex2</location>
+
+<syntax>make_fitex2 --help</syntax>
+<syntax>make_fitex2 [<ar>rawacfname</ar>]</syntax>
+<syntax>make_fitex2 -old <ar>rawname</ar> <ar>fitname</ar> [<ar>inxname</ar>]</syntax>
+
+<option><on>--help</on><od>print the help message and exit.</od>
+</option>
+<option><on><ar>rawacfname</ar></on><od>filename of the <code>rawacf</code> format file. If this is omitted the file is read from standard input.</od>
+</option>
+<option><on>-old</on><od>input file is in <code>raw</code> (<code>dat</code>) file format and the output should be in <code>fit</code> file format.</od>
+</option>
+<option><on><ar>rawname</ar></on><od>filename of the <code>raw</code> (<code>dat</code>) format file.</od>
+</option>
+<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> format file to create.</od>
+</option>
+<option><on>[<ar>inxname</ar>]</on><od>filename of the associated index file to create.</od>
+</option>
+<synopsis><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p></synopsis>
+<description><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p>
+<p>If the "<code>-old</code>" option is not specified then the <code>fitacf</code> format file is written to standard output.</p>
+</description>
+
+<example>
+<command>make_fitex2 -vb 19981105.kap.rawacf &gt; 19981105.kap.fitacf</command>
+<description>Generates a fitacf file from the <code>rawacf</code> file "<code>19981105.kap.rawacf</code>" to produce a file called "<code>19981105.kap.fitacf</code>". Status is logged on standard error.</description>
+</example>
+
+<example>
+<command>make_fitex2 -old 19971020.gbr.dat 19971020gbr.fit 19971020.gbr.inx</command>
+<description>Generates a <code>fit</code> file from the <code>dat</code> file "<code>19971020.gbr.dat</code>" to produce a file called "<code>19971020.gbr.fit</code>" and an index file called "<code>19971020.gbr.inx</code>".</description>
+</example>
+
+</binary>

--- a/codebase/superdarn/src.bin/tk/tool/make_fitex2.1.0/doc/make_fitex2.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_fitex2.1.0/doc/make_fitex2.doc.xml
@@ -21,7 +21,7 @@
 <option><on>[<ar>inxname</ar>]</on><od>filename of the associated index file to create.</od>
 </option>
 <synopsis><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p></synopsis>
-<synopsis><p>\nUses the same 120 phase variation models from fitex(1) as an initial guess for a bisection method.</p></synopsis>
+<synopsis><p>Uses the same 120 phase variation models from fitex(1) as an initial guess for a bisection method.</p></synopsis>
 <description><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p>
 <p>If the "<code>-old</code>" option is not specified then the <code>fitacf</code> format file is written to standard output.</p>
 </description>

--- a/codebase/superdarn/src.bin/tk/tool/make_fitex2.1.0/doc/make_fitex2.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_fitex2.1.0/doc/make_fitex2.doc.xml
@@ -21,6 +21,7 @@
 <option><on>[<ar>inxname</ar>]</on><od>filename of the associated index file to create.</od>
 </option>
 <synopsis><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p></synopsis>
+<synopsis><p>\nUses the same 120 phase variation models from fitex(1) as an initial guess for a bisection method.</p></synopsis>
 <description><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p>
 <p>If the "<code>-old</code>" option is not specified then the <code>fitacf</code> format file is written to standard output.</p>
 </description>

--- a/codebase/superdarn/src.bin/tk/tool/make_lmfit.1.0/doc/make_lmfit.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_lmfit.1.0/doc/make_lmfit.doc.xml
@@ -21,7 +21,7 @@
 <option><on>[<ar>inxname</ar>]</on><od>filename of the associated index file to create.</od>
 </option>
 <synopsis><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p></synopsis>
-<synopsis><p>A model complex ACF (single component, exponential decay) is fitted to the observed one using the Levenberg-Marquardt algorithm in order to obtain lag 0 power, velocity and spectral width. For more detail see RADIO SCIENCE, VOL. 48, 274–282, doi:10.1002/rds.20031, 201.</p></synopsis>
+<synopsis><p>A model complex ACF (single component, exponential decay) is fitted to the observed one using the Levenberg-Marquardt algorithm in order to obtain lag 0 power, velocity and spectral width. For more detail see RADIO SCIENCE, VOL. 48, 274–282, doi:10.1002/rds.20031, 2013.</p></synopsis>
 <description><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p>
 <p>If the "<code>-old</code>" option is not specified then the <code>fitacf</code> format file is written to standard output.</p>
 </description>

--- a/codebase/superdarn/src.bin/tk/tool/make_lmfit.1.0/doc/make_lmfit.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_lmfit.1.0/doc/make_lmfit.doc.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<binary>
+<project>superdarn</project>
+<name>make_lmfit</name>
+<location>src.bin/tk/tool/make_lmfit</location>
+
+<syntax>make_lmfit --help</syntax>
+<syntax>make_lmfit [<ar>rawacfname</ar>]</syntax>
+<syntax>make_lmfit -old <ar>rawname</ar> <ar>fitname</ar> [<ar>inxname</ar>]</syntax>
+
+<option><on>--help</on><od>print the help message and exit.</od>
+</option>
+<option><on><ar>rawacfname</ar></on><od>filename of the <code>rawacf</code> format file. If this is omitted the file is read from standard input.</od>
+</option>
+<option><on>-old</on><od>input file is in <code>raw</code> (<code>dat</code>) file format and the output should be in <code>fit</code> file format.</od>
+</option>
+<option><on><ar>rawname</ar></on><od>filename of the <code>raw</code> (<code>dat</code>) format file.</od>
+</option>
+<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> format file to create.</od>
+</option>
+<option><on>[<ar>inxname</ar>]</on><od>filename of the associated index file to create.</od>
+</option>
+<synopsis><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p></synopsis>
+<description><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p>
+<p>If the "<code>-old</code>" option is not specified then the <code>fitacf</code> format file is written to standard output.</p>
+</description>
+
+<example>
+<command>make_lmfit -vb 19981105.kap.rawacf &gt; 19981105.kap.fitacf</command>
+<description>Generates a fitacf file from the <code>rawacf</code> file "<code>19981105.kap.rawacf</code>" to produce a file called "<code>19981105.kap.fitacf</code>". Status is logged on standard error.</description>
+</example>
+
+<example>
+<command>make_lmfit -old 19971020.gbr.dat 19971020gbr.fit 19971020.gbr.inx</command>
+<description>Generates a <code>fit</code> file from the <code>dat</code> file "<code>19971020.gbr.dat</code>" to produce a file called "<code>19971020.gbr.fit</code>" and an index file called "<code>19971020.gbr.inx</code>".</description>
+</example>
+
+</binary>

--- a/codebase/superdarn/src.bin/tk/tool/make_lmfit.1.0/doc/make_lmfit.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_lmfit.1.0/doc/make_lmfit.doc.xml
@@ -21,6 +21,7 @@
 <option><on>[<ar>inxname</ar>]</on><od>filename of the associated index file to create.</od>
 </option>
 <synopsis><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p></synopsis>
+<synopsis><p>A model complex ACF (single component, exponential decay) is fitted to the observed one using the Levenberg-Marquardt algorithm in order to obtain lag 0 power, velocity and spectral width. For more detail see RADIO SCIENCE, VOL. 48, 274–282, doi:10.1002/rds.20031, 201.</p></synopsis>
 <description><p>Creates a <code>fit</code> or <code>fitacf</code> format file from a <code>raw</code> (<code>dat</code>) or <code>rawacf</code> format file.</p>
 <p>If the "<code>-old</code>" option is not specified then the <code>fitacf</code> format file is written to standard output.</p>
 </description>


### PR DESCRIPTION
This pull request addresses @ksterne's remaining concerns from issue #113 by adding documentation for the `make_fitex`, `make_fitex2`, and `make_lmfit` binaries.  I can't speak to the actual functionality of any of those binaries (although I think there are some fundamental issues with `make_fitex` and the `fitacfex` library stemming from subsequent changes to the fit data/software structure).  Also note that I haven't added documentation for the `lagfr_fix` binary as no examples have been provided for how/when it should be used.