### PR TITLE
Statistical convection model solver (solve_model)

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/doc/solve_model.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/doc/solve_model.doc.xml
@@ -40,15 +40,15 @@
 </option>
 <option><on>-nointerp</on><od>Do not interpolate coeffiecients, instead use discrete models.</od>
 </option>
-<option><on>-noigrf</on><od>Do not use IGRF model to convert potential to velocities,</od></option>
-<option><on></on><od> instead use constant values.</od></option>
-<option><on>-old_aacgm</on><od>uses the older AACGM software and coefficients. The default</od></option>
-<option><on></on><od>  is to use AACGM-v2.</od></option>
-<option><on>-lat_step <ar>dlat</ar></on><od>set the latitudinal step size of the grid to <ar>dlat</ar> [degrees]. Default is 1 degree.</od>
+<option><on>-noigrf</on><od>Do not use IGRF model to convert potential to velocities, instead use constant values.</od>
 </option>
-<option><on>-lon_step <ar>dlon</ar></on><od>set the longitudinal step size of the grid to <ar>dlon</ar> [degrees]. Default is 2 degrees.</od>
+<option><on>-old_aacgm</on><od>uses the older AACGM software and coefficients. The default is to use AACGM-v2 coefficients.</od>
 </option>
-<option><on>-equal</on><od>use an equal-area grid with cell sizes defined by <ar>dlat</ar> [degrees]. Default is 1 degree in latitude.</od>
+<option><on>-lat_step <ar>dlat</ar></on><od>set the latitudinal step size of the grid to <ar>dlat</ar> [degrees]. The default value is 1 degree.</od>
+</option>
+<option><on>-lon_step <ar>dlon</ar></on><od>set the longitudinal step size of the grid to <ar>dlon</ar> [degrees]. The default value is 2 degrees.</od>
+</option>
+<option><on>-equal</on><od>use an equal-area grid with cell sizes defined by <ar>dlat</ar> [degrees]. The default value is 1 degree in latitude.</od>
 </option>
 
 <synopsis><p>Calculates the statistical model and writes it to standard output.</p></synopsis>

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/doc/solve_model.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/doc/solve_model.doc.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<binary>
+<project>superdarn</project>
+<name>solve_model</name>
+<location>src.bin/tk/tool/solve_model</location>
+
+<syntax></syntax>
+<syntax>solve_model --help</syntax>
+<syntax>solve_model [-nointerp] [-noigrf] [-rg96|-psr10|-cs10|-ts18|-ts18_kp]</syntax>
+<syntax></syntax>
+
+<option><on>--help</on><od>print the help message and exits.</od>
+</option>
+<option><on>-rg96</on><od>uses the RG96 statistical model.</od>
+</option>
+<option><on>-psr10</on><od>uses the PSR10 statistical model (equivalent to the RG05 model.)</od>
+</option>
+<option><on>-cs10</on><od>uses the CS10 statistical model.</od>
+</option>
+<option><on>-ts18</on><od>uses the TS18 statistical model [default].</od>
+</option>
+<option><on>-ts18_kp</on><od>uses the TS18-Kp statistical model.</od>
+</option>
+<option><on>-nointerp</on><od>Do not interpolate coeffiecients, instead use discrete models.</od>
+</option>
+<option><on>-noigrf</on><od>Do not use IGRF model to convert potential to velocities,</od></option>
+<option><on></on><od> instead use constant values.</od></option>
+<option><on>-old_aacgm</on><od>uses the older AACGM software and coefficients. The default</od></option>
+<option><on></on><od>  is to use AACGM-v2.</od></option>
+
+<synopsis><p>Calculates the statistical model and writes it to standard output.</p></synopsis>
+
+<description><p>Calculates the statistical model and writes it to standard output.</p>
+</description>
+
+<example>
+<command>solve_model -bz -2.5 -by 3.3 -tilt 4.0 -vx 350 &gt; model.txt</command>
+<description>Calculates TS18 model vectors and potential on a uniform grid for input solar wind and dipole tilt parameters. The output is written to the file "<code>model.txt</code>".</description>
+</example>
+
+</binary>

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/doc/solve_model.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/doc/solve_model.doc.xml
@@ -6,10 +6,27 @@
 
 <syntax></syntax>
 <syntax>solve_model --help</syntax>
-<syntax>solve_model [-nointerp] [-noigrf] [-rg96|-psr10|-cs10|-ts18|-ts18_kp]</syntax>
+<syntax>solve_model [-by <ar>by</ar>] [-bz <ar>bz</ar>] [-vx <ar>vx</ar>] [-tilt <ar>tilt</ar>] [-kp <ar>kp</ar>] [-rg96|-psr10|-cs10|-ts18|-ts18_kp] [-nointerp] [-noigrf]</syntax>
+<syntax>solve_model [-sh] [-lat_step <ar>dlat</ar>] [-lon_step <ar>dlon</ar>] [-equal]</syntax>
 <syntax></syntax>
 
 <option><on>--help</on><od>print the help message and exits.</od>
+</option>
+<option><on>-d <ar>yyymmdd</ar></on><od>calculate for the date <ar>yyyymmdd</ar>.</od>
+</option>
+<option><on>-t <ar>hr:mn</ar></on><od>calculate for the time <ar>hr:mn</ar>.</od>
+</option>
+<option><on>-sh</on><od>calculate the model pattern for the southern hemisphere.</od>
+</option>
+<option><on>-by <ar>by</ar></on><od>set the Y component of the magnetic field to <ar>by</ar> [nT].</od>
+</option>
+<option><on>-bz <ar>bz</ar></on><od>set the Z component of the magnetic field to <ar>by</ar> [nT].</od>
+</option>
+<option><on>-vx <ar>vx</ar></on><od>set the solar wind velocity to <ar>vx</ar> [km/s].</od>
+</option>
+<option><on>-tilt <ar>tilt</ar></on><od>set the dipole tilt angle to <ar>tilt</ar> [degrees].</od>
+</option>
+<option><on>-kp <ar>kp</ar></on><od>set the Kp magnetic index to <ar>kp</ar>.</od>
 </option>
 <option><on>-rg96</on><od>uses the RG96 statistical model.</od>
 </option>
@@ -27,6 +44,12 @@
 <option><on></on><od> instead use constant values.</od></option>
 <option><on>-old_aacgm</on><od>uses the older AACGM software and coefficients. The default</od></option>
 <option><on></on><od>  is to use AACGM-v2.</od></option>
+<option><on>-lat_step <ar>dlat</ar></on><od>set the latitudinal step size of the grid to <ar>dlat</ar> [degrees].</od>
+</option>
+<option><on>-lon_step <ar>dlon</ar></on><od>set the longitudinal step size of the grid to <ar>dlon</ar> [degrees].</od>
+</option>
+<option><on>-equal</on><od>use an equal-area grid with cell sizes defined by <ar>dlat</ar> [degrees].</od>
+</option>
 
 <synopsis><p>Calculates the statistical model and writes it to standard output.</p></synopsis>
 

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/doc/solve_model.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/doc/solve_model.doc.xml
@@ -10,45 +10,45 @@
 <syntax>solve_model [-sh] [-lat_step <ar>dlat</ar>] [-lon_step <ar>dlon</ar>] [-equal]</syntax>
 <syntax></syntax>
 
-<option><on>--help</on><od>print the help message and exits.</od>
+<option><on>--help</on><od>print the help message and exit.</od>
 </option>
-<option><on>-d <ar>yyymmdd</ar></on><od>calculate for the date <ar>yyyymmdd</ar>.</od>
+<option><on>-by <ar>by</ar></on><od>set the Y component of the magnetic field to <ar>by</ar> [nT]. The default value is 0 nT.</od>
 </option>
-<option><on>-t <ar>hr:mn</ar></on><od>calculate for the time <ar>hr:mn</ar>.</od>
+<option><on>-bz <ar>bz</ar></on><od>set the Z component of the magnetic field to <ar>bz</ar> [nT]. The default value is 0 nT.</od>
+</option>
+<option><on>-vx <ar>vx</ar></on><od>set the solar wind velocity to <ar>vx</ar> [km/s]. The default value is 450 km/s.</od>
+</option>
+<option><on>-tilt <ar>tilt</ar></on><od>set the dipole tilt angle to <ar>tilt</ar> [degrees]. The default value is determined by date/time.</od>
+</option>
+<option><on>-kp <ar>kp</ar></on><od>set the Kp magnetic index to <ar>kp</ar>. The default value is 0.</od>
+</option>
+<option><on>-d <ar>yyymmdd</ar></on><od>calculate for the date <ar>yyyymmdd</ar>. The default value is the current date.</od>
+</option>
+<option><on>-t <ar>hr:mn</ar></on><od>calculate for the time <ar>hr:mn</ar>. The default value is 00:00 UT.</od>
 </option>
 <option><on>-sh</on><od>calculate the model pattern for the southern hemisphere.</od>
 </option>
-<option><on>-by <ar>by</ar></on><od>set the Y component of the magnetic field to <ar>by</ar> [nT].</od>
+<option><on>-rg96</on><od>use the RG96 statistical model.</od>
 </option>
-<option><on>-bz <ar>bz</ar></on><od>set the Z component of the magnetic field to <ar>by</ar> [nT].</od>
+<option><on>-psr10</on><od>use the PSR10 statistical model (equivalent to the RG05 model.)</od>
 </option>
-<option><on>-vx <ar>vx</ar></on><od>set the solar wind velocity to <ar>vx</ar> [km/s].</od>
+<option><on>-cs10</on><od>use the CS10 statistical model.</od>
 </option>
-<option><on>-tilt <ar>tilt</ar></on><od>set the dipole tilt angle to <ar>tilt</ar> [degrees].</od>
+<option><on>-ts18</on><od>use the TS18 statistical model [default].</od>
 </option>
-<option><on>-kp <ar>kp</ar></on><od>set the Kp magnetic index to <ar>kp</ar>.</od>
+<option><on>-ts18_kp</on><od>use the TS18-Kp statistical model.</od>
 </option>
-<option><on>-rg96</on><od>uses the RG96 statistical model.</od>
+<option><on>-nointerp</on><od>do not interpolate coeffiecients, instead use discrete models (applies to CS10 and TS18 models only).</od>
 </option>
-<option><on>-psr10</on><od>uses the PSR10 statistical model (equivalent to the RG05 model.)</od>
-</option>
-<option><on>-cs10</on><od>uses the CS10 statistical model.</od>
-</option>
-<option><on>-ts18</on><od>uses the TS18 statistical model [default].</od>
-</option>
-<option><on>-ts18_kp</on><od>uses the TS18-Kp statistical model.</od>
-</option>
-<option><on>-nointerp</on><od>Do not interpolate coeffiecients, instead use discrete models.</od>
-</option>
-<option><on>-noigrf</on><od>Do not use IGRF model to convert potential to velocities, instead use constant values.</od>
+<option><on>-noigrf</on><od>do not use IGRF model to convert potential to velocities, instead use constant values.</od>
 </option>
 <option><on>-old_aacgm</on><od>uses the older AACGM software and coefficients. The default is to use AACGM-v2 coefficients.</od>
 </option>
-<option><on>-lat_step <ar>dlat</ar></on><od>set the latitudinal step size of the grid to <ar>dlat</ar> [degrees]. The default value is 1 degree.</od>
+<option><on>-lat_step <ar>dlat</ar></on><od>set the latitudinal step size of the grid to <ar>dlat</ar> [degrees]. The default value is 1 degree MLAT.</od>
 </option>
-<option><on>-lon_step <ar>dlon</ar></on><od>set the longitudinal step size of the grid to <ar>dlon</ar> [degrees]. The default value is 2 degrees.</od>
+<option><on>-lon_step <ar>dlon</ar></on><od>set the longitudinal step size of the grid to <ar>dlon</ar> [degrees]. The default value is 2 degrees MLON.</od>
 </option>
-<option><on>-equal</on><od>use an equal-area grid with cell sizes defined by <ar>dlat</ar> [degrees]. The default value is 1 degree in latitude.</od>
+<option><on>-equal</on><od>use an equal-area grid with cell sizes defined by <ar>dlat</ar> [degrees] instead of a uniform grid. The default value is 1 degree in latitude.</od>
 </option>
 
 <synopsis><p>Calculates the statistical model and writes it to standard output.</p></synopsis>

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/doc/solve_model.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/doc/solve_model.doc.xml
@@ -22,7 +22,7 @@
 </option>
 <option><on>-kp <ar>kp</ar></on><od>set the Kp magnetic index to <ar>kp</ar>. The default value is 0.</od>
 </option>
-<option><on>-d <ar>yyymmdd</ar></on><od>calculate for the date <ar>yyyymmdd</ar>. The default value is the current date.</od>
+<option><on>-d <ar>yyyymmdd</ar></on><od>calculate for the date <ar>yyyymmdd</ar>. The default value is the current date.</od>
 </option>
 <option><on>-t <ar>hr:mn</ar></on><od>calculate for the time <ar>hr:mn</ar>. The default value is 00:00 UT.</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/doc/solve_model.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/doc/solve_model.doc.xml
@@ -44,11 +44,11 @@
 <option><on></on><od> instead use constant values.</od></option>
 <option><on>-old_aacgm</on><od>uses the older AACGM software and coefficients. The default</od></option>
 <option><on></on><od>  is to use AACGM-v2.</od></option>
-<option><on>-lat_step <ar>dlat</ar></on><od>set the latitudinal step size of the grid to <ar>dlat</ar> [degrees].</od>
+<option><on>-lat_step <ar>dlat</ar></on><od>set the latitudinal step size of the grid to <ar>dlat</ar> [degrees]. Default is 1 degree.</od>
 </option>
-<option><on>-lon_step <ar>dlon</ar></on><od>set the longitudinal step size of the grid to <ar>dlon</ar> [degrees].</od>
+<option><on>-lon_step <ar>dlon</ar></on><od>set the longitudinal step size of the grid to <ar>dlon</ar> [degrees]. Default is 2 degrees.</od>
 </option>
-<option><on>-equal</on><od>use an equal-area grid with cell sizes defined by <ar>dlat</ar> [degrees].</od>
+<option><on>-equal</on><od>use an equal-area grid with cell sizes defined by <ar>dlat</ar> [degrees]. Default is 1 degree in latitude.</od>
 </option>
 
 <synopsis><p>Calculates the statistical model and writes it to standard output.</p></synopsis>

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/makefile
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/makefile
@@ -1,0 +1,21 @@
+# Makefile for solve_model
+# ========================
+# Author: E.G.Thomas
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+
+INCLUDE = -I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/analysis \
+          -I$(IPATH)/superdarn
+SRC = hlpstr.h solve_model.c errstr.h map_addmodel.h
+OBJS = solve_model.o
+
+DSTPATH = $(BINPATH)
+OUTPUT = solve_model
+
+SLIB = -lm -lz
+LIBS = -lshf.1 -laacgm.1 -lmlt.1 -lrtime.1 -lopt.1 -lrcnv.1 \
+       -lmlt_v2.1 -laacgm_v2.1 -ligrf_v2.1 -lastalg.1
+
+include $(MAKEBIN).$(SYSTEM)

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/map_addmodel.h
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/map_addmodel.h
@@ -1,0 +1,9 @@
+
+/* statistical models */
+
+#define RG96  1
+#define PSR10 2
+#define CS10  4
+#define TS18  8
+#define TS18_Kp 16
+

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
@@ -1421,7 +1421,10 @@ double strtime(char *text) {
   int i;
 
   for (i=0;(text[i] !=':') && (text[i] !=0);i++);
-  if (text[i]==0) return atoi(text)*3600L;
+  if (text[i]==0) {
+    fprintf(stderr,"Warning: must include ':' in '-t hr:mn' input - your date/time is probably incorrect!\n");
+    return atoi(text)*3600L;
+  }
   text[i]=0;
   hr=atoi(text);
   mn=atoi(text+i+1);

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
@@ -247,7 +247,7 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"-help",'x',&help);
   OptionAdd(&opt,"-option",'x',&option);
 
-  OptionAdd(&opt,"d",'d',&dtetxt);
+  OptionAdd(&opt,"d",'t',&dtetxt);
   OptionAdd(&opt,"t",'t',&tmetxt);
 
   OptionAdd(&opt,"sh",'x',&sh);

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
@@ -378,8 +378,8 @@ int main(int argc,char *argv[]) {
       fprintf(stdout,"Bin:   %s, %s\n",mod->level,mod->angle);
       break;
   }
-  if (equal) fprintf(stdout,"Grid: Equal-area (lat_step: %4.2f [deg])\n",lat_step);
-  else       fprintf(stdout,"Grid: Uniform (lat_step: %4.2f, lon_step: %4.2f [deg])\n",lat_step,lon_step);
+  if (equal) fprintf(stdout,"Grid:  Equal-area (lat_step: %4.2f [deg])\n",lat_step);
+  else       fprintf(stdout,"Grid:  Uniform (lat_step: %4.2f, lon_step: %4.2f [deg])\n",lat_step,lon_step);
   fprintf(stdout,"\n");
   fprintf(stdout,"MLAT [deg]   MLT [hr]   Pot [kV] Vazm [deg] Vmag [m/s]\n");
   fprintf(stdout,"---------- ---------- ---------- ---------- ----------\n");
@@ -1022,7 +1022,7 @@ struct mdata *get_model_pos(float latmin,int hemi,int *num,
   int i,j;
   int cnt=0;
 
-  nlat=(int)(90.0-latmin)/lat_step;
+  nlat=(int)((90.0-latmin)/lat_step);
 
   if (equal) {
 
@@ -1053,7 +1053,7 @@ struct mdata *get_model_pos(float latmin,int hemi,int *num,
 
     for (i=0;i<nlat;i++) {
       for (j=0;j<nlon;j++) {
-        ptr[cnt].mlat=i*lat_step+latmin;
+        ptr[cnt].mlat=i*lat_step+latmin+lat_step/2.0;
         ptr[cnt].mlon=j*lon_step;
         ptr[cnt].pot=0;
         ptr[cnt].azm=0;

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
@@ -1,0 +1,1390 @@
+/* solve_model.c
+   =============
+   Author: E.G.Thomas
+*/
+
+/*
+   See license.txt
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+#include <ctype.h>
+#include <sys/types.h>
+#include "rtypes.h"
+#include "rmath.h"
+#include "option.h"
+#include "rtime.h"
+
+#include "aacgm.h"
+#include "mlt.h"
+#include "aacgmlib_v2.h"
+#include "mlt_v2.h"
+#include "shfconst.h" /* use the same constants as in fitting procedure */
+#include "igrfcall.h"
+#include "igrflib.h"
+#include "map_addmodel.h"
+#include "calc_bmag.h"
+#include "hlpstr.h"
+
+/*-----------------------------------------------------------------------------
+ *
+ * global variables
+ *
+ *
+ */
+char *mod_hemi[6] = {"north","south",0};
+char *mod_tilt[] = {"DP-","DP0","DP+",0};
+char *mod_tilts[] = {"negative","neutral","positive"};
+int   mod_tlti[]  = {-10,10,-1};
+
+/*
+ * RG96 Model bins
+ * ---------------
+ */
+int   RG96_nang = 8;
+char *RG96_mod_ang[]   = {"315t45", "0t90"   , "45t135", "90t180" , "135t225",
+                          "180t270", "225t315", "270t360", 0};
+char *RG96_mod_angs[]  = {"Bz+"   , "Bz+/By+", "By+"   , "Bz-/By+", "Bz-"    ,
+                          "Bz-/By-", "By-"    , "Bz+/By-", 0};
+float RG96_mod_angil[] = {-22.5, 22.5, 67.5, 112.5, 157.5, 202.5, 247.5, 292.5};
+float RG96_mod_angih[] = {22.5, 67.5, 112.5, 157.5, 202.5, 247.5, 292.5, 337.5};
+
+int   RG96_nlev = 5;
+char *RG96_mod_lev[]   = {"2t3"   ,"0t4"   ,"4t6"   ,"6t12"   ,"7t20"   , 0};
+char *RG96_mod_levs[]  = {"2<Kp<3","0<BT<4","4<BT<6","6<BT<12","7<BT<20", 0};
+float RG96_mod_levi[]  = {0,4,6,12,20,-1};
+
+/*
+ * PSR10 Model bins
+ * ----------------
+ */
+int   PSR10_nang = 8;
+      /* bins are same as RG96 but filenames are same as CS10 */
+
+int   PSR10_nlev = 3;
+char *PSR10_mod_lev[]   = {"0t3"   ,"3t5"   ,"5t10"   ,0};
+char *PSR10_mod_levs[]  = {"0<BT<3","3<BT<5","5<BT<10",0};
+float PSR10_mod_levi[]  = {3,5,10,-1};
+
+/*
+ * CS10 Model bins
+ * ---------------
+ */
+int   CS10_nang = 8;
+char *CS10_mod_ang[]   = {"Bz+", "Bz+_By+", "By+", "Bz-_By+", "Bz-",
+                          "Bz-_By-", "By-", "Bz+_By-",0};
+char *CS10_mod_angs[]  = {"Bz+", "Bz+/By+", "By+", "Bz-/By+", "Bz-",
+                          "Bz-/By-", "By-", "Bz+/By-",0};
+float CS10_mod_angil[] = {-25, 25, 70, 110, 155, 205, 250, 290};
+float CS10_mod_angih[] = {25, 70, 110, 155, 205, 250, 290, 335};
+
+int   CS10_nlev = 6;
+char *CS10_mod_lev[]   = {"0.00t1.20","1.20t1.70","1.70t2.20","2.20t2.90",
+                          "2.90t4.10","4.10t20.00",0};
+char *CS10_mod_levs[]  = {"0<Esw<1.2","1.2<Esw<1.7","1.7<Esw<2.2","2.2<Esw<2.9",
+                          "2.9<Esw<4.1","4.1<Esw<20",0};
+float CS10_mod_levi[]  = {1.2, 1.7, 2.2, 2.9, 4.1, 20, -1};
+
+/*
+ * TS18 Model bins
+ * ---------------
+ */
+int   TS18_nang = 8;
+char *TS18_mod_ang[]   = {"Bz+", "Bz+_By+", "By+", "Bz-_By+", "Bz-",
+                          "Bz-_By-", "By-", "Bz+_By-",0};
+char *TS18_mod_angs[]  = {"Bz+", "Bz+/By+", "By+", "Bz-/By+", "Bz-",
+                          "Bz-/By-", "By-", "Bz+/By-",0};
+float TS18_mod_angil[] = {-25, 25, 70, 110, 155, 205, 250, 290};
+float TS18_mod_angih[] = {25, 70, 110, 155, 205, 250, 290, 335};
+
+int   TS18_nlev = 5;
+char *TS18_mod_lev[]   = {"0.00t1.20","1.20t1.60","1.60t2.10","2.10t3.00",
+                          "3.00t20.00",0};
+char *TS18_mod_levs[]  = {"0<Esw<1.2","1.2<Esw<1.6","1.6<Esw<2.1","2.1<Esw<3.0",
+                          "3.0<Esw<20",0};
+float TS18_mod_levi[]  = {1.2, 1.6, 2.1, 3.0, 20, -1};
+
+/*
+ * TS18-Kp Model bins
+ * ---------------
+ */
+int   TS18_Kp_nang = 8;
+char *TS18_Kp_mod_ang[]   = {"Bz+", "Bz+_By+", "By+", "Bz-_By+", "Bz-",
+                             "Bz-_By-", "By-", "Bz+_By-",0};
+char *TS18_Kp_mod_angs[]  = {"Bz+", "Bz+/By+", "By+", "Bz-/By+", "Bz-",
+                             "Bz-/By-", "By-", "Bz+/By-",0};
+float TS18_Kp_mod_angil[] = {-25, 25, 70, 110, 155, 205, 250, 290};
+float TS18_Kp_mod_angih[] = {25, 70, 110, 155, 205, 250, 290, 335};
+
+int   TS18_Kp_nlev = 6;
+char *TS18_Kp_mod_lev[]   = {"0t1","1t2","2t3","3t4",
+                             "4t6","6t8",0};
+char *TS18_Kp_mod_levs[]  = {"0<Kp<1","1<Kp<2","2<Kp<3","3<Kp<4",
+                             "4<Kp<6","6<Kp<8",0};
+float TS18_Kp_mod_levi[]  = {1, 2, 3, 4, 6, 8, -1};
+
+
+struct OptionData opt;
+
+struct model {
+  char hemi[64];
+  char tilt[64];
+  char angle[64];
+  char level[64];
+  int ihem,ilev,itlt,iang;
+  char str[3][128];
+  float latref;
+  int ltop,mtop;
+  struct complex *aoeff_n;
+  struct complex *aoeff_p;
+};
+
+int mnum = 0;
+struct model *model[2][3][6][8]; /* [hemi][tilt][lev][ang] */
+
+struct mdata {
+  double mlat,mlon;
+  double azm,vel;
+  double pot;
+};
+
+
+/*-----------------------------------------------------------------------------
+ *
+ * prototypes
+ *
+ *
+ */
+int solve_model(int num, struct mdata *ptr, float latmin, struct model *mod,
+                int hemi, float decyear, int igrf_flag, int old_aacgm);
+double factorial(double n);
+void cmult(struct complex *a, struct complex *b, struct complex *c);
+void slv_ylm_mod(float theta, float phi, int order, struct complex *ylm_p,
+                 struct complex *ylm_n, double *anorm, double *plm_p,
+                 double *apcnv);
+void slv_sph_kset(float latmin, int num, float *phi, float *the,
+                  float *the_col, double *ele_phi, double *ele_the,
+                  struct model *mod, double *pot);
+struct mdata *get_model_pos(float latmin, int hemi, int *num,
+                            float lat_step, float lon_step);
+struct model *determine_model(float Vsw, float By, float Bz, int hemi,
+                              float tilt, float kp, int imod, int nointerp);
+struct model *interp_coeffs(int ih, float tilt, float mag, float cang, int imod);
+struct model *load_model(FILE *fp, int ihem, int ilev, int iang, int itlt,
+                                   int imod);
+int load_all_models(char *path, int imod);
+double strdate(char *txt);
+double strtime(char *txt);
+
+/*-----------------------------------------------------------------------------
+ *
+ * function definitions
+ *
+ *
+ */
+
+int rst_opterr(char *txt) {
+  fprintf(stderr,"Option not recognized: %s\n",txt);
+  fprintf(stderr,"Please try: solve_model --help\n");
+  return(-1);
+}
+
+int main(int argc,char *argv[]) {
+
+  int old_aacgm=0;
+
+  int arg;
+  unsigned char help=0;
+  unsigned char option=0;
+
+  char *fmt="%#10g %#10g %#10g %#10g %#10g\n";
+
+  char *envstr;
+  int num=0;
+  int status;
+  int yrsec;
+  int i;
+
+  char *tmetxt=NULL;
+  char *dtetxt=NULL;
+  double dval=-1;
+  double tval=-1;
+
+  unsigned char sh=0;
+  int hemisphere=1;
+
+  int yr,mo,dy,hr,mt,sec,dno;
+  double sc;
+
+  struct model *mod = NULL;
+
+  float dBy=0;
+  float dBz=0;
+  float dVx=0;
+  float dtilt=-99;
+  float dKp=0;
+
+  float decyear = 0.;
+  float tilt = 0.;
+  int noigrf = 0;
+  int nointerp = 0;
+  int rg96 = 0;
+  int psr10 = 0;
+  int cs10 = 0;
+  int ts18 = 0;
+  int ts18_kp = 0;
+  int imod = 0;
+
+  float lat_step=1.0;
+  float lon_step=2.0;
+
+  struct mdata *mdata=NULL;
+
+  OptionAdd(&opt,"-help",'x',&help);
+  OptionAdd(&opt,"-option",'x',&option);
+
+  OptionAdd(&opt,"t",'t',&tmetxt);
+  OptionAdd(&opt,"d",'d',&dtetxt);
+
+  OptionAdd(&opt,"sh",'x',&sh);
+
+  OptionAdd(&opt,"by",'f',&dBy);
+  OptionAdd(&opt,"bz",'f',&dBz);
+  OptionAdd(&opt,"vx",'f',&dVx);
+  OptionAdd(&opt,"tilt",'f',&dtilt);
+  OptionAdd(&opt,"kp",'f',&dKp);
+
+  OptionAdd(&opt,"old_aacgm",'x',&old_aacgm);
+  OptionAdd(&opt,"rg96",'x',&rg96);
+  OptionAdd(&opt,"psr10",'x',&psr10);
+  OptionAdd(&opt,"cs10",'x',&cs10);
+  OptionAdd(&opt,"ts18",'x',&ts18);
+  OptionAdd(&opt,"ts18_kp",'x',&ts18_kp);
+  OptionAdd(&opt,"nointerp",'x',&nointerp);
+  OptionAdd(&opt,"noigrf",'x',&noigrf);        /* SGS: default is to use IGRF
+                                                       to compute model vecs  */
+
+  OptionAdd(&opt,"lat_step",'f',&lat_step);
+  OptionAdd(&opt,"lon_step",'f',&lon_step);
+
+  arg=OptionProcess(1,argc,argv,&opt,rst_opterr);
+
+  if (arg==-1) {
+    exit(-1);
+  }
+
+  if (help==1) {
+    OptionPrintInfo(stdout,hlpstr);
+    exit(0);
+  }
+
+  if (option==1) {
+    OptionDump(stdout,&opt);
+    exit(0);
+  }
+
+  if (!ts18 && !ts18_kp && !cs10 && !psr10 && !rg96) ts18 = 1;
+  if (rg96)    imod = RG96;
+  if (psr10)   imod = PSR10;
+  if (cs10)    imod = CS10;
+  if (ts18_kp) imod = TS18_Kp;
+  if (ts18)    imod = TS18;
+
+  envstr=getenv("SD_MODEL_TABLE");
+  if (envstr==NULL) {
+    fprintf(stderr,"Environment variable SD_MODEL_TABLE must be defined.\n");
+    exit(-1);
+  }
+
+  status = load_all_models(envstr,imod);
+  if (status != 0) {
+    fprintf(stderr,"Failed to load statistical model.\n");
+    exit(-1);
+  }
+
+  if (tmetxt !=NULL) tval=strtime(tmetxt);
+  if (dtetxt !=NULL) dval=strdate(dtetxt);
+
+  if (dval == -1) {
+    fprintf(stderr,"\nDate not set, using today's date\n\n");
+    AACGM_v2_SetNow();
+    AACGM_v2_GetDateTime(&yr,&mo,&dy,&hr,&mt,&sec,&dno);
+    dval=TimeYMDHMSToEpoch(yr,mo,dy,0,0,0);
+  }
+
+  if (tval !=-1) tval+=dval;
+  else tval=dval;
+
+  TimeEpochToYMDHMS(tval,&yr,&mo,&dy,&hr,&mt,&sc);
+  yrsec = TimeYMDHMSToYrsec(yr,mo,dy,hr,mt,(int) sc);
+  decyear = yr + (float)yrsec/TimeYMDHMSToYrsec(yr,12,31,23,59,59);
+
+  if (!noigrf)    IGRF_SetDateTime(yr,mo,dy,hr,mt,(int)sc);
+  if (!old_aacgm) AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,(int)sc);
+
+  if ((dtilt == -99) && (imod == TS18 || imod == CS10 || imod == PSR10))
+    tilt = IGRF_Tilt(yr,mo,dy,hr,mt,(int)sc);
+  else tilt = dtilt;
+
+  if (sh==1) hemisphere = -1;
+
+  /* determine the model */
+  mod = determine_model(dVx, dBy, dBz, hemisphere, tilt, dKp, imod, nointerp);
+fprintf(stderr,"tilt: %f, dtilt: %f, model: %s\n",tilt,dtilt,mod->tilt);
+  /* create model grid */
+  mdata = get_model_pos(mod->latref,hemisphere,&num,lat_step,lon_step);
+
+  /* solve for the model */
+  status = solve_model(num, mdata, mod->latref, mod, hemisphere,
+                       decyear, noigrf, old_aacgm);
+
+  if (status != 0) {
+    fprintf(stderr,"Failed to solve statistical model.\n");
+    exit(-1);
+  }
+
+  fprintf(stdout,"Date:  %4d-%02d-%02d %02d:%02d\n",yr,mo,dy,hr,mt);
+  switch (imod) {
+    case RG96:
+      fprintf(stdout,"Model: RG96\n");
+      fprintf(stdout,"Bin:   %s, %s\n",mod->level,mod->angle);
+      break;
+    case PSR10:
+      fprintf(stdout,"Model: PSR10\n");
+      fprintf(stdout,"Bin:   %s, %s, %s tilt\n",mod->level,mod->angle,mod->tilt);
+      break;
+    case CS10:
+      fprintf(stdout,"Model: CS10\n");
+      fprintf(stdout,"Bin:   %s, %s, %s",mod->level,mod->angle,mod->tilt);
+      if (nointerp) fprintf(stdout," tilt\n");
+      else          fprintf(stdout,"\n");
+      break;
+    case TS18:
+      fprintf(stdout,"Model: TS18\n");
+      fprintf(stdout,"Bin:   %s, %s, %s",mod->level,mod->angle,mod->tilt);
+      if (nointerp) fprintf(stdout," tilt\n");
+      else          fprintf(stdout,"\n");
+      break;
+    case TS18_Kp:
+      fprintf(stdout,"Model: TS18-Kp\n");
+      fprintf(stdout,"Bin:   %s, %s\n",mod->level,mod->angle);
+      break;
+  }
+  fprintf(stdout,"\n");
+  fprintf(stdout,"MLAT [deg]   MLT [hr]   Pot [kV] Vazm [deg] Vmag [m/s]\n");
+  fprintf(stdout,"---------- ---------- ---------- ---------- ----------\n");
+  for (i=0;i<num;i++) {
+    fprintf(stdout,fmt,mdata[i].mlat,mdata[i].mlon,mdata[i].pot,mdata[i].azm,mdata[i].vel);
+  }
+
+  free(mdata);
+
+  return 0;
+}
+
+
+struct model *load_model(FILE *fp, int ihem, int ilev, int iang,
+                                   int itlt, int imod)
+{
+  struct model *ptr = NULL;
+  int i,k,l,m,lx,mx;
+  float cr,ci;
+
+  ptr = malloc(sizeof(struct model));
+  if (ptr==NULL) return NULL;
+  ptr->ihem = ihem;
+  ptr->ilev = ilev;
+  ptr->iang = iang;
+  ptr->itlt = itlt;
+
+  switch (imod) {
+    case RG96:
+      strcpy(ptr->hemi,"Null");
+      strcpy(ptr->tilt,"Null");
+      strcpy(ptr->level,RG96_mod_levs[ilev]);
+      strcpy(ptr->angle,RG96_mod_angs[iang]);
+      break;
+    case PSR10:
+      strcpy(ptr->hemi,mod_hemi[ihem]);
+      strcpy(ptr->tilt,mod_tilts[itlt]);
+      strcpy(ptr->level,PSR10_mod_levs[ilev]);
+      strcpy(ptr->angle,RG96_mod_angs[iang]); /* same as RG96 */
+      break;
+    case CS10:
+      strcpy(ptr->hemi,mod_hemi[ihem]);
+      strcpy(ptr->tilt,mod_tilts[itlt]);
+      strcpy(ptr->level,CS10_mod_levs[ilev]);
+      strcpy(ptr->angle,CS10_mod_angs[iang]);
+      break;
+    case TS18:
+      strcpy(ptr->hemi,"Null");
+      strcpy(ptr->tilt,mod_tilts[itlt]);
+      strcpy(ptr->level,TS18_mod_levs[ilev]);
+      strcpy(ptr->angle,TS18_mod_angs[iang]); /* same as CS10 */
+      break;
+    case TS18_Kp:
+      strcpy(ptr->hemi,"Null");
+      strcpy(ptr->tilt,"Null");
+      strcpy(ptr->level,TS18_Kp_mod_levs[ilev]);
+      strcpy(ptr->angle,TS18_Kp_mod_angs[iang]); /* same as CS10 */
+      break;
+  }
+
+  for (i=0; i<3; i++) 
+    if (fgets(ptr->str[i],128,fp) == NULL) break;
+  if (i < 3) {
+    free(ptr);
+    return NULL;
+  }
+
+  if (fscanf(fp,"%g",&ptr->latref) !=1) {
+    free(ptr);
+    return NULL;
+  }
+
+  if (fscanf(fp,"%d %d",&ptr->ltop,&ptr->mtop) !=2) {
+    free(ptr);
+    return NULL;
+  }
+
+  ptr->aoeff_p=malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  if (ptr->aoeff_p==NULL) {
+    free(ptr);
+    return NULL;
+  }
+  ptr->aoeff_n=malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  if (ptr->aoeff_n==NULL) {
+    free(ptr->aoeff_p);
+    free(ptr);
+    return NULL;
+  }
+  memset(ptr->aoeff_p,0,sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  memset(ptr->aoeff_n,0,sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+
+
+  for (l=0; l<=ptr->ltop; l++) {
+    for (m=-l; m<=l; m++) {
+      if (fscanf(fp,"%d %d %g %g",&lx,&mx,&cr,&ci) != 4) break;
+
+      if (m < 0) {
+        k = l*(ptr->ltop+1)-m;
+        ptr->aoeff_n[k].x = cr;
+        ptr->aoeff_n[k].y = ci;
+      } else {
+        k = l*(ptr->ltop+1)+m;
+        ptr->aoeff_p[k].x = cr;
+        ptr->aoeff_p[k].y = ci;
+      }
+
+    }
+    if (m <= l) break;
+  }
+
+  if (l <= ptr->ltop) {
+    free(ptr->aoeff_n);
+    free(ptr->aoeff_p);
+    free(ptr);
+  }
+
+  return ptr;
+}
+
+
+int load_all_models(char *path, int imod)
+{
+  char fname[256];
+  FILE *fp;
+  int h,i,j,k;
+
+  switch (imod) {
+    case RG96:  /***********************************************************/
+      for (i=0; i<RG96_nlev; i++) {
+        for (j=0; j<RG96_nang; j++) {
+          sprintf(fname,"%s/rg96/mod_%s_%s.spx",path,RG96_mod_lev[i],
+                         RG96_mod_ang[j]);
+          fp = fopen(fname,"r");
+          if (fp == NULL) continue;
+          model[0][0][i][j] = load_model(fp,-1,i,j,-1,imod);
+          fclose(fp);
+          if (model[0][0][i][j] == NULL) continue;
+          mnum++;
+        }
+      }
+      break;
+    case PSR10:  /***********************************************************/
+      for (h=0; mod_hemi[h] != NULL; h++) {
+        for (i=0; i<PSR10_nlev; i++) {
+          for (j=0; j<PSR10_nang; j++) {
+            for (k=0; mod_tilt[k] != NULL; k++) {
+              sprintf(fname,"%s/psr10/mod_%s_%s_%s_%s.spx",path,mod_hemi[h],
+                             PSR10_mod_lev[i],CS10_mod_ang[j],mod_tilt[k]);
+              fp = fopen(fname,"r");
+              if (fp == NULL) continue;
+              model[h][k][i][j] = load_model(fp,h,i,j,k,imod);
+              fclose(fp);
+              if (model[h][k][i][j] == NULL) continue;
+              mnum++;
+            }
+          }
+        }
+      }
+      break;
+    case CS10:  /***********************************************************/
+      for (h=0; mod_hemi[h] != NULL; h++) {
+        for (i=0; i<CS10_nlev; i++) {
+          for (j=0; j<CS10_nang; j++) {
+            for (k=0; mod_tilt[k] != NULL; k++) {
+              if ((i==5) && (j>2) && (j<6)) continue;   /* skip extreme Bz- */
+
+              sprintf(fname,"%s/cs10/mod_%s_%s_%s_%s.spx",path,mod_hemi[h],
+                             CS10_mod_lev[i],CS10_mod_ang[j],mod_tilt[k]);
+              fp = fopen(fname,"r");
+              if (fp == NULL) continue;
+              model[h][k][i][j] = load_model(fp,h,i,j,k,imod);
+              fclose(fp);
+              if (model[h][k][i][j] == NULL) continue;
+              mnum++;
+            }
+          }
+        }
+      }
+      break;
+    case TS18:  /***********************************************************/
+      for (i=0; i<TS18_nlev; i++) {
+        for (j=0; j<TS18_nang; j++) {
+          for (k=0; mod_tilt[k] != NULL; k++) {
+            sprintf(fname,"%s/ts18/mod_%s_%s_%s.spx",path,TS18_mod_lev[i],
+                           TS18_mod_ang[j],mod_tilt[k]);
+            fp = fopen(fname,"r");
+            if (fp == NULL) continue;
+            model[0][k][i][j] = load_model(fp,-1,i,j,k,imod);
+            fclose(fp);
+            if (model[0][k][i][j] == NULL) continue;
+            mnum++;
+          }
+        }
+      }
+      break;
+    case TS18_Kp:  /********************************************************/
+      for (i=0; i<TS18_Kp_nlev; i++) {
+        for (j=0; j<TS18_Kp_nang; j++) {
+          sprintf(fname,"%s/ts18_kp/mod_%s_%s.spx",path,TS18_Kp_mod_lev[i],
+                         TS18_Kp_mod_ang[j]);
+          fp = fopen(fname,"r");
+          if (fp == NULL) continue;
+          model[0][0][i][j] = load_model(fp,-1,i,j,-1,imod);
+          fclose(fp);
+          if (model[0][0][i][j] == NULL) continue;
+          mnum++;
+        }
+      }
+      break;
+    default:
+      fprintf(stderr, "Statistical Model %d not defined.\n", imod);
+      return (-1);
+  }
+
+  return (0);
+}  
+
+/* Ideally this should be a more generalized function that allows other models
+   to also be interpolated. Each model may have a different number of
+   parameters to consider.
+ */
+struct model *interp_coeffs(int ih, float tilt, float mag, float cang, int imod)
+{
+  struct model *ptr=NULL;
+  float tlow[2] = {-20, 0};
+  float thgh[2] = {  0,20};
+  int i,it1,it2,im1,im2,ia1,ia2,l,m,k;
+  double afac,afac_l,afac_h,denom;
+  float Al,Bl,Cl,Dl,El,Fl,Gl,Hl;
+  double dtp,dtn,mgp,mgn,afp,afn;
+  struct complex *Ap,*Bp,*Cp,*Dp,*Ep,*Fp,*Gp,*Hp;
+  struct complex *An,*Bn,*Cn,*Dn,*En,*Fn,*Gn,*Hn;
+
+  /* These are hardcoded to the largest possible number of
+   * model bins (currently CS10) - EGT */
+  int nang=0,nlev=0;
+  float alow[8],ahgh[8];
+  float mlow[6],mhgh[6];
+  float mod_angil[8],mod_angih[8];
+  float mod_levi[6];
+
+  switch (imod) {
+    case CS10:
+      nang = CS10_nang;
+      for (i=0; i<nang; i++) {
+        mod_angil[i] = CS10_mod_angil[i];
+        mod_angih[i] = CS10_mod_angih[i];
+      }
+      nlev = CS10_nlev;
+      for (i=0; i<nlev-1; i++)
+        mod_levi[i] = CS10_mod_levi[i];
+      break;
+
+    case TS18:
+      nang = TS18_nang;
+      for (i=0; i<nang; i++) {
+        mod_angil[i] = TS18_mod_angil[i];
+        mod_angih[i] = TS18_mod_angih[i];
+      }
+      nlev = TS18_nlev;
+      for (i=0; i<nlev-1; i++)
+        mod_levi[i] = TS18_mod_levi[i];
+      break;
+  }
+
+  /* setup reference point arrays */
+  mlow[0] = .5*mod_levi[0];
+  mhgh[0] = .5*(mod_levi[0]+mod_levi[1]);
+  for (i=1; i<nlev-1; i++) {
+    mlow[i] = .5*(mod_levi[i-1]+mod_levi[i]);
+    mhgh[i] = .5*(mod_levi[i]+mod_levi[i+1]);
+  }
+  if (imod == TS18) {
+    mhgh[nlev-2] = 5.0;
+  } else {
+    mhgh[nlev-2] = 7.5;
+  }
+
+  for (i=0; i<nang-1; i++) {
+    alow[i] = .5*(mod_angil[i]+mod_angih[i]);
+    ahgh[i] = .5*(mod_angil[i+1]+mod_angih[i+1]);
+  }
+  alow[i] = .5*(mod_angil[i]+mod_angih[i]);
+  ahgh[i] = alow[0]+360;
+
+  /* restrict parameter values to within valid range */
+  if (cang >= ahgh[nang-1]) cang -= 360.;
+  if (cang < alow[0])       cang += 360.;
+
+  if (mag > mhgh[nlev-2]) mag = mhgh[nlev-2];
+  if (mag < mlow[0])      mag = mlow[0];
+
+  if (tilt > thgh[1]) tilt = thgh[1];
+  if (tilt < tlow[0]) tilt = tlow[0];
+
+  /* check for Bz<0 saturation */
+  if (imod == CS10) {
+    if ((mag>mhgh[CS10_nlev-3]) && (cang>alow[2]) && (cang<ahgh[5]))
+      mag = mhgh[CS10_nlev-3];
+  }
+
+  /* find nearest neighbors */
+  it1 = (tilt < 0) ? 0 : 1;  /* dipole tilt */
+  it2 = it1+1;
+
+  for (im1=0; (mag > mhgh[im1]); im1++);  /* Magnitude */
+  im2 = im1+1;
+
+  for (ia1=0; ia1 < nang; ia1++)   /* Angle */
+    if ((cang >= alow[ia1]) && (cang < ahgh[ia1])) break;
+
+  /* set up new model structure */
+  ptr = malloc(sizeof(struct model));
+  if (ptr==NULL) return NULL;
+
+  for (i=0; i<3; i++) strcpy(ptr->str[i],model[0][0][0][0]->str[i]);
+  ptr->ltop = model[0][0][0][0]->ltop;
+  ptr->mtop = model[0][0][0][0]->mtop;
+
+  strcpy(ptr->hemi,mod_hemi[ih]);
+  sprintf(ptr->tilt, "tilt %5.1f deg.",tilt);
+  sprintf(ptr->level,"Esw  %5.1f mV/m",mag);
+  sprintf(ptr->angle,"Bang %5.0f deg.",cang);
+
+  ptr->aoeff_p=malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  ptr->aoeff_n=malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  memset(ptr->aoeff_p,0,sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  memset(ptr->aoeff_n,0,sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+
+  ptr->ihem = ih;
+  ptr->ilev = im1;
+  ptr->iang = ia1;
+  ptr->itlt = it1;
+
+  /* do tri-linear interpolation of coeffs */
+  if (ia1 == nang-1) ia2 = 0;
+  else ia2 = ia1+1;
+
+  afac_h = fabs(sin(.5*ahgh[ia1]*PI/180.));
+  afac_l = fabs(sin(.5*alow[ia1]*PI/180.));
+  afac   = fabs(sin(.5*cang*PI/180.));
+  denom = (afac_h-afac_l)*(mhgh[im1]-mlow[im1])*(thgh[it1]-tlow[it1]);
+
+  /* deltas for interpolation */
+  dtp = thgh[it1] - tilt;
+  dtn = tilt - tlow[it1];
+  afp = afac_h - afac;
+  afn = afac - afac_l;
+  mgp = mhgh[im1] - mag;
+  mgn = mag - mlow[im1];
+
+  Ap = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  Bp = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  Cp = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  Dp = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  Ep = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  Fp = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  Gp = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  Hp = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+
+  An = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  Bn = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  Cn = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  Dn = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  En = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  Fn = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  Gn = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+  Hn = malloc(sizeof(struct complex)*(ptr->ltop+1)*(ptr->ltop+1));
+
+  for (l=0; l<=ptr->ltop; l++) {
+    for (m=-l; m<=l; m++) {
+      if (m < 0) {
+        k = l*(ptr->ltop+1)-m;
+        An[k].x = model[ih][it1][im1][ia1]->aoeff_n[k].x/denom;
+        An[k].y = model[ih][it1][im1][ia1]->aoeff_n[k].y/denom;
+        Bn[k].x = model[ih][it1][im1][ia2]->aoeff_n[k].x/denom;
+        Bn[k].y = model[ih][it1][im1][ia2]->aoeff_n[k].y/denom;
+        Cn[k].x = model[ih][it1][im2][ia1]->aoeff_n[k].x/denom;
+        Cn[k].y = model[ih][it1][im2][ia1]->aoeff_n[k].y/denom;
+        Dn[k].x = model[ih][it1][im2][ia2]->aoeff_n[k].x/denom;
+        Dn[k].y = model[ih][it1][im2][ia2]->aoeff_n[k].y/denom;
+        En[k].x = model[ih][it2][im1][ia1]->aoeff_n[k].x/denom;
+        En[k].y = model[ih][it2][im1][ia1]->aoeff_n[k].y/denom;
+        Fn[k].x = model[ih][it2][im1][ia2]->aoeff_n[k].x/denom;
+        Fn[k].y = model[ih][it2][im1][ia2]->aoeff_n[k].y/denom;
+        Gn[k].x = model[ih][it2][im2][ia1]->aoeff_n[k].x/denom;
+        Gn[k].y = model[ih][it2][im2][ia1]->aoeff_n[k].y/denom;
+        Hn[k].x = model[ih][it2][im2][ia2]->aoeff_n[k].x/denom;
+        Hn[k].y = model[ih][it2][im2][ia2]->aoeff_n[k].y/denom;
+      } else {
+        k = l*(ptr->ltop+1)+m;
+        Ap[k].x = model[ih][it1][im1][ia1]->aoeff_p[k].x/denom;
+        Ap[k].y = model[ih][it1][im1][ia1]->aoeff_p[k].y/denom;
+        Bp[k].x = model[ih][it1][im1][ia2]->aoeff_p[k].x/denom;
+        Bp[k].y = model[ih][it1][im1][ia2]->aoeff_p[k].y/denom;
+        Cp[k].x = model[ih][it1][im2][ia1]->aoeff_p[k].x/denom;
+        Cp[k].y = model[ih][it1][im2][ia1]->aoeff_p[k].y/denom;
+        Dp[k].x = model[ih][it1][im2][ia2]->aoeff_p[k].x/denom;
+        Dp[k].y = model[ih][it1][im2][ia2]->aoeff_p[k].y/denom;
+        Ep[k].x = model[ih][it2][im1][ia1]->aoeff_p[k].x/denom;
+        Ep[k].y = model[ih][it2][im1][ia1]->aoeff_p[k].y/denom;
+        Fp[k].x = model[ih][it2][im1][ia2]->aoeff_p[k].x/denom;
+        Fp[k].y = model[ih][it2][im1][ia2]->aoeff_p[k].y/denom;
+        Gp[k].x = model[ih][it2][im2][ia1]->aoeff_p[k].x/denom;
+        Gp[k].y = model[ih][it2][im2][ia1]->aoeff_p[k].y/denom;
+        Hp[k].x = model[ih][it2][im2][ia2]->aoeff_p[k].x/denom;
+        Hp[k].y = model[ih][it2][im2][ia2]->aoeff_p[k].y/denom;
+      }
+    }
+  }
+
+  for (l=0; l<=ptr->ltop; l++) {
+    for (m=-l; m<=l; m++) {
+      if (m < 0) {
+        k = l*(ptr->ltop+1)-m;
+
+        ptr->aoeff_n[k].x = An[k].x*afp*mgp*dtp + Bn[k].x*afn*mgp*dtp +
+                            Cn[k].x*afp*mgn*dtp + Dn[k].x*afn*mgn*dtp +
+                            En[k].x*afp*mgp*dtn + Fn[k].x*afn*mgp*dtn +
+                            Gn[k].x*afp*mgn*dtn + Hn[k].x*afn*mgn*dtn;
+
+        ptr->aoeff_n[k].y = An[k].y*afp*mgp*dtp + Bn[k].y*afn*mgp*dtp +
+                            Cn[k].y*afp*mgn*dtp + Dn[k].y*afn*mgn*dtp +
+                            En[k].y*afp*mgp*dtn + Fn[k].y*afn*mgp*dtn +
+                            Gn[k].y*afp*mgn*dtn + Hn[k].y*afn*mgn*dtn;
+      } else {
+        k = l*(ptr->ltop+1)+m;
+
+        ptr->aoeff_p[k].x = Ap[k].x*afp*mgp*dtp + Bp[k].x*afn*mgp*dtp +
+                            Cp[k].x*afp*mgn*dtp + Dp[k].x*afn*mgn*dtp +
+                            Ep[k].x*afp*mgp*dtn + Fp[k].x*afn*mgp*dtn +
+                            Gp[k].x*afp*mgn*dtn + Hp[k].x*afn*mgn*dtn;
+
+        ptr->aoeff_p[k].y = Ap[k].y*afp*mgp*dtp + Bp[k].y*afn*mgp*dtp +
+                            Cp[k].y*afp*mgn*dtp + Dp[k].y*afn*mgn*dtp +
+                            Ep[k].y*afp*mgp*dtn + Fp[k].y*afn*mgp*dtn +
+                            Gp[k].y*afp*mgn*dtn + Hp[k].y*afn*mgn*dtn;
+
+      }
+    }
+  }
+
+  /* interpolate boundary also */
+  Al = model[ih][it1][im1][ia1]->latref/denom;
+  Bl = model[ih][it1][im1][ia2]->latref/denom;
+  Cl = model[ih][it1][im2][ia1]->latref/denom;
+  Dl = model[ih][it1][im2][ia2]->latref/denom;
+  El = model[ih][it2][im1][ia1]->latref/denom;
+  Fl = model[ih][it2][im1][ia2]->latref/denom;
+  Gl = model[ih][it2][im2][ia1]->latref/denom;
+  Hl = model[ih][it2][im2][ia2]->latref/denom;
+
+  ptr->latref = roundf( Al*afp*mgp*dtp + Bl*afn*mgp*dtp +
+                        Cl*afp*mgn*dtp + Dl*afn*mgn*dtp +
+                        El*afp*mgp*dtn + Fl*afn*mgp*dtn +
+                        Gl*afp*mgn*dtn + Hl*afn*mgn*dtn );
+
+  return (ptr);
+}
+
+
+struct model *determine_model(float Vsw, float By, float Bz, int hemi,
+                              float tilt, float kp, int imod, int nointerp)
+{
+  int ihem,itlt, ilev,iang,i;
+  float esw,bt,bazm;
+  struct model *imodel = NULL;
+
+  bt   = sqrt(By*By + Bz*Bz);
+
+  /* flip sign of By for shemi in models w/o shemi patterns */
+  if (hemi < 0 && (imod == RG96 || imod == TS18 || imod == TS18_Kp)) By = -By;
+  bazm = atan2(By,Bz)*180/PI;
+
+  switch (imod) {
+    case RG96:
+      ihem = 0; /* no bins for these in RG96 */
+      itlt = 0;
+
+      if (bazm >= RG96_mod_angih[RG96_nang-1]) bazm -= 360;
+      if (bazm <  RG96_mod_angil[0])           bazm += 360;
+
+      /* magnitude */
+      for (i=0; (RG96_mod_levi[i] !=-1) && (bt > RG96_mod_levi[i]); i++);
+      if (RG96_mod_levi[i] == -1) i--;
+      ilev = i;
+
+      /* angle */
+      for (i=0; i < RG96_nang; i++)
+        if ( (bazm > RG96_mod_angil[i]) && (bazm < RG96_mod_angih[i]) ) break;
+      if (i == RG96_nang) i--;
+      iang = i;
+
+      /* correct for extreme Bz+ */
+      if ((ilev == 4) && (iang != 0)) ilev--;
+
+      imodel = model[ihem][itlt][ilev][iang];
+      break;
+
+    case PSR10:
+      if (hemi < 0) tilt = -tilt;
+
+      /* hemisphere */ 
+      ihem = (hemi < 0) ? 1 : 0;
+
+      if (bazm >= RG96_mod_angih[RG96_nang-1]) bazm -= 360.;
+      if (bazm <  RG96_mod_angil[0])           bazm += 360.;
+
+      /* tilt */
+      for (i=0; (mod_tlti[i] !=-1) && (tilt > mod_tlti[i]); i++);
+      itlt = i;
+
+      /* angle */
+      for (i=0; i < PSR10_nang; i++)
+        if ((bazm >= RG96_mod_angil[i]) && (bazm < RG96_mod_angih[i])) break;
+      if (i == RG96_nang) i--;
+      iang = i;
+
+      /* magnitude */
+      for (i=0; (PSR10_mod_levi[i] !=-1) && (bt >= PSR10_mod_levi[i]); i++);
+      if (PSR10_mod_levi[i] == -1) i--;
+      ilev = i;
+
+      /* correct for extreme Bz- */
+/*    if ((ilev==5) && (iang>2) && (iang<6)) ilev--;*/
+/* SGS: is there a correction for PSR10??? */
+
+      imodel = model[ihem][itlt][ilev][iang];
+
+      break;
+
+    case CS10:
+      if (Vsw == 0) Vsw = 450.; /* not sure if this should be here: SGS */
+                                /* Default solar wind velocity */
+      esw = 1e-3*abs(Vsw*bt);
+      if (hemi < 0) tilt = -tilt;
+
+      /* hemisphere */
+      ihem = (hemi < 0) ? 1 : 0;
+
+      if (nointerp) {
+
+        if (bazm >= CS10_mod_angih[CS10_nang-1]) bazm -= 360.;
+        if (bazm <  CS10_mod_angil[0])           bazm += 360.;
+
+        /* tilt */
+        for (i=0; (mod_tlti[i] !=-1) && (tilt > mod_tlti[i]); i++);
+        itlt = i;
+
+        /* angle */
+        for (i=0; i < CS10_nang; i++)
+          if ((bazm >= CS10_mod_angil[i]) && (bazm < CS10_mod_angih[i])) break;
+        if (i == CS10_nang) i--;
+        iang = i;
+
+        /* magnitude */
+        for (i=0; (CS10_mod_levi[i] !=-1) && (esw >= CS10_mod_levi[i]); i++);
+        if (CS10_mod_levi[i] == -1) i--;
+        ilev = i;
+
+        /* correct for extreme Bz- */
+        if ((ilev==5) && (iang>2) && (iang<6)) ilev--;
+
+        imodel = model[ihem][itlt][ilev][iang];
+
+      } else imodel = interp_coeffs(ihem,tilt,esw,bazm,imod);
+
+      break;
+
+    case TS18:
+      if (Vsw == 0) Vsw = 450.; /* not sure if this should be here: SGS */
+                                /* Default solar wind velocity */
+      esw = 1e-3*abs(Vsw*bt);
+      if (hemi < 0) tilt = -tilt;
+
+      ihem = 0; /* no hemisphere bins for TS18 */
+
+      if (nointerp) {
+
+        if (bazm >= TS18_mod_angih[TS18_nang-1]) bazm -= 360.;
+        if (bazm <  TS18_mod_angil[0])           bazm += 360.;
+
+        /* tilt */
+        for (i=0; (mod_tlti[i] !=-1) && (tilt > mod_tlti[i]); i++);
+        itlt = i;
+
+        /* angle */
+        for (i=0; i < TS18_nang; i++)
+          if ((bazm >= TS18_mod_angil[i]) && (bazm < TS18_mod_angih[i])) break;
+        if (i == TS18_nang) i--;
+        iang = i;
+
+        /* magnitude */
+        for (i=0; (TS18_mod_levi[i] !=-1) && (esw >= TS18_mod_levi[i]); i++);
+        if (TS18_mod_levi[i] == -1) i--;
+        ilev = i;
+
+        imodel = model[ihem][itlt][ilev][iang];
+
+      } else imodel = interp_coeffs(ihem,tilt,esw,bazm,imod);
+
+      break;
+
+    case TS18_Kp:
+      ihem = 0; /* no bins for these in TS18-Kp */
+      itlt = 0;
+
+      if (bazm >= TS18_Kp_mod_angih[TS18_Kp_nang-1]) bazm -= 360.;
+      if (bazm <  TS18_Kp_mod_angil[0])              bazm += 360.;
+
+      /* magnitude */
+      for (i=0; (TS18_Kp_mod_levi[i] !=-1) && (kp >= TS18_Kp_mod_levi[i]); i++);
+      if (TS18_Kp_mod_levi[i] == -1) i--;
+      ilev = i;
+
+      /* angle */
+      for (i=0; i < TS18_Kp_nang; i++)
+        if ((bazm >= TS18_Kp_mod_angil[i]) && (bazm < TS18_Kp_mod_angih[i])) break;
+      if (i == TS18_Kp_nang) i--;
+      iang = i;
+  
+      /* correct for extreme Kp */
+      if ((ilev==5) && (iang!=4)) ilev--;
+
+      imodel = model[ihem][itlt][ilev][iang];
+      break;
+  }
+
+  return (imodel); 
+}     
+
+
+struct mdata *get_model_pos(float latmin,int hemi,int *num,float lat_step,float lon_step)
+{
+  struct mdata *ptr=NULL;
+  int nlat,nlon;
+  int i,j;
+  int cnt=0;
+
+  nlat=(int)(90.0-latmin)/lat_step;
+  nlon=(int)(360.0/lon_step);
+
+  if (ptr == NULL) ptr = malloc(sizeof(struct mdata)*nlat*nlon);
+
+  for (i=0;i<nlat;i++) {
+    for (j=0;j<nlon;j++) {
+      ptr[cnt].mlat=i*lat_step+latmin;
+      ptr[cnt].mlon=j*lon_step;
+      ptr[cnt].pot=0;
+      ptr[cnt].azm=0;
+      ptr[cnt].vel=0;
+      cnt++;
+    }
+  }
+
+  *num = cnt;
+
+  return ptr;
+}
+
+double factorial(double n)
+{
+  double nfac=1;
+  int m;
+  for (m=n;m>0;m--) nfac=nfac*m;
+  return nfac;
+}
+
+void cmult(struct complex *a,struct complex *b,struct complex *c)
+{
+  a->x = b->x*c->x - b->y*c->y;
+  a->y = b->x*c->y + b->y*c->x;
+}
+
+void slv_ylm_mod(float theta, float phi, int order, struct complex *ylm_p,
+                 struct complex *ylm_n, double *anorm, double *plm_p,
+                 double *apcnv)
+{
+  int l,m,i;
+  double x;
+  double Pmm;
+  double num,den;
+  double numf,denf;
+  for (l=0;l<=order;l++) {
+    for (m=0;m<=l;m++) {
+       num=l-m;
+       den=l+m;
+
+       numf=factorial(num);
+       denf=factorial(den);
+
+       anorm[l*(order+1)+m]=sqrt((2*l+1)/(4*PI)*numf/denf);
+       apcnv[l*(order+1)+m]=pow(-1,m)*numf/denf;
+    }
+  }
+
+  for (l=0;l<=order;l++) {
+    for (m=0;m<=l;m++) {
+      x=cos(theta);
+
+      Pmm=1.0;
+
+      if (m>0) {
+        double fct;
+        double sx2;
+        sx2=sqrt((1-x)*(1+x));
+        fct=1;
+        for (i=1;i<=m;i++) {
+          Pmm=-Pmm*fct*sx2;
+          fct=fct+2;
+        }
+      }
+      if (l !=m) {
+         double pnmp1;
+         pnmp1=x*(2*m+1)*Pmm;
+         if (l != (m+1)) {
+           double Pll=0;
+           int ll;
+           for (ll=m+2;ll<=l;ll++) {
+             Pll=(x*(2*ll-1)*pnmp1-(ll+m-1)*Pmm)/(ll-m);
+             Pmm=pnmp1;
+             pnmp1=Pll;
+           }
+           Pmm=Pll;
+         } else Pmm=pnmp1;
+      }
+      plm_p[l*(order+1)+m]=Pmm;
+
+      ylm_p[l*(order+1)+m].x=Pmm*anorm[l*(order+1)+m]*cos(m*phi);
+      ylm_p[l*(order+1)+m].y=Pmm*anorm[l*(order+1)+m]*sin(m*phi);
+      ylm_n[l*(order+1)+m].x=pow(-1,m)*ylm_p[l*(order+1)+m].x;
+      ylm_n[l*(order+1)+m].y=-pow(-1,m)*ylm_p[l*(order+1)+m].y;
+
+    }
+  }
+}
+
+void slv_sph_kset(float latmin, int num, float *phi, float *the,
+                  float *the_col, double *ele_phi, double *ele_the,
+                  struct model *mod, double *pot)
+{
+  int i,m,l,n;
+  int ltop,mtop;
+  struct complex *ylm_px=NULL;
+  struct complex *ylm_nx=NULL;
+  double *plm_px=NULL;
+  struct complex *xot_arr=NULL;
+
+  double *pot_arr=NULL;
+  struct complex Ix;
+  struct complex T1,T2;
+  struct complex t;
+/*  float Re=6362.0+300.0; */
+  float Rd = Radial_Dist/1000.;  /* using values in shfconst.h */
+
+  int mlow,mhgh;
+
+  double *anorm,*apcnv;
+
+  ltop=mod->ltop;
+  mtop=mod->mtop;
+  ylm_px=malloc(sizeof(struct complex)*(ltop+1)*(ltop+1)*num);
+  ylm_nx=malloc(sizeof(struct complex)*(ltop+1)*(ltop+1)*num);
+  plm_px=malloc(sizeof(struct complex)*(ltop+1)*(ltop+1)*num);
+  pot_arr=malloc(sizeof(double)*num);
+  xot_arr=malloc(sizeof(struct complex)*num);
+  anorm=malloc(sizeof(double)*(ltop+1)*(ltop+1));
+  apcnv=malloc(sizeof(double)*(ltop+1)*(ltop+1));
+
+
+  if ((ylm_px==NULL) || (ylm_nx==NULL) || (plm_px==NULL) ||
+      (pot_arr==NULL) || (xot_arr==NULL) || (anorm==NULL) ||
+      (apcnv==NULL)) {
+    if (ylm_px !=NULL) free(ylm_px);
+    if (ylm_nx !=NULL) free(ylm_nx);
+    if (plm_px !=NULL) free(plm_px);
+    if (pot_arr !=NULL) free(pot_arr);
+    if (xot_arr !=NULL) free(xot_arr);
+    if (anorm !=NULL) free(anorm);
+    if (apcnv !=NULL) free(apcnv);
+
+  }
+
+  for (i=0;i<num;i++) {
+    slv_ylm_mod(the[i],phi[i],ltop, &ylm_px[(ltop+1)*(ltop+1)*i],
+                                    &ylm_nx[(ltop+1)*(ltop+1)*i], anorm,
+                                    &plm_px[(ltop+1)*(ltop+1)*i], apcnv);
+  }
+
+  for (i=0;i<num;i++) {
+
+    Ix.x=0;
+    Ix.y=0;
+    for (l=0;l<=ltop;l++) {
+      mlow=-l;
+      if (mtop<l) mlow=-mtop;
+      mhgh=-mlow;
+
+      for (m=mlow;m<0;m++) {
+
+        cmult(&t,&mod->aoeff_n[l*(ltop+1)-m],
+              &ylm_nx[i*(ltop+1)*(ltop+1)+l*(ltop+1)-m]);
+
+        Ix.x += t.x;
+        Ix.y += t.y;
+      }
+
+      for (m=0;m<=mhgh;m++) {
+
+        cmult(&t,&mod->aoeff_p[l*(ltop+1)+m],
+              &ylm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m]);
+         Ix.x += t.x;
+         Ix.y += t.y;
+       }
+    }
+
+    pot[i]       = Ix.x;
+    pot_arr[i]   = Ix.x;
+    xot_arr[i].x = Ix.x;
+    xot_arr[i].y = Ix.y;
+  }
+
+  for (i=0;i<num;i++) {
+    Ix.x=0;
+    Ix.y=0;
+
+    for (l=0;l<=ltop;l++) {
+
+      mlow=-l;
+      if (mtop<l) mlow=-mtop;
+      mhgh=-mlow;
+
+      for (m=mlow;m<0;m++) {
+        cmult(&t,&mod->aoeff_n[l*(ltop+1)-m],
+              &ylm_nx[i*(ltop+1)*(ltop+1)+l*(ltop+1)-m]);
+        Ix.x += m*t.x;
+        Ix.y += m*t.y;
+
+      }
+
+      for (m=0;m<=mhgh;m++) {
+
+         cmult(&t,&mod->aoeff_p[l*(ltop+1)+m],
+               &ylm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m]);
+         Ix.x += m*t.x;
+         Ix.y += m*t.y; 
+       }
+    }
+
+    ele_phi[i] = (1000.0/(Rd*sin(the_col[i])))*Ix.y;
+
+    Ix.x=0;
+    Ix.y=0;
+    for (l=0;l<=ltop;l++) {
+      mlow=-l;
+      if (mtop<l) mlow=-mtop;
+      mhgh=-mlow;
+
+      for (m=mlow;m<0;m++) {
+        n=-m;
+        T1.x=n*cos(the[i])/sin(the[i])*
+            plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)-m];
+        T1.y=n*cos(the[i])/sin(the[i])*
+            plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)-m];
+        if ((n+1) <=l) {
+           T2.x=plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+n+1];
+           T2.y=plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+n+1];
+        } else {
+          T2.x=0;
+          T2.y=0;
+        }
+
+        T1.x=(T1.x+T2.x)*pow(-1,m)*cos(m*phi[i])*anorm[l*(ltop+1)-m];
+        T1.y=(T1.y+T2.y)*pow(-1,m)*sin(m*phi[i])*anorm[l*(ltop+1)-m];
+        cmult(&t,&T1,&mod->aoeff_n[l*(ltop+1)-m]);
+        Ix.x += t.x; 
+        Ix.y += t.y;
+      }
+
+      for (m=0;m<=mhgh;m++) {
+        T1.x=m*cos(the[i])/sin(the[i])*
+             plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m];
+        T1.y=m*cos(the[i])/sin(the[i])*
+             plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m];
+        if ((m+1) <=l) {
+          T2.x=plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m+1];
+          T2.y=plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m+1];
+        } else {
+          T2.x=0;
+          T2.y=0;
+        }
+        T1.x=(T1.x+T2.x)*cos(m*phi[i])*anorm[l*(ltop+1)+m];
+        T1.y=(T1.y+T2.y)*sin(m*phi[i])*anorm[l*(ltop+1)+m];
+        cmult(&t,&T1,&mod->aoeff_p[l*(ltop+1)+m]);
+
+        Ix.x += t.x; 
+        Ix.y += t.y;
+      }
+    }
+    if (latmin > 0)
+      ele_the[i]=-1000.0*(180.0/(90.0-latmin))/Rd*Ix.x;
+    else 
+      ele_the[i]=-1000.0*(180.0/(90.0+latmin))/Rd*Ix.x;
+  }
+}
+
+
+int solve_model(int num, struct mdata *ptr, float latmin, struct model *mod,
+                int hemi, float decyear, int noigrf, int old_aacgm)
+{
+  int i;
+  double *ele_phi=NULL,*ele_the=NULL,*pot=NULL;
+  float *phi=NULL,*the=NULL,*the_col=NULL; 
+  double bpolar;
+  double bmag = -0.5e-4;
+
+  if (hemi == 1) bpolar = BNorth;
+  else           bpolar = BSouth;
+
+  if (mod==NULL) return -1; 
+
+  phi     = malloc(sizeof(float)*num);
+  the     = malloc(sizeof(float)*num);
+  the_col = malloc(sizeof(float)*num);
+  ele_the = malloc(sizeof(double)*num);
+  ele_phi = malloc(sizeof(double)*num);
+  pot     = malloc(sizeof(double)*num);
+
+  if ( (phi==NULL) || (the==NULL) || (the_col==NULL) ||
+       (ele_the==NULL) || (ele_phi==NULL) || (pot==NULL) ) {
+    if (phi !=NULL) free(phi);
+    if (the !=NULL) free(the);
+    if (the_col !=NULL) free(the_col);
+    if (ele_the !=NULL) free(ele_the);
+    if (ele_phi !=NULL) free(ele_phi);
+    if (pot !=NULL) free(pot);
+
+    return -1;
+  }
+
+  for (i=0; i<num; i++) {
+    phi[i]     = ptr[i].mlon*PI/180.0;
+    the[i]     = (90-ptr[i].mlat)*(1.0/(90-latmin))*PI;
+    the_col[i] = (90-ptr[i].mlat)*PI/180.0;
+    ele_phi[i] = 0;
+    ele_the[i] = 0;
+    pot[i]     = 0;
+  }
+
+  slv_sph_kset(latmin,num,phi,the,the_col,ele_phi,ele_the,mod,pot);
+
+  for (i=0; i<num; i++) {
+    ele_phi[i] = ele_phi[i]*hemi;
+    ele_the[i] = ele_the[i]*hemi;
+
+    if (noigrf) {
+      bmag = -1e3*bpolar*(1 - 3*Altitude/Re)*
+              sqrt(3.*(cos(the_col[i])*cos(the_col[i]))+1.)/2.;
+    } else {
+      bmag = 1e3*calc_bmag(hemi*ptr[i].mlat,ptr[i].mlon,decyear,old_aacgm);
+    }
+
+    ptr[i].azm        = atan2(ele_the[i]/bmag,ele_phi[i]/bmag)*180./PI;
+    ptr[i].vel        = sqrt( ele_the[i]*ele_the[i] +
+                              ele_phi[i]*ele_phi[i] )/bmag;
+
+    if (fabs(pot[i]) > 0.001) ptr[i].pot = pot[i];
+    if (hemi==-1) ptr[i].mlat = -ptr[i].mlat;
+    ptr[i].mlon = ptr[i].mlon*24.0/360.0;
+  }
+
+  free(the);
+  free(the_col);
+  free(phi);
+  free(ele_phi);
+  free(ele_the);
+  free(pot);
+
+  return 0;
+}
+
+
+double strdate(char *text) {
+
+  double tme;
+  int val;
+  int yr,mo,dy;
+
+  val=atoi(text);
+  dy=val % 100;
+  mo=(val / 100) % 100;
+  yr=(val / 10000);
+
+  if (yr<1970) yr+=1900;
+
+  tme=TimeYMDHMSToEpoch(yr,mo,dy,0,0,0);
+
+  return tme;
+}
+
+
+double strtime(char *text) {
+
+  int hr,mn;
+  int i;
+
+  for (i=0;(text[i] !=':') && (text[i] !=0);i++);
+  if (text[i]==0) return atoi(text)*3600L;
+  text[i]=0;
+  hr=atoi(text);
+  mn=atoi(text+i+1);
+
+  return hr*3600L+mn*60L;
+}
+

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
@@ -339,6 +339,11 @@ int main(int argc,char *argv[]) {
   /* determine the model */
   mod = determine_model(dVx, dBy, dBz, hemisphere, tilt, dKp, imod, nointerp);
 
+  if (mod == NULL) {
+    fprintf(stderr,"PSR10 model not defined for input conditions.\n");
+    exit(-1);
+  }
+
   /* create model grid */
   mdata = get_model_pos(mod->latref,hemisphere,&num,lat_step,lon_step,equal);
 

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
@@ -718,6 +718,11 @@ struct model *interp_coeffs(int ih, float tilt, float mag, float cang, int imod)
   if (ia1 == nang-1) ia2 = 0;
   else ia2 = ia1+1;
 
+  /* check for Bz- saturation */
+  if ((imod == CS10) && (im2 == 5) && ((ia2>2) && (ia2<6))) {
+    ia2 = ia1;
+  }
+
   afac_h = fabs(sin(.5*ahgh[ia1]*PI/180.));
   afac_l = fabs(sin(.5*alow[ia1]*PI/180.));
   afac   = fabs(sin(.5*cang*PI/180.));

--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
@@ -240,7 +240,7 @@ int main(int argc,char *argv[]) {
 
   float lat_step=1.0;
   float lon_step=2.0;
-  int equal = 0;
+  int equal=0;
 
   struct mdata *mdata=NULL;
 
@@ -333,6 +333,9 @@ int main(int argc,char *argv[]) {
 
   if (sh==1) hemisphere = -1;
 
+  if (lat_step < 0.5) lat_step=0.5;
+  if (lon_step < 0.5) lon_step=0.5;
+
   /* determine the model */
   mod = determine_model(dVx, dBy, dBz, hemisphere, tilt, dKp, imod, nointerp);
 
@@ -375,6 +378,8 @@ int main(int argc,char *argv[]) {
       fprintf(stdout,"Bin:   %s, %s\n",mod->level,mod->angle);
       break;
   }
+  if (equal) fprintf(stdout,"Grid: Equal-area (lat_step: %4.2f [deg])\n",lat_step);
+  else       fprintf(stdout,"Grid: Uniform (lat_step: %4.2f, lon_step: %4.2f [deg])\n",lat_step,lon_step);
   fprintf(stdout,"\n");
   fprintf(stdout,"MLAT [deg]   MLT [hr]   Pot [kV] Vazm [deg] Vmag [m/s]\n");
   fprintf(stdout,"---------- ---------- ---------- ---------- ----------\n");
@@ -1016,9 +1021,6 @@ struct mdata *get_model_pos(float latmin,int hemi,int *num,
   double lspc;
   int i,j;
   int cnt=0;
-
-  if (lat_step < 0.5) lat_step=0.5;
-  if (lon_step < 0.5) lon_step=0.5;
 
   nlat=(int)(90.0-latmin)/lat_step;
 


### PR DESCRIPTION
This pull request adds a new `solve_model` binary which, given solar wind / geomagnetic conditions as input via the command line, solves for the model potential and velocity values over either a uniform or equal-area grid and writes to stdout in a fixed-column ASCII-style output.  This supports all available SuperDARN convection models in the RST (RG96, PSR10, CS10, TS18, TS18-Kp).  Below is sample output:

```
Date:  2018-05-21 00:00
Model: TS18-Kp
Bin:   6<Kp<8, Bz-
Grid:  Equal-area (lat_step: 1.00 [deg])

MLAT [deg]   MLT [hr]   Pot [kV] Vazm [deg] Vmag [m/s]
---------- ---------- ---------- ---------- ----------
   46.5000  0.0483871  -0.138252   -90.2309    63.7825
   46.5000   0.145161  -0.136914   -90.2490    63.0686
   46.5000   0.241935  -0.135492   -90.2674    62.3145
   46.5000   0.338710  -0.133989   -90.2861    61.5213
   46.5000   0.435484  -0.132407   -90.3051    60.6902
   46.5000   0.532258  -0.130747   -90.3244    59.8223
...
```
And using a simple IDL routine to read and plot the model velocity vectors and potential contours:

![image](https://user-images.githubusercontent.com/1869073/40330330-9cc50b54-5d1a-11e8-9e74-3755f5593237.png)

Because this program relies on TS18 and TS18-Kp model functionality I am requesting to merge it into the `feature/ts18_model` branch first rather than directly to `develop`.