### PR TITLE
Auto-adjust time domain in time_plot

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -1086,7 +1086,8 @@ int main(int argc,char *argv[]) {
   if (etime !=-1) {
     if (edate==-1) etime+=stime - ( (int) stime % (24*3600));
     else etime+=edate;
-  } else {
+  } else if (extime !=0) etime=stime+extime;
+  else {
    /* determine end time from the last record in the file
       if the total time range is less than 10min then set it to 10min.
       this has been implemented only for fit/fitacf format files */
@@ -1108,7 +1109,7 @@ int main(int argc,char *argv[]) {
   if (etime-stime<10*60) etime=stime+10*60;
   }
 
-  if (extime !=0) etime=stime+extime;
+  
 
   if (name==NULL) name=dname;
 

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -1083,14 +1083,13 @@ int main(int argc,char *argv[]) {
   }
 
   
-
-
   if (etime !=-1) {
     if (edate==-1) etime+=stime - ( (int) stime % (24*3600));
     else etime+=edate;
   } else {
    /* determine end time from the last record in the file
-      (then navigate back to the start time) 
+      (then navigate back to the start time)
+      if the total time range is less than 10min then set it to 10min.
       this has been implemented only for fit/fitacf format files */
     int status=0;
     if (fitflg && old) {
@@ -1109,6 +1108,7 @@ int main(int argc,char *argv[]) {
        status=FitFseek(fitfp,yr,mo,dy,hr,mt,0,NULL,inx);
 
      } else etime=stime+24*3600; /* cfit or smr format: default 24 hour */
+  if (etime-stime<10*60) etime=stime+10*60;
   }
 
   if (extime !=0) etime=stime+extime;

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -1088,7 +1088,6 @@ int main(int argc,char *argv[]) {
     else etime+=edate;
   } else {
    /* determine end time from the last record in the file
-      (then navigate back to the start time)
       if the total time range is less than 10min then set it to 10min.
       this has been implemented only for fit/fitacf format files */
     int status=0;
@@ -1100,13 +1099,11 @@ int main(int argc,char *argv[]) {
        TimeEpochToYMDHMS(stime,&yr,&mo,&dy,&hr,&mt,&sc);
        status=OldFitSeek(oldfitfp,yr,mo,dy,hr,mt,0,NULL);
      } else if (fitflg) {
-       while (status!=-1) status=FitFread(fitfp,prm,fit);
-       etime=TimeYMDHMSToEpoch(prm->time.yr,prm->time.mo,prm->time.dy,
-                               prm->time.hr,prm->time.mt,
-                               prm->time.sc+prm->time.us/1.0e6);
+       double atme;
+       status=FitFseek(fitfp,yr+1,mo,dy,hr,mt,0,&atme,inx);
+       etime=atme;
        TimeEpochToYMDHMS(stime,&yr,&mo,&dy,&hr,&mt,&sc);
        status=FitFseek(fitfp,yr,mo,dy,hr,mt,0,NULL,inx);
-
      } else etime=stime+24*3600; /* cfit or smr format: default 24 hour */
   if (etime-stime<10*60) etime=stime+10*60;
   }

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -1576,6 +1576,7 @@ int main(int argc,char *argv[]) {
   if (xmajor==0) {
     xmajor=3*3600;
     if ((etime-stime)<8*3600) xmajor=3600;
+    if ((etime-stime)<2*3600) xmajor=600;
     if ((etime-stime)>48*3600) xmajor=12*3600;
     if ((etime-stime)>160*3600) xmajor=24*3600;
   }
@@ -1583,6 +1584,7 @@ int main(int argc,char *argv[]) {
   if (xminor==0) {
     xminor=15*60;
     if ((etime-stime)<8*3600) xminor=600;
+    if ((etime-stime)<2*3600) xminor=120;
     if ((etime-stime)>48*3600) xminor=3600;
     if ((etime-stime)>160*3600) xminor=3*3600;
   }


### PR DESCRIPTION
By default, `time_plot` produces plots with a 24-hour range, regardless of the actual time range of the input file (#214). This pull request allows the time range to be determined automatically from the input file, unless the user specifies the end time (`-et`) or extent (`-ex`) of the plot. I have implemented this only for the FIT/FITACF format files. CFIT and SMR are a mystery to me ;)

I hope my implementation is not too much of a hack. I used `FitFread()` to loop through to the last record in the file, and then calculate the end time from the last value of `prm->time`. It is then necessary to use `FitSeek()` to jump back to the start time before the data are read in "for real". 

`time_plot -png -a -b 7 20170505.0601.00.sas.fitacf` now produces this: 

![tplot](https://user-images.githubusercontent.com/22493623/59867826-8efc0c00-938f-11e9-85fe-79d152ab6c39.png)