### PR TITLE
Fixing segmentation fault in dmap.c when dmap array dimension value is corrupted

### DIFF
--- a/codebase/general/src.lib/dmap.1.25/src/dmap.c
+++ b/codebase/general/src.lib/dmap.1.25/src/dmap.c
@@ -1194,7 +1194,9 @@ struct DataMap *DataMapDecodeBuffer(unsigned char *buf,int size) {
     a->type=type;
     ptr->arr[c]=a;   
     ConvertToInt(buf+off,(int32 *) &(a->dim));
-    if (a->dim <= 0) {
+    /* check for possibly corrupted array dimension size */
+    if (a->dim <= 0 || a->dim > 999) {
+      fprintf(stderr,"Warning: %s array dimension possibly corrupted (%d)\n",a->name,a->dim);
       a->rng=NULL;
       a->data.vptr=NULL;
       break;

--- a/codebase/general/src.lib/dmap.1.25/src/dmap.c
+++ b/codebase/general/src.lib/dmap.1.25/src/dmap.c
@@ -1194,6 +1194,11 @@ struct DataMap *DataMapDecodeBuffer(unsigned char *buf,int size) {
     a->type=type;
     ptr->arr[c]=a;   
     ConvertToInt(buf+off,(int32 *) &(a->dim));
+    if (a->dim <= 0) {
+      a->rng=NULL;
+      a->data.vptr=NULL;
+      break;
+    }
     off+=sizeof(int32);
     a->rng=malloc(a->dim*sizeof(int32));
     if (a->rng==NULL) break;


### PR DESCRIPTION
As the title indicates, this pull request fixes an issue identified by @ksterne when trying to process `20180624.0601.00.hkw.rawacf` on the current `develop` branch.  An `xcfd` array near the end of this file appears to be corrupted with a negative dimension value.  The proposed fix tests for array dim values less than or equal to zero in `DataMapDecodeBuffer` and sets a few uninitialized pointers to NULL before breaking for the later calls to `DataMapFree` and `DataMapFreeArray`.