### PR TITLE
Fixing bug in solve_model.c when determining longitude spacing for equal-area grid

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
+++ b/codebase/superdarn/src.bin/tk/tool/solve_model.1.0/solve_model.c
@@ -301,7 +301,7 @@ struct mdata *get_model_pos(float latmin,int hemi,int *num,
     for (i=0;i<nlat;i++) {
 
       grdlat=i*lat_step+latmin+lat_step/2.0;
-      lspc=((int) (360*cos(fabs(grdlat)*PI/180)+0.5))/(360.0);
+      lspc=((int) (360.0/lat_step*cos(fabs(grdlat)*PI/180)+0.5))/(360.0);
       nlon=lspc*360.0;
 
       for (j=0;j<nlon;j++) {


### PR DESCRIPTION
This pull request fixes a bug when using the `-equal` option with `solve_model` to create an output grid with equal-area spacing but a latitudinal step size not equal to one.  For example, on the develop branch setting the `-equal` option and `-lat_step` to 2, eg

`solve_model -equal -lat_step 2 > develop_equal_2.txt`

gives you this:

![develop_equal2](https://user-images.githubusercontent.com/1869073/52376034-1d01d680-2a2f-11e9-9afa-cb270b86339a.png)

whereas executing the same command on this branch will produce this:

![fix_equal2](https://user-images.githubusercontent.com/1869073/52376084-34d95a80-2a2f-11e9-94da-85827d1eb17b.png)

Likewise for a `-lat_step` of 3, eg

`solve_model -equal -lat_step 3 > develop_equal_3.txt`

produces this output:

![develop_equal3](https://user-images.githubusercontent.com/1869073/52376115-46226700-2a2f-11e9-9df1-68e86388b57b.png)

and on this branch:

![fix_equal3](https://user-images.githubusercontent.com/1869073/52376123-4a4e8480-2a2f-11e9-9d59-9bf0e3974b94.png)
