### PR TITLE
Updating make_fitex and the fitacfex library to no longer immediately seg fault

### DIFF
--- a/codebase/superdarn/src.lib/tk/fitacfex.1.3/src/fitacfex.c
+++ b/codebase/superdarn/src.lib/tk/fitacfex.1.3/src/fitacfex.c
@@ -97,6 +97,12 @@ void FitACFex(struct RadarParm *prm,struct RawData *raw,
       model_vels[nslopes+i] =  model_vel_pos;
    }
 
+   FitSetRng(fit,prm->nrang);
+   if (prm->xcf) {
+     FitSetXrng(fit,prm->nrang);
+     FitSetElv(fit,prm->nrang);
+   }
+
 /* Loop every range gate and calculate parameters */
 
    for (R=0;R<prm->nrang;R++) {
@@ -222,6 +228,12 @@ void FitACFex(struct RadarParm *prm,struct RawData *raw,
                   fit->rng[R].gsct = 1;
          }
       }
+      if (prm->xcf) {
+        fit->xrng[R].phi0 = 0.0;
+        fit->elv[R].normal = 0.0;
+        fit->elv[R].high = 0.0;
+        fit->elv[R].low = 0.0;
+      }
    }
    free(model_phi);
    free(model_vels);
@@ -232,4 +244,6 @@ void FitACFex(struct RadarParm *prm,struct RawData *raw,
    free(data_phi_neg);
    free(lag_avail);
    free(good_lags);
+
+   return;
 }


### PR DESCRIPTION
Following discussions with Ray at the SD workshop last week, this pull request updates the `make_fitex` binary and `fitacfex` library so that calls to `make_fitex` no longer immediately throw a seg fault.  This was occurring because the two underlying .c files were never updated along with the rest of the RST to follow the pointer/structure convention currently being used by the other fitting libraries.

It should be emphasized that I have not modified any of the underlying algorithms and have only made the bare minimum changes to ensure successful execution of `make_fitex` (which I believe was originally designed to fit data collected with tauscan pulse sequences).  Also note that documentation for the `make_fitex` binary was added separately in #157.