### PR TITLE
Updating NASA CDF download link for travis-ci .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ before_install:
   - sudo apt-get -y install libncurses-dev
   - sudo apt-get -y install netpbm
   - sudo apt-get -y install libpng12-dev
-  - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf36_3_1/linux/cdf36_3_1-dist-all.tar.gz
-  - tar -xf cdf36_3_1-dist-all.tar.gz
-  - cd cdf36_3-dist && make clean && make OS=linux ENV=gnu all && make INSTALLDIR=/home/travis/build/SuperDARN/cdf install
+  - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf36_4/linux/cdf36_4-dist-all.tar.gz
+  - tar -xf cdf36_4-dist-all.tar.gz
+  - cd cdf36_4-dist && make clean && make OS=linux ENV=gnu all && make INSTALLDIR=/home/travis/build/SuperDARN/cdf install
   - export RSTPATH=/home/travis/build/SuperDARN/rst
   - . $RSTPATH/.profile.bash
   - export CDF_PATH=/home/travis/build/SuperDARN/cdf


### PR DESCRIPTION
This pull request updates the address used by wget in the `.travis.yml` file to download the CDF software from NASA.  Without this fix, all future Travis-CI builds will fail.