### PR TITLE
Update HMB latitude limit

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/map_addhmb.1.17/map_addhmb.c
+++ b/codebase/superdarn/src.bin/tk/tool/map_addhmb.1.17/map_addhmb.c
@@ -36,9 +36,9 @@
 struct CnvMapData *map[3];
 struct GridData *grd[3];
 
-float bndarr[24][26];
-float lathmb[26];
-int latcnt[26];
+float bndarr[24][36];
+float lathmb[36];
+int latcnt[36];
 
 struct OptionData opt;
 
@@ -94,7 +94,7 @@ int main(int argc,char *argv[])
   float latdef=62;
 
   float latref=59;
-  int nlat=26;
+  int nlat=36;
 
   float bndstep=5;
   int bndnp;

--- a/codebase/superdarn/src.lib/tk/hmb.1.0/src/hmb.c
+++ b/codebase/superdarn/src.lib/tk/hmb.1.0/src/hmb.c
@@ -32,10 +32,10 @@
 #include "map_addhmb.h"
 
 float latref=59;
-int nlat=26;
+int nlat=36;
 
-float bndarr[24][26];
-float lathmb[26];
+float bndarr[24][36];
+float lathmb[36];
 
 #define HMBSTEP 50
 
@@ -183,7 +183,7 @@ void make_hmb()
 
       mlt=m;
 
-      lathmb[n]=n+50.0;
+      lathmb[n]=n+40.0;
       latmin=lathmb[n];
 
       bfac=(90-latmin)/(90-latref);


### PR DESCRIPTION
This updates the HMB geomagnetic latitude boundary limit from 50 degrees to be at 40 degrees, whilst keeping to high-latitude limit the same (76 degrees).
It thus allows for a better fitting of the HMB when using data from the mid-latitude radars, which goes down to ~40 degrees.
