### PR TITLE
Fixing typo in tar options in step 4a of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For Opensuse you will need to make a symlink lcurses library to libncuses (recom
 
 	 ```
 	 cd $RSTPATH/codebase/superdarn/src.lib/tk
-	 tar -P -czuf idl.tar.gz idl
+	 tar -P -czvf idl.tar.gz idl
 	 rm -rf idl
 	 cd $RSTPATH/build/script
 	 make.code


### PR DESCRIPTION
This pull request fixes the typo identified in step 4a of the readme file by @brianbienvenu in issue #170.