### PR TITLE
radar.dat update

### DIFF
--- a/tables/superdarn/radar.dat
+++ b/tables/superdarn/radar.dat
@@ -1,3 +1,35 @@
+# radar.dat
+# =========
+#
+# This file contains status information for each radar in the SuperDARN network.
+# Radar information is stored, one radar per line, as a series of white space separated fields.
+# Text fields are quoted (") to allow spaces. The definiton of those fields are as follows:
+#
+# 01  Station ID Number  Unique numerical radar identifier.
+#                        Zero (0) is reserved for a "test" radar. Other numbers are
+#                        allocated on request.
+#
+# 02  Status             Current status of the radar. Possible values are:
+#                        (0)     Offline, or under test
+#                        (1)     Operational
+#                        (-1)    Decommissioned
+#
+# 03  Start Date         First date (YYYYMMDD) that data is available from the radar.
+#
+# 04  End Date           Last date (YYYYMMDD) that data is available from the radar. For
+#                        operational radars, this is set to some future date.
+#
+# 05  Station Name       Full name of the radar site.
+#
+# 06  Operator           Operator, or PI instituition of the radar.
+#
+# 07  Hardware Filename  Filename of the text file containing radar hardware configuration.
+#
+# 08+ Station ID Codes   Station identifiers. Radars are usually identified by a three letter
+#                        code. Older radars also have a single letter code letter. Multiple
+#                        identifiers can be defined and they can be of any length to allow
+#                        short nicknames for a given radar.
+
 0   0 20080203 25000101 "Test Radar"              "United Nations of SuperDARN"         "hdw.dat.tst" "tst" "x"
 1   1 19831001 25000101 "Goose Bay"               "Virginia Tech"                       "hdw.dat.gbr" "gbr" "g"
 2  -1 19861001 19950930 "Schefferville"           "CNRS/LPC2E"                          "hdw.dat.sch" "sch" "s"

--- a/tables/superdarn/radar.dat
+++ b/tables/superdarn/radar.dat
@@ -21,14 +21,16 @@
 #
 # 05  Station Name       Full name of the radar site.
 #
-# 06  Operator           Operator, or PI instituition of the radar.
+# 06  Operator           Operator, or PI institution of the radar.
 #
 # 07  Hardware Filename  Filename of the text file containing radar hardware configuration.
 #
-# 08+ Station ID Codes   Station identifiers. Radars are usually identified by a three letter
-#                        code. Older radars also have a single letter code letter. Multiple
-#                        identifiers can be defined and they can be of any length to allow
-#                        short nicknames for a given radar.
+# 08+ Station ID Codes   Station identifiers. Radars are currently identified by a unique
+#                        three letter code. Older radars were originally identified by a
+#                        single letter code, however this practice was discontinued when
+#                        it became evident the number of radars would surpass the number of
+#                        unique possibilities; these single letter codes are now retained
+#                        for backwards compatibility only.
 
 0   0 20080203 25000101 "Test Radar"              "United Nations of SuperDARN"         "hdw.dat.tst" "tst" "x"
 1   1 19831001 25000101 "Goose Bay"               "Virginia Tech"                       "hdw.dat.gbr" "gbr" "g"
@@ -51,21 +53,21 @@
 19  1 20100401 25000101 "Zhongshan Station"       "Polar Research Institute of China"   "hdw.dat.zho" "zho" "z"
 20  1 20100122 25000101 "McMurdo"                 "University of Alaska Fairbanks"      "hdw.dat.mcm" "mcm" "m"
 21  1 20100214 25000101 "Falkland Islands"        "British Antarctic Survey"            "hdw.dat.fir" "fir" "q"
-22  1 20130122 25000101 "South Pole Station"      "University of Alaska Fairbanks"      "hdw.dat.sps" "sps" "z"
-24  1 20141201 25000101 "Buckland Park"           "La Trobe University"                 "hdw.dat.bpk" "bpk" "i"
+22  1 20130122 25000101 "South Pole Station"      "University of Alaska Fairbanks"      "hdw.dat.sps" "sps"
+24  1 20141201 25000101 "Buckland Park"           "La Trobe University"                 "hdw.dat.bpk" "bpk"
 32  1 20050610 25000101 "Wallops Island"          "JHU/APL"                             "hdw.dat.wal" "wal" "i"
-33  1 20080202 25000101 "Blackstone"              "Virginia Tech"                       "hdw.dat.bks" "bks" "i"
-40  1 20061101 25000101 "Hokkaido East"           "Nagoya University"                   "hdw.dat.hok" "hok" "i"
-41  1 20141029 25000101 "Hokkaido West"           "Nagoya University"                   "hdw.dat.hkw" "hkw" "i"
-64  1 20080101 25000101 "Inuvik"                  "University of Saskatchewan"          "hdw.dat.inv" "inv" "i"
-65  1 20070501 25000101 "Rankin Inlet"            "University of Saskatchewan"          "hdw.dat.rkn" "rkn" "i"
-66  1 20120806 25000101 "Clyde River"             "University of Saskatchewan"          "hdw.dat.cly" "cly" "i"
-90  1 20161019 25000101 "Longyearbyen"            "University Centre in Svalbard"       "hdw.dat.lyr" "lyr" "i"
-96  1 20120112 25000101 "Dome C East"             "IAPS-INAF"                           "hdw.dat.dce" "dce" "i"
-204 1 20091120 25000101 "Fort Hays West"          "Virginia Tech"                       "hdw.dat.fhw" "fhw" "z"
-205 1 20091120 25000101 "Fort Hays East"          "Virginia Tech"                       "hdw.dat.fhe" "fhe" "z"
-206 1 20101104 25000101 "Christmas Valley West"   "Dartmouth College"                   "hdw.dat.cvw" "cvw" "z"
-207 1 20101104 25000101 "Christmas Valley East"   "Dartmouth College"                   "hdw.dat.cve" "cve" "z"
-208 1 20120906 25000101 "Adak West"               "University of Alaska Fairbanks"      "hdw.dat.adw" "adw" "z"
-209 1 20120906 25000101 "Adak East"               "University of Alaska Fairbanks"      "hdw.dat.ade" "ade" "z"
-512 0 20110101 25000101 "EKB Radar"               "Russian Academy of Sciences"         "hdw.dat.ekb" "ekb" "z"
+33  1 20080202 25000101 "Blackstone"              "Virginia Tech"                       "hdw.dat.bks" "bks"
+40  1 20061101 25000101 "Hokkaido East"           "Nagoya University"                   "hdw.dat.hok" "hok"
+41  1 20141029 25000101 "Hokkaido West"           "Nagoya University"                   "hdw.dat.hkw" "hkw"
+64  1 20080101 25000101 "Inuvik"                  "University of Saskatchewan"          "hdw.dat.inv" "inv"
+65  1 20070501 25000101 "Rankin Inlet"            "University of Saskatchewan"          "hdw.dat.rkn" "rkn"
+66  1 20120806 25000101 "Clyde River"             "University of Saskatchewan"          "hdw.dat.cly" "cly"
+90  1 20161019 25000101 "Longyearbyen"            "University Centre in Svalbard"       "hdw.dat.lyr" "lyr"
+96  1 20120112 25000101 "Dome C East"             "IAPS-INAF"                           "hdw.dat.dce" "dce"
+204 1 20091120 25000101 "Fort Hays West"          "Virginia Tech"                       "hdw.dat.fhw" "fhw"
+205 1 20091120 25000101 "Fort Hays East"          "Virginia Tech"                       "hdw.dat.fhe" "fhe"
+206 1 20101104 25000101 "Christmas Valley West"   "Dartmouth College"                   "hdw.dat.cvw" "cvw"
+207 1 20101104 25000101 "Christmas Valley East"   "Dartmouth College"                   "hdw.dat.cve" "cve"
+208 1 20120906 25000101 "Adak West"               "University of Alaska Fairbanks"      "hdw.dat.adw" "adw"
+209 1 20120906 25000101 "Adak East"               "University of Alaska Fairbanks"      "hdw.dat.ade" "ade"
+512 0 20110101 25000101 "EKB Radar"               "Russian Academy of Sciences"         "hdw.dat.ekb" "ekb"


### PR DESCRIPTION
This pull request returns the header information previously included at the top of the `radar.dat` file in RST versions [3.3](https://github.com/SuperDARN/rst-archive/blob/rst.3.3/tables/superdarn/radar.dat) to [3.5](https://github.com/SuperDARN/rst-archive/blob/rst.3.5/tables/superdarn/radar.dat) but removed at some point in [VTRST3.5](https://github.com/SuperDARN/rst-archive/blob/vtrst.3.5/tables/superdarn/radar.dat).  No other changes are made to the contents of the `radar.dat` file.