### PR TITLE
Fixing bug in map_addhmb.c

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/map_addhmb.1.17/map_addhmb.c
+++ b/codebase/superdarn/src.bin/tk/tool/map_addhmb.1.17/map_addhmb.c
@@ -239,7 +239,7 @@ int main(int argc,char *argv[])
           fprintf(stderr,"%d-%d-%d %d:%d:%d latmin: median=%g actual=%g\n",
                 yr,mo,dy,hr,mt,(int) sc,latmed,latmin[0]);  
       }
-      (*Map_Read)(fp,map[0],grd[0]);
+      s = (*Map_Read)(fp,map[0],grd[0]);
     }
 
   } else {


### PR DESCRIPTION
This pull request fixes a bug in `map_addhmb.c` of the `map_addhmb` binary identified by Bill Bristow when the boundary latitude is specified on the command line, causing the routine to never return.