### PR TITLE
Adding #ifndef wrapper to map_addhmb.h in hmb library

### DIFF
--- a/codebase/superdarn/src.lib/tk/hmb.1.0/include/map_addhmb.h
+++ b/codebase/superdarn/src.lib/tk/hmb.1.0/include/map_addhmb.h
@@ -2,6 +2,9 @@
  * function prototypes
  */
 
+#ifndef _HMB_H
+#define _HMB_H
+
 struct hmbtab *load_hmb(FILE *fp);
 void make_hmb(void);
 void add_hmb_grd(float latmin,int yr,int yrsec,struct CnvMapData *map,
@@ -10,3 +13,4 @@ void map_addhmb(int yr, int yrsec, struct CnvMapData *map, int bndnp,
                 float bndstep, float latref, float latmin, int old_aacgm);
 int latcmp(const void *a,const void *b);
 
+#endif


### PR DESCRIPTION
As the title indicates, this pull request adds an `#ifndef` wrapper to the `map_addhmb.h` file in the recently separated hmb library.  This fix was previously included in the elevation library pull request (#150) which has since been closed due to other issues.