### PR TITLE
Bugfix map_addimf and missing omni/IMF data

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
@@ -69,7 +69,11 @@
 
 <p><strong>NOTE:</strong> The default OMNI invalid measurement value for <em>vx</em> is 99999.9.  This invalid measurement value needs to be modified to 0.0 in order to select the correct CS10 or TS18 map model.</p>
 
-<p>The IMF will be fixed at this value and will only change if a subsequent entry in the IMF file alters it.</p>
+<p>In the case where there is missing IMF data in the middle of the file, the missing values for <em>bx</em>, <em>by</em>, <em>bz</em>, and <em>Vx</em> will be filled in from an interpolation between the two closest values. The IMF will be fixed to the last value if there is missing IMF data at the end of a file.  For example, if the last value is: </p>
+
+<quote><code>2016 12 30 23 17 00     0.64    2.59   -1.96  -336.9</code></quote>
+
+<p>then the records for 23:18 and after will contain the values for IMF and <em>vx</em> in this entry.</p>
 </description>
 
 <example>

--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
@@ -73,7 +73,7 @@
 
 <quote><code>2016 12 30 23 17 00     0.64    2.59   -1.96  -336.9</code></quote>
 
-<p>then the records for 23:18 and after will contain the values for IMF and <em>vx</em> in this entry.  Similarly, if values are missing at the beginning of a file, then the first line in the IMF file will be used where there is missing data until new updates are available in IMF data.</p>
+<p>then the records for 23:18 and after will contain the values for IMF and <em>vx</em> in this entry.  Similarly, if values are missing at the beginning of a file, then the first line in the IMF file will be used in place of the missing data.</p>
 </description>
 
 <example>

--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
@@ -74,7 +74,7 @@
 
 <example>
 <command>map_addimf -vb -old -bx 1.5 -by -1.2 -bx 0.4 19970406.map &gt; 19970406.imf.map</command>
-<description>Adds a fixed IMF of Bx=-15, By=-1.2 and Bz=0.4 to the map file "<coode>19970406.map</code>". The output is stored in the file "<code>19970406.imf.map</code>" and status is logged to standard error.</description>
+<description>Adds a fixed IMF of Bx=-15, By=-1.2 and Bz=0.4 to the map file "<code>19970406.map</code>". The output is stored in the file "<code>19970406.imf.map</code>" and status is logged to standard error.</description>
 </example>
 
 <example>

--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
@@ -73,7 +73,7 @@
 
 <quote><code>2016 12 30 23 17 00     0.64    2.59   -1.96  -336.9</code></quote>
 
-<p>then the records for 23:18 and after will contain the values for IMF and <em>vx</em> in this entry.</p>
+<p>then the records for 23:18 and after will contain the values for IMF and <em>vx</em> in this entry.  Similarly, if values are missing at the beginning of a file, then the first line in the IMF file will be used where there is missing data until new updates are available in IMF data.</p>
 </description>
 
 <example>

--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/doc/map_addimf.doc.xml
@@ -23,7 +23,7 @@
 <option><on>-vb</on><od>verbose. Log information to the console.</od>
 </option>
 <option><on>-old</on><od>the input file is a <code>map</code> format file.</od></option>
-<option><on>-omni</on><od>use data from OMNI.</od>
+<option><on>-omni</on><od>use data from OMNI. (Currently not functional)</od>
 </option>
 <option><on>-ace</on><od>use IMF data from ACE.</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/map_addimf.c
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/map_addimf.c
@@ -1,5 +1,5 @@
 /* map_addimf.c
-   =========== 
+   ===========
    Author: R.J.Barnes and others
 */
 
@@ -51,7 +51,7 @@ FILE *fp;
 
 struct GridData *grd;
 struct CnvMapData *map;
- 
+
 char dpath[256]={"/data"};
 
 double st_time;
@@ -103,7 +103,7 @@ int main(int argc,char *argv[])
   unsigned char vb=0;
 
   char *envstr;
- 
+
   char *dname=NULL;
   struct delaytab *dtable=NULL;
 
@@ -139,8 +139,8 @@ int main(int argc,char *argv[])
   int (*Map_Write)(FILE *, struct CnvMapData *, struct GridData *);
 
   grd = GridMake();
-  map = CnvMapMake(); 
- 
+  map = CnvMapMake();
+
   envstr = getenv("ISTP_PATH");
   if (envstr != NULL) strcpy(dpath,envstr);
 
@@ -191,9 +191,9 @@ int main(int argc,char *argv[])
   }
 
   if (pstr !=NULL) strcpy(dpath,pstr);
-  if (dstr !=NULL) delay=strtime(dstr);  
+  if (dstr !=NULL) delay=strtime(dstr);
   if (estr !=NULL) extent=strtime(estr);
-  
+
   if (arg !=argc) fname=argv[arg];
 
   if (dname !=NULL) {
@@ -202,7 +202,7 @@ int main(int argc,char *argv[])
      dtable=load_delay(fp);
      fclose(fp);
     }
-  }  
+  }
 
   if (iname != NULL) {
     fp = fopen(iname,"r");
@@ -234,7 +234,7 @@ int main(int argc,char *argv[])
   s = (*Map_Read)(fp,map,grd);
 
   st_time = map->st_time - delay;
-  ed_time = map->st_time - delay + extent; 
+  ed_time = map->st_time - delay + extent;
 
   if (wflg == 1)      load_wind();
   else if (aflg == 1) load_ace();
@@ -242,13 +242,13 @@ int main(int argc,char *argv[])
 
   k = 0;
 
-  do {  
+  do {
 
     if (dtable != NULL) {
       while ((k < dtable->num) && (dtable->time[k] <= map->st_time)) k++;
       if (k == 0) delay = dtable->delay[0];
       else        delay = dtable->delay[k-1];
-    }  
+    }
 
     tme = map->st_time - delay;
     map->Bx = dBx;
@@ -286,15 +286,15 @@ int main(int argc,char *argv[])
                  "%d-%d-%d %d:%d:%d delay=%d:%d Bx=%g By=%g Bz=%g Vx=%g Kp=%g\n",
                  yr,mo,dy,hr,mt,(int) sc,(int) (delay/3600),
                  ( (int) delay % 3600)/60, map->Bx,map->By,map->Bz,map->Vx,map->Kp);
-    }  
+    }
 
     s = (*Map_Read)(fp,map,grd);
 
   } while (s != -1);
 
-  fclose(fp); 
+  fclose(fp);
 
-  return 0; 
+  return 0;
 }
 
 
@@ -320,7 +320,7 @@ int findvalue(struct swdata *ptr, double tme, float *val)
   while ((einx < cnt) && (fabs(imf[3*einx]) > fabs(FILL_VALUE/2))) einx++;
   sinx = i-1;
   while ((sinx >= 0)  && (fabs(imf[3*sinx]) > fabs(FILL_VALUE/2))) sinx--;
- 
+
   if (sinx < 0)    sinx = 0;      /* start index */
   if (einx >= cnt) einx = cnt-1;  /* end   index */
 
@@ -451,13 +451,13 @@ struct delaytab *load_delay(FILE *fp)
   ptr=malloc(sizeof(struct delaytab));
   ptr->time=malloc(sizeof(double)*DELAYSTEP);
   ptr->delay=malloc(sizeof(float)*DELAYSTEP);
- 
+
   while(fgets(line,256,fp) !=NULL) {
     for (i=0;(line[i] !=0) && ((line[i]==' ') || (line[i]=='\t') ||
              (line[i] =='\n'));i++);
     if (line[i]==0) continue;
     if (line[i]=='#') continue;
-  
+
     if (sscanf(line,"%d %d %d %d %d %g %d %d",&yr,&mo,&dy,&hr,&mt,&sc,
               &dhr,&dmt) != 8) continue;
 
@@ -476,10 +476,10 @@ struct delaytab *load_delay(FILE *fp)
   ptr->num=cnt;
   ptr->time=realloc(ptr->time,sizeof(double)*cnt);
   ptr->delay=realloc(ptr->delay,sizeof(float)*cnt);
- 
+
   return ptr;
 }
- 
+
 
 double strtime(char *text)
 {
@@ -491,7 +491,7 @@ double strtime(char *text)
   hr=atoi(text);
   mn=atoi(text+i+1);
   return hr*3600L+mn*60L;
-}  
+}
 
 
 int load_omni()
@@ -508,7 +508,7 @@ int load_wind()
 
   CDFid id;
   CDFstatus status;
- 
+
   sprintf(path,"%s/%s",dpath,"wind");
 
   fprintf(stderr,"%s\n",path);
@@ -523,9 +523,9 @@ int load_wind()
       fprintf(stderr,"Could not open cdf file.\n");
       continue;
     }
-  
+
     status=windmfi_imf(id,&sw,st_time,ed_time);
-    
+
     CDFclose(id);
   }
   free_locate(fptr);
@@ -540,7 +540,7 @@ int load_ace()
 
   CDFid id;
   CDFstatus status;
- 
+
   sprintf(path,"%s/%s",dpath,"ace");
   fprintf(stderr,"%s\n",path);
 
@@ -557,12 +557,12 @@ int load_ace()
         continue;
       }
       status=acemfi_imf(id,&sw,st_time,ed_time,0);
-    
+
       CDFclose(id);
     }
     free_locate(fptr);
   } else {
-    free_locate(fptr);    
+    free_locate(fptr);
     fptr=locate_files(path,"k1_mfi",st_time,ed_time);
 
     for (i=0;i<fptr->cnt;i++) {
@@ -573,9 +573,9 @@ int load_ace()
         fprintf(stderr,"Could not open cdf file.\n");
         continue;
       }
-    
+
       status=acemfi_imf(id,&sw,st_time,ed_time,1);
-    
+
       CDFclose(id);
     }
     free_locate(fptr);

--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/map_addimf.c
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/map_addimf.c
@@ -317,8 +317,8 @@ int findvalue(struct swdata *ptr, double tme, float *val)
 
   /* Increment i until end of file or until the start time */
   /* of making the map is reached.  This is likely most */
-  /* useful for sw data that contains multiple days.  The */
-  /* default format from OMNI is a year-long file */
+  /* useful for sw data that contains multiple days.  OMNI */
+  /* data is produced in monthly and yearly files. */
   for (i=0; (i < cnt) && (ptr->time[i] <= tme); i++);
 
   /* Skip over where the IMF value is invalid.  Here invalid */

--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/map_addimf.c
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/map_addimf.c
@@ -312,10 +312,18 @@ int findvalue(struct swdata *ptr, double tme, float *val)
   kp  = ptr->Kp;
   cnt = ptr->cnt;
 
+  /* Fill in with default values */
   for (i=0; i<5; i++) val[i] = FILL_VALUE;
 
+  /* Increment i until end of file or until the start time */
+  /* of making the map is reached.  This is likely most */
+  /* useful for sw data that contains multiple days.  The */
+  /* default format from OMNI is a year-long file */
   for (i=0; (i < cnt) && (ptr->time[i] <= tme); i++);
 
+  /* Skip over where the IMF value is invalid.  Here invalid */
+  /* is evaluated by being greater than half of the */
+  /* FILL_VALUE value. */
   einx = i;
   while ((einx < cnt) && (fabs(imf[3*einx]) > fabs(FILL_VALUE/2))) einx++;
   sinx = i-1;
@@ -326,6 +334,7 @@ int findvalue(struct swdata *ptr, double tme, float *val)
 
   etime = ptr->time[einx];
   stime = ptr->time[sinx];
+  /* These error codes are left unchecked in map_addimf */
   if (tme < stime) return -1;
   if (tme > etime) return -1;
 

--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/map_addimf.c
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/map_addimf.c
@@ -334,9 +334,14 @@ int findvalue(struct swdata *ptr, double tme, float *val)
 
   etime = ptr->time[einx];
   stime = ptr->time[sinx];
-  /* These error codes are left unchecked in map_addimf */
-  if (tme < stime) return -1;
-  if (tme > etime) return -1;
+  /* The tme < stime and tme > etime are believed to be */
+  /* error checking in case something has gone wrong. */
+  /* Otherwise, the sinx != einx condition exempts when there */
+  /* is a gap in IMF data at the beginning or end of an IMF */
+  /* file. These returned error codes are left unchecked */
+  /* in map_addimf(). */
+  if ((tme < stime) && (sinx != einx)) return -1;
+  if ((tme > etime) && (sinx != einx)) return -1;
 
   if (einx != sinx) v = (tme - stime)/(etime - stime);
   else              v = 0;


### PR DESCRIPTION
This pull request fixes part of the bugs that @egthomas and I found (and discussed in #201) while looking at another issue that related to the map_addimf binary.  Here the issue that's addressed is when `map_addimf -if imf.txt` is used and the data in `imf.txt` doesn't always match the time range of the input file into `map_addimf`.

Here's generally how to setup that input file:
```
map_grd 20161230.north.grid2 > step1
map_addhmb step1 > step2
map_addimf -if imf.txt -d 0 step2 > step3
```
where the *.grid2 file is a result of the gridding process and it's possible `map_addhmb` code be skipped but I haven't tested that.  The `imf.txt` file can be any file that fits the input format for dynamic IMF data.  Here the test cases are:

- Remove data in the imf.txt file for the last hour or so at the end of the file.  The current (or version as of a few weeks ago) from the OMNI website (ftp://spdf.gsfc.nasa.gov/pub/data/omni/high_res_omni/) for the one-minute 2016 data that has a big chunk of data missing at the end of 20161230.
- Remove data in the `imf.txt` for an hour or so at the beginning of a file.  This can be done manually with any daily parsed file by opening your favorite text editor and removing some of the files.

From here, do `dmapdump step3 > step3_dump` and then open up `step3_dump` in your favorite text editor.  Here you'll want to look at the `IMF.Bx`, `IMF.By`, and `IMF.Bz` variables.

For the first case, the records at the end of the file will have these IMF values populated with 9999.9 using the `develop` branch.  In this branch, the values will remain constant with whatever the last value in the `imf.txt` file is.  For the case of data missing at the beginning of the file (one day of OMNI data) the 9999.9 values will appear in at the beginning of the dmapdump'ed file using the `develop` branch.  In this branch, the values will be populated with the first line in the `imf.txt` file.  

In addition to this, please run `make.doc` and look at the documentation in `~/superdarn/src.bin/tk/tool/map_addimf/index.html` as I've updated the description of how the `-if` option works in this binary.  You can also refer to this if you've having trouble with the format of the `imf.txt` file that is used with the `-if` option.  From here you can also see the third case (which you could test with if necessary, as a check it still works as in `develop`) where there is a gap in data in the middle of the file.  The documentation is updated to note the values are interpolated as I found in #201.  
