### PR TITLE
Fixing pointer comparisons

### DIFF
--- a/codebase/superdarn/src.bin/tk/reformat/dattorawacf.1.8/dattorawacf.c
+++ b/codebase/superdarn/src.bin/tk/reformat/dattorawacf.1.8/dattorawacf.c
@@ -162,7 +162,7 @@ int main(int argc,char *argv[]) {
   if (rawfp==NULL) {
     fprintf(stderr,"File not found.\n");
     exit(-1);
-  } else if (rawfp->rawread==-2) {
+  } else if (rawfp->error==-2) {
     /* Error case where num_bytes < 0 */
     free(rawfp);
     exit(-1);

--- a/codebase/superdarn/src.bin/tk/testing/test_raw.1.12/test_raw.c
+++ b/codebase/superdarn/src.bin/tk/testing/test_raw.1.12/test_raw.c
@@ -116,7 +116,7 @@ int main (int argc,char *argv[]) {
       if (rawfp==NULL) {
         fprintf(stderr,"Could not open file %s.\n",argv[c]);
         continue;
-      } else if (rawfp->rawread==-2) {
+      } else if (rawfp->error==-2) {
       /* Error case where num_bytes is less than 0 */
         free(rawfp);
         exit(-1);

--- a/codebase/superdarn/src.bin/tk/tool/cat_raw.1.14/cat_raw.c
+++ b/codebase/superdarn/src.bin/tk/tool/cat_raw.1.14/cat_raw.c
@@ -131,7 +131,7 @@ int main (int argc,char *argv[]) {
     if (infp==NULL) {
       fprintf(stderr,"Could not open file %s.\n",argv[i]);
       continue;
-    } else if(infp->rawread==-2) {
+    } else if(infp->error==-2) {
         /* Error case where num_bytes is less than 0 */
         free(infp);
         exit(-1);

--- a/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
@@ -189,7 +189,7 @@ int main(int argc,char *argv[]) {
      if (rawfp==NULL) {
        fprintf(stderr,"File not found.\n");
        exit(-1);
-     } else if (rawfp->rawread==-2) {
+     } else if (rawfp->error == -2) {
        /* Error case where num_bytes is less than 0 */
        free(rawfp);
        exit(-1);

--- a/codebase/superdarn/src.bin/tk/tool/make_fitex.1.4/make_fitex.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fitex.1.4/make_fitex.c
@@ -138,7 +138,7 @@ int main(int argc,char *argv[]) {
     if (rawfp==NULL) {
       fprintf(stderr,"File not found.\n");
       exit(-1);
-    } else if (rawfp->rawread==-2) {
+    } else if (rawfp->error==-2) {
         /* Error case where num_bytes is less than 0 */
         free(rawfp);
         exit(-1);

--- a/codebase/superdarn/src.bin/tk/tool/make_fitex2.1.0/make_fitex2.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fitex2.1.0/make_fitex2.c
@@ -165,7 +165,7 @@ int main(int argc,char *argv[])
       if (rawfp==NULL) {
           fprintf(stderr,"File not found.\n");
           exit(-1);
-      } else if (rawfp->rawread==-2) {
+      } else if (rawfp->error==-2) {
           /* Error case where num_bytes is less than 0 */
           free(rawfp);
           exit(-1);

--- a/codebase/superdarn/src.bin/tk/tool/make_info.1.13/make_info.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_info.1.13/make_info.c
@@ -240,7 +240,7 @@ int main(int argc,char *argv[]) {
         if (rawfp==NULL) {
           fprintf(stderr,"file %s not found\n",argv[c]);
           continue;
-        } else if (rawfp->rawread==-2) {
+        } else if (rawfp->error==-2) {
             /* Error case where num_bytes is less than 0 */
             free(rawfp);
             exit(-1);

--- a/codebase/superdarn/src.bin/tk/tool/make_lmfit.1.0/make_lmfit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_lmfit.1.0/make_lmfit.c
@@ -166,7 +166,7 @@ int main(int argc,char *argv[])
       if (rawfp==NULL) {
           fprintf(stderr,"File not found.\n");
           exit(-1);
-      } else if (rawfp->rawread==-2) {
+      } else if (rawfp->error==-2) {
           /* Error code for num_bytes less than 0 */
           free(rawfp);
           exit(-1);

--- a/codebase/superdarn/src.bin/tk/tool/raw_cp.1.5/raw_cp.c
+++ b/codebase/superdarn/src.bin/tk/tool/raw_cp.1.5/raw_cp.c
@@ -119,7 +119,7 @@ int main (int argc,char *argv[]) {
       if (rawfp==NULL) {
         fprintf(stderr,"File %s not found.\n",argv[c]);
         continue;
-      } else if (rawfp->rawread==-2) {
+      } else if (rawfp->error==-2) {
         /* Error code where num_bytes < 0 */
         free(rawfp);
         continue;

--- a/codebase/superdarn/src.bin/tk/tool/rawstat.1.5/rawstat.c
+++ b/codebase/superdarn/src.bin/tk/tool/rawstat.1.5/rawstat.c
@@ -128,7 +128,7 @@ int main (int argc,char *argv[]) {
     if (rawfp==NULL) {
       fprintf(stderr,"file %s not found\n",argv[arg]);
       exit(2);
-    } else if (rawfp->rawread==-2) {
+    } else if (rawfp->error==-2) {
         /* Error case where num_bytes is less than 0 */
         free(rawfp);
         exit(-1);

--- a/codebase/superdarn/src.bin/tk/tool/trim_raw.1.15/trim_raw.c
+++ b/codebase/superdarn/src.bin/tk/tool/trim_raw.1.15/trim_raw.c
@@ -196,7 +196,7 @@ int main (int argc,char *argv[]) {
     if (rawfp==NULL) {
       fprintf(stderr,"File not found.\n");
       exit(-1);
-    } else if (rawfp->rawread==-2) {
+    } else if (rawfp->error==-2) {
         /* Error case where num_bytes is less than 0 */
         free(rawfp);
         exit(-1);

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/include/oldrawread.h
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/include/oldrawread.h
@@ -48,7 +48,7 @@ struct OldRawFp {
   int major_rev;
   int minor_rev;
   int (*rawread)(struct OldRawFp *ptr,struct RadarParm *,struct RawData *);
-
+  int error; 
 };
 
 

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/src/rawopen.c
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/src/rawopen.c
@@ -84,6 +84,7 @@ struct OldRawFp *OldRawOpenFd(int rawfd,int inxfd) {
   ptr->frec=0;
   ptr->rlen=0;
   ptr->ptr=0;
+  ptr->error=0;
 
   fstat(ptr->rawfp,&ptr->rstat);
 
@@ -92,7 +93,7 @@ struct OldRawFp *OldRawOpenFd(int rawfd,int inxfd) {
         fprintf(stderr,"WARNING : rawopen : OldRawOpenFd : num_byte < 0 in record header, potentially corrupted file.\n");
         close(ptr->rawfp);
         free(inbuf);
-        ptr->rawread=-2;
+        ptr->error=-2;
         return ptr;
     }
     close(ptr->rawfp);


### PR DESCRIPTION
As addressed in Issue #233 coming from PR #165, I created a hotfix to remove the warnings. 

This is not a complete solution nor it is best practices but good enough for now until we determine the error codes standard for RST.

 develop branch compilation:
`make.code |& grep "warning" | wc -l 
127`

`make_fit -old 2001102410w.dat w_fit
WARNING : rawopen : OldRawOpenFd : num_byte < 0 in record header, potentially corrupted file.`

fix/pointer_comparison 
`make.code |& grep "warning" | wc -l 
114`

`make_fit -old 2001102410w.dat w_fit
WARNING : rawopen : OldRawOpenFd : num_byte < 0 in record header, potentially corrupted file.`


