### PR TITLE
Time fix

### DIFF
--- a/codebase/general/src.lib/time.1.7/src/time.c
+++ b/codebase/general/src.lib/time.1.7/src/time.c
@@ -167,7 +167,7 @@ double TimeYMDHMSToJulian(int yr,int mo,int dy,int hr,int mt,double sc) {
   jdoy=i+1720994.5+B;
 
   
-  dfrac=1+TimeYMDHMSToYrsec(yr+1,mo,dy,hr,mt,sc)/DAY_SEC;
+  dfrac=1+(double)TimeYMDHMSToYrsec(yr+1,mo,dy,hr,mt,sc)/DAY_SEC;
    
   return jdoy+dfrac; 
 


### PR DESCRIPTION
Fixing integer division bug in TimeYMDHMSToJulian(). The return type of TimeYMDHMSToYrsec() and the #define constant DAY_SEC are both integers, so the following expression to compute a fraction of a day is not correct:

dfrac=1+TimeYMDHMSToYrsec(yr+1,mo,dy,hr,mt,sc)/DAY_SEC;

The fix is to type cast the return value of the function call to force floating point division:

dfrac=1+(double)TimeYMDHMSToYrsec(yr+1,mo,dy,hr,mt,sc)/DAY_SEC;

This function is correct in the equivalent IDL code and is actually only called by ptime() (which does not seem to be called by any other RST functions) and mlt_v2(). The change does not affect mlt_v2() since it is only used to detect a 30-day threshold, so the incorrect value works okay for this purpose.

The problem was discovered by comparing timestamps in .dat files and has been tested.