### PR TITLE
Fix trim_fit to allow removal of first record in fit file

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/trim_fit.1.20/trim_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/trim_fit.1.20/trim_fit.c
@@ -361,6 +361,9 @@ int main (int argc,char *argv[]) {
                             prm->time.sc+prm->time.us/1.0e6);
 
 
+    /* rewind file pointer in case we want to trim first record */
+    rewind(fp);
+
     /* skip here */
 
     if ((stime !=-1) || (sdate !=-1)) { 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fitseek.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fitseek.c
@@ -130,7 +130,8 @@ int FitSeek(int fid,
       if (ptr==NULL) break;
       tfile=FitGetTime(ptr);
       DataMapFree(ptr);
-      if (tval>=tfile) fptr=tptr;
+      /*if (tval>=tfile) fptr=tptr;*/
+      fptr=tptr;
       if (atme !=NULL) *atme=tfile;
     } 
     if (tval>tfile) return -1;

--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fitseek.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fitseek.c
@@ -45,7 +45,8 @@
 double FitGetTime(struct DataMap *ptr) {
   struct DataMapScalar *s;
   int c;
-  int yr=0,mo=0,dy=0,hr=0,mt=0,sc=0,us=0;  
+  int yr=0,mo=0,dy=0,hr=0,mt=0,sc=0;
+  int32 us=0;
   for (c=0;c<ptr->snum;c++) {
     s=ptr->scl[c];
     if ((strcmp(s->name,"time.yr")==0) && (s->type==DATASHORT)) 
@@ -60,8 +61,8 @@ double FitGetTime(struct DataMap *ptr) {
       mt=*(s->data.sptr);
     if ((strcmp(s->name,"time.sc")==0) && (s->type==DATASHORT))
       sc=*(s->data.sptr);
-    if ((strcmp(s->name,"time.us")==0) && (s->type==DATASHORT))
-      us=*(s->data.sptr);
+    if ((strcmp(s->name,"time.us")==0) && (s->type==DATAINT))
+      us=*(s->data.iptr);
    }
    if (yr==0) return -1;
    return TimeYMDHMSToEpoch(yr,mo,dy,hr,mt,sc+us/1.0e6); 

--- a/codebase/superdarn/src.lib/tk/iq.1.7/src/iqseek.c
+++ b/codebase/superdarn/src.lib/tk/iq.1.7/src/iqseek.c
@@ -45,7 +45,8 @@
 double IQGetTime(struct DataMap *ptr) {
   struct DataMapScalar *s;
   int c;
-  int yr=0,mo=0,dy=0,hr=0,mt=0,sc=0,us=0;  
+  int yr=0,mo=0,dy=0,hr=0,mt=0,sc=0;
+  int32 us=0;
   for (c=0;c<ptr->snum;c++) {
     s=ptr->scl[c];
     if ((strcmp(s->name,"time.yr")==0) && (s->type==DATASHORT)) 
@@ -60,8 +61,8 @@ double IQGetTime(struct DataMap *ptr) {
       mt=*(s->data.sptr);
     if ((strcmp(s->name,"time.sc")==0) && (s->type==DATASHORT))
       sc=*(s->data.sptr);
-    if ((strcmp(s->name,"time.us")==0) && (s->type==DATASHORT))
-      us=*(s->data.sptr);
+    if ((strcmp(s->name,"time.us")==0) && (s->type==DATAINT))
+      us=*(s->data.iptr);
    }
    if (yr==0) return -1;
    return TimeYMDHMSToEpoch(yr,mo,dy,hr,mt,sc+us/1.0e6); 

--- a/codebase/superdarn/src.lib/tk/raw.1.22/src/rawseek.c
+++ b/codebase/superdarn/src.lib/tk/raw.1.22/src/rawseek.c
@@ -46,7 +46,8 @@
 double RawGetTime(struct DataMap *ptr) {
   struct DataMapScalar *s;
   int c;
-  int yr=0,mo=0,dy=0,hr=0,mt=0,sc=0,us=0;  
+  int yr=0,mo=0,dy=0,hr=0,mt=0,sc=0;
+  int32 us=0;
   for (c=0;c<ptr->snum;c++) {
     s=ptr->scl[c];
     if ((strcmp(s->name,"time.yr")==0) && (s->type==DATASHORT)) 
@@ -61,8 +62,8 @@ double RawGetTime(struct DataMap *ptr) {
       mt=*(s->data.sptr);
     if ((strcmp(s->name,"time.sc")==0) && (s->type==DATASHORT))
       sc=*(s->data.sptr);
-    if ((strcmp(s->name,"time.us")==0) && (s->type==DATASHORT))
-      us=*(s->data.sptr);
+    if ((strcmp(s->name,"time.us")==0) && (s->type==DATAINT))
+      us=*(s->data.iptr);
    }
    if (yr==0) return -1;
    return TimeYMDHMSToEpoch(yr,mo,dy,hr,mt,sc+us/1.0e6); 


### PR DESCRIPTION
This pull request addresses a bug found by @sshepherd where `trim_fit` will not remove a record if it is the first record in a fit file and is the only one which needs to be removed.

I've also fixed a seemingly unimportant bug where the microseconds were not being correctly read by the `FitGetTime`, `RawGetTime`, and `IQGetTime` functions called by `FitSeek`, `RawSeek`, and `IQSeek` respectively.  Previously the microseconds were always set to zero by these functions because they were looking for `"time.us"` with a `DATASHORT` rather than `DATAINT` type (as the microsecond value is defined in [rprm.h.](https://github.com/SuperDARN/rst/blob/master/codebase/superdarn/src.lib/tk/radar.1.22/include/rprm.h)).