### PR TITLE
Update map_addimf documentation

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
@@ -67,7 +67,7 @@
 
 <quote><em>year month day hour minute second bx by bz vx</em></quote>
 
-<p><strong>NOTE:</strong> The default OMNI invalid measurement value for <em>vx</em> is 99999.9.  This invalid measurement value needs to be modified to be 0.0 in order to select the correct map model.</p>
+<p><strong>NOTE:</strong> The default OMNI invalid measurement value for <em>vx</em> is 99999.9.  This invalid measurement value needs to be modified to 0.0 in order to select the correct map model.</p>
 
 <p>The IMF will be fixed at this value and will only change if a subsequent entry the IMF file alters it.</p>
 </description>

--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
@@ -60,12 +60,14 @@
 <p>If the "<code>-ace</code>" or "<code>-wind</code>" options are specified, the IMF data is taken from the appropriate CDF files for each spacecraft. The files are read from the "ace" and "wind" sub-directories of the path given by given by the "-path" option or by the environment variable "<code>ISTP_PATH</code>".  The argument "<code>-ex</code>" is used to specify how much IMF data should be loaded. By default only 24 hours of data is read.</p>
 <p>The IMF delay can either be fixed using the "<code>-d</code>" option or read from a text file using the "<code>-df</code>" option.  Any lines in the file beginning the character "<code>#</code>" are treated as comments and ignored. Any other lines are expected to contain a time followed by the delay in hours and minutes:</p>
 
-<quote><em>year month day hour minut second dhour dminute</em></quote>
+<quote><em>year month day hour minute second dhour dminute</em></quote>
 
 <p>The delay will be applied to the IMF starting at the time specified and will only change if a subsequent entry in the delay file alters it.</p>
-<p>The "<code>-if</code>" option will read the IMF from the plain text file ifile. Any lines in the file beginning the character "<code>#</code>" are treated as comments and ignored. Any other lines are expected to contain a time followed by the three components of the IMF defined in GSM coordinates.</p>
+<p>The "<code>-if</code>" option will read the IMF from the plain text file ifile. Any lines in the file beginning the character "<code>#</code>" are treated as comments and ignored. Any other lines are expected to contain a time followed by the three components of the IMF defined in GSM coordinates and the solar wind velocity (<em>vx</em>) in km/s units and GSE coordinates. </p>
 
-<quote><em>year month day hour minut second bx by bz</em></quote>
+<quote><em>year month day hour minute second bx by bz vx</em></quote>
+
+<p><strong>NOTE:</strong> The default OMNI invalid measurement value for <em>vx</em> is 99999.9.  This invalid measurement value needs to be modified to be 0.0 in order to select the correct map model.</p>
 
 <p>The IMF will be fixed at this value and will only change if a subsequent entry the IMF file alters it.</p>
 </description>

--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
@@ -58,18 +58,18 @@
 <description><p>Adds IMF and solar wind data to a convection map file.</p>
 <p>The IMF applied to the map file can be fixed, taken from the ACE or Wind spacecraft, or read from a plain text file. The processed file is written to standard output.</p>
 <p>If the "<code>-ace</code>" or "<code>-wind</code>" options are specified, the IMF data is taken from the appropriate CDF files for each spacecraft. The files are read from the "ace" and "wind" sub-directories of the path given by given by the "-path" option or by the environment variable "<code>ISTP_PATH</code>".  The argument "<code>-ex</code>" is used to specify how much IMF data should be loaded. By default only 24 hours of data is read.</p>
-<p>The IMF delay can either be fixed using the "<code>-d</code>" option or read from a text file using the "<code>-df</code>" option.  Any lines in the file beginning the character "<code>#</code>" are treated as comments and ignored. Any other lines are expected to contain a time followed by the delay in hours and minutes:</p>
+<p>The IMF delay can either be fixed using the "<code>-d</code>" option or read from a text file using the "<code>-df</code>" option.  Any lines in the file beginning with the character "<code>#</code>" are treated as comments and ignored. Any other lines are expected to contain a time followed by the delay in hours and minutes:</p>
 
 <quote><em>year month day hour minute second dhour dminute</em></quote>
 
 <p>The delay will be applied to the IMF starting at the time specified and will only change if a subsequent entry in the delay file alters it.</p>
-<p>The "<code>-if</code>" option will read the IMF from the plain text file ifile. Any lines in the file beginning the character "<code>#</code>" are treated as comments and ignored. Any other lines are expected to contain a time followed by the three components of the IMF defined in GSM coordinates and the solar wind velocity (<em>vx</em>) in km/s units and GSE coordinates. </p>
+<p>The "<code>-if</code>" option will read the IMF from the plain text file ifile. Any lines in the file beginning with the character "<code>#</code>" are treated as comments and ignored. Any other lines are expected to contain a time followed by the three components of the IMF defined in GSM coordinates; the solar wind velocity (<em>vx</em>) in km/s units and GSE coordinates; and the Kp index (only used for the TS18-Kp model). </p>
 
-<quote><em>year month day hour minute second bx by bz vx</em></quote>
+<quote><em>year month day hour minute second bx by bz vx kp</em></quote>
 
-<p><strong>NOTE:</strong> The default OMNI invalid measurement value for <em>vx</em> is 99999.9.  This invalid measurement value needs to be modified to 0.0 in order to select the correct map model.</p>
+<p><strong>NOTE:</strong> The default OMNI invalid measurement value for <em>vx</em> is 99999.9.  This invalid measurement value needs to be modified to 0.0 in order to select the correct CS10 or TS18 map model.</p>
 
-<p>The IMF will be fixed at this value and will only change if a subsequent entry the IMF file alters it.</p>
+<p>The IMF will be fixed at this value and will only change if a subsequent entry in the IMF file alters it.</p>
 </description>
 
 <example>


### PR DESCRIPTION
This doesn't change any functional code and just the documentation.  It would be good to get approval from @sshepherd and/or @egthomas that I've captured things accurately here.  This comes from some notes @egthomas noted to me while using the new mapping software.  The biggest thing is the need to have the solar wind speed in the IMF text file when using `-if`.  We also noticed that the default error code for data coming from the OMNI website uses a very large value whereas it should be zero.  So you can't just straight use the OMNI data and it needs to be modified some.

To see the changes, make sure to run `make.doc` and then look at:
`~/doc/superdarn/src.bin/tk/tool/map_addimf/index.html`
with your favorite html browser.
