### PR TITLE
map_plot -gfov option

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/doc/map_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/doc/map_plot.doc.xml
@@ -112,6 +112,8 @@
 </option>
 <option><on>-ffov</on><od>plot the filled radar field of view.</od>
 </option>
+<option><on>-gfov</on><od>only plot fields of view of the radars contributing data (when using -fov and/or -ffov).</od>
+</option>
 <option><on>-tmtick <ar>tick</ar></on><od>set the grid interval for the time clock-dial to <ar>tick</ar> hours.</od>
 </option>
 <option><on>-lst</on><od>use local solar time rather than local time.</od>

--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/make_fov.c
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/make_fov.c
@@ -39,7 +39,7 @@
 #include "polygon.h"
 
 
-
+/* This function returns FOVs for all operational radars */
 struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
                              int chisham,int old_aacgm) {
 
@@ -105,6 +105,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
 }
 
 
+/* This function returns FOVs for only the radars contributing grid vectors */
 struct PolygonData *make_fov_data(struct GridData *gptr,struct RadarNetwork *network,
                                   int chisham,int old_aacgm) {
 

--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/make_fov.h
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/make_fov.h
@@ -26,3 +26,5 @@
 
 struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
                              int chisham,int old_aacgm);
+struct PolygonData *make_fov_data(struct GridData *ptr,struct RadarNetwork *network,
+                                  int chisham,int old_aacgm);

--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
@@ -397,6 +397,7 @@ int main(int argc,char *argv[]) {
   unsigned char ctrflg=0;
   unsigned char hmbflg=0;
   unsigned char fovflg=0;
+  unsigned char gfovflg=0;
   unsigned char nopad=0;
   unsigned char ffovflg=0;
 
@@ -652,6 +653,7 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"hmb",'x',&hmbflg);
   OptionAdd(&opt,"fov",'x',&fovflg);
   OptionAdd(&opt,"ffov",'x',&ffovflg);
+  OptionAdd(&opt,"gfov",'x',&gfovflg);
   OptionAdd(&opt,"exc",'x',&excflg);
 
   OptionAdd(&opt,"pwr",'x',&pwrflg);
@@ -822,7 +824,10 @@ int main(int argc,char *argv[]) {
   else clip=MapSquareClip();
 
   if (lat>90) lat=90*rcmap->hemisphere;
-  if (fovflg || ffovflg) fov=make_fov(rgrid->st_time,network,chisham,old_aacgm);
+  if (fovflg || ffovflg) {
+      if (gfovflg) fov=make_fov_data(rgrid,network,chisham,old_aacgm);
+      else         fov=make_fov(rgrid->st_time,network,chisham,old_aacgm);
+  }
   if ((fovflg || ffovflg) && !magflg) {
     if (old_aacgm) MapModify(fov,AACGMtransform,&flg);
     else           MapModify(fov,AACGM_v2_transform,&flg);
@@ -1142,6 +1147,14 @@ int main(int argc,char *argv[]) {
 
     if (mrgflg) GridMerge(rgrid,rgridmrg);
     if (avflg) GridAverage(rgrid,rgridavg,aval+cprm*(aval !=0)); 
+
+    if ((fovflg || ffovflg) && gfovflg) {
+      fov=make_fov_data(rgrid,network,chisham,old_aacgm);
+      if (!magflg) {
+        if (old_aacgm) MapModify(fov,AACGMtransform,&flg);
+        else           MapModify(fov,AACGM_v2_transform,&flg);
+      }
+    }
     
     /* do plotting here */
     if (rcmap->num_coef !=0) {


### PR DESCRIPTION
This pull request adds a new `-gfov` option which tells `map_plot` to only draw and/or fill FOVs for the radars which provided grid vectors for that particular record (in combination with `-fov` and/or `-ffov`) .