### PR TITLE
Add dependencies for CentOS 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@ Radar Software Toolkit
 
 In addition to this code, you will need the following packages:
 
-Debian 8.7 | Mint 18.1 | OpenSUSE 42.2 | Ubuntu 16.04 | macOS 10.12.4
----------- | --------- | ------------- | ------------ | --------------
-gcc | libc6-dev | gcc | libhdf5-serial-dev | libhdf5
-libhdf5-serial-dev | libncurses5-dev | hdf5-devel | libncurses-dev | libnetcdf
-libnetcdf-dev | libnetcdf-dev | libpng16-devel | libnetcdf-dev | libcurses
-libncurses | libpng16-dev | libX11-devel | libpng12-dev | libpng16
-libpng12-dev | libx11-dev | libXext6 | libx11-dev | libx11
-libx11-dev | libxext-dev | libXext-devel | libxext-dev | cdf
-libxext-dev | | netcdf | netpbm | netpbm (10.77.03_2+x11)
-netpbm | | netcdf-devel | |
- | | | ncurses-devel | |
- | | | zlib-devel | |
+Debian 8.7 | Mint 18.1 | OpenSUSE 42.2 | Ubuntu 16.04 | macOS 10.12.4 | CentOS 7
+---------- | --------- | ------------- | ------------ | --------------|----------
+gcc | libc6-dev | gcc | libhdf5-serial-dev | libhdf5 | hdf5-devel
+libhdf5-serial-dev | libncurses5-dev | hdf5-devel | libncurses-dev | libnetcdf | libpng12-devel
+libnetcdf-dev | libnetcdf-dev | libpng16-devel | libnetcdf-dev | libcurses | libX11-devel
+libncurses | libpng16-dev | libX11-devel | libpng12-dev | libpng16 | libXext
+libpng12-dev | libx11-dev | libXext6 | libx11-dev | libx11 | libXext-devel
+libx11-dev | libxext-dev | libXext-devel | libxext-dev | cdf | netcdf
+libxext-dev | | netcdf | netpbm | netpbm (10.77.03_2+x11) | netcdf-devel
+netpbm | | netcdf-devel | | | ncurses-devel
+ | | | ncurses-devel | | | zlib-devel
+ | | | zlib-devel | | |
 
 You will also need the CDF (Common Data Format) library which can be downloaded from NASA.
 You can find the latest release at: http://cdf.gsfc.nasa.gov/  


### PR DESCRIPTION
I just successfully installed RST4.1 on CentOS 7. It required installing the following dependencies:

hdf5-devel
libpng12-devel
libX11-devel
libXext
libXext-devel
netcdf
netcdf-devel
ncurses-devel
zlib-devel

I've added a column for CentOS 7 to the README.md file.

Long term, I'm not sure this is sustainable. I'm about to install RST on a Fedora 26 machine. Where should I put the dependency installation info? I don't think the README can handle another column in the table.