### PR TITLE
Fix for SMR output formatting

### DIFF
--- a/codebase/superdarn/src.lib/tk/smr.1.7/src/smrwrite.c
+++ b/codebase/superdarn/src.lib/tk/smr.1.7/src/smrwrite.c
@@ -101,7 +101,7 @@ int SmrFwrite(FILE *fp,struct RadarParm *prm,struct FitData *fit,int pwr) {
    n = 0;
    for (i = 0; i < prm->nrang; ++i) if (rng[i] == 1) {
     
-     status = fprintf(fp, "%3d", i);
+     status = fprintf(fp, "%4d", i);
      if (status < 0 ){
         free(rng);
         return -1;


### PR DESCRIPTION
Hi

When generating SMR files, I was noticing that in some cases values were running into each other, causing problems when trying to plot. For example, using a sample from the data from the `hal` radar on 2014-01-22:

```
time = 2014 1818804  4  8  12254 959 4  0 110  180  45 151   0
 10 59102103
    21.3     6.1     9.8    10.9
   235.8   -67.0    74.0   215.7
     17    151    150    230
```

With the fix to the output format, the data now looks like this:

```
time = 2014 1818804  4  8  12254 959 4  0 110  180  45 151   0
  10  59 102 103
    21.3     6.1     9.8    10.9
   235.8   -67.0    74.0   215.7
     17    151    150    230
```