### PR TITLE
Modifying OldFitWrite of fitwrite.c in the oldfit library to store the offset value in usr_resL1

### DIFF
--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/src/fitwrite.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/src/fitwrite.c
@@ -247,6 +247,8 @@ int OldFitWrite(int fitfp,struct RadarParm *prm,struct FitData *fit,
   oldfit.prms.MXPWR=prm->mxpwr;
   oldfit.prms.LVMAX=prm->lvmax;   
 
+  oldfit.prms.usr_resL1=prm->offset;
+
   if (oldfit.prms.NRANG>ORIG_MAX_RANGE) oldfit.prms.NRANG=ORIG_MAX_RANGE;
     
   for (c=0;c<prm->mppul;c++) oldfit.pulse[c]=prm->pulse[c];


### PR DESCRIPTION
This pull request fixes an issue identified in #231 (unfortunately not the original issue though!) where the `offset` value in the parameter block was being dropped when creating a `fit` file from a `dat` file.  By contrast, the `offset` value is retained when converting a `dat` file to `rawacf` and then creating a `fitacf` file.

To test, follow these steps for both the `develop` branch and this branch:

1. `make_fit -old 2002020202f.dat 2002020202f.fit`
2. `fittofitacf 2002020202f.fit > 2002020202f.fitacf`
3. `dmapdump 2002020202f.fitacf > fitacf.dump`

and then compare the `offset` values in each `fitacf.dump` file.  On the `develop` branch, the values will all be zero, while on this branch they should be 400.  This can be further compared to the output of the following steps on either branch:

1. `dattorawacf 2002020202f.dat > 2002020202f.rawacf`
2. `make_fit 2002020202f.rawacf > 2002020202f.fitacf`
3. `dmapdump 2002020202f.fitacf > fitacf.dump`

where again the `offset` value should be 400.