### PR TITLE
Fixed the typo in rtgrid

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/doc/rtgrid.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/doc/rtgrid.doc.xml
@@ -95,15 +95,15 @@
 </description>
 
 <example>
-<command>rtgrid -L log -tl 120 -i 120 -if pid.id kapqnx.jhuapl.edu 1024</command>
-<description>Generate a grdmap file using the real-time data stream from the host "<code>kapqnx.jhuapl.edu</code>", served at port 1024. Ignore the scan flag and use a scan length of two minutes. Generate a record every two minutes.  The process identifier is recorded in the file "<code>pid.id</code>", logs of all transactions are recorded in the file "<code>log.<em>yyyymmdd</em></code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, and <em>dd</em> is the day.
+    <command>rtgrid -L log -tl 120 -i 120 -if pid.id <ip address/hostname> <port number></command>
+            <description>Generate a grdmap file using the real-time data stream from the specified <ip address/hostname>, served at the provided <port number>. Ignore the scan flag and use a scan length of two minutes. Generate a record every two minutes.  The process identifier is recorded in the file "<code>pid.id</code>", logs of all transactions are recorded in the file "<code>log.<em>yyyymmdd</em></code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, and <em>dd</em> is the day.
 </description>
 </example>
 
 <example>
-<command>rtgrid -rpf -L log -if pid.id -p /data/rt/grd gbayqnx.jhuapl.edu port.gbr</command>
+    <command>rtgrid -rpf -L log -if pid.id -p /data/rt/grd <ip address/hostname> port.<radar identifier></command>
 <description>
-Generate a grdmap file using the real-time data stream from the host "<code>gbayqnx.jhuapl.edu</code>", served at port contained in the file "<code>port.gbr</code>". The process identifier is recorded in the file "<code>pid.id</code>", and logs of all transactions are recorded in the file "<code>log.<em>yyyymmdd</em></code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, and <em>dd</em> is the day.
+    Generate a grdmap file using the real-time data stream from the specified ip address/hostname, served at the port number contained in the file "<code>port.<radar identifier></code>". The process identifier is recorded in the file "<code>pid.id</code>", and logs of all transactions are recorded in the file "<code>log.<em>yyyymmdd</em></code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, and <em>dd</em> is the day.
 The daily files are stored in the directory "<code>/data/rt/grd</code>".
 </description>
 </example>

--- a/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/doc/rtgrid.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/doc/rtgrid.doc.xml
@@ -16,9 +16,9 @@
 </option>
 <option><on>-i <ar>intt</ar></on><od>integrate the grid data into records of length <ar>intt</ar> seconds.</od>
 </option>
-<option><on>-cn <ar>channel</ar></on><od>process data from channel <ar>channel</ar> for stereo mode data.</od>
+<option><on>-cn <ar>channel</ar></on><od>process data from a specific channel number for stereo mode data or twofsound data.</od>
 </option>
-<option><on>-ebm <ar>ebeams</ar></on><od>exclude the beams listed in <ar>ebeams</ar>, which is a comma separated list of beam numbers.</od>
+<option><on>-ebm <ar>ebeams</ar></on><od>exclude the beam numbers listed in <ar>ebeams</ar>, comma separated.</od>
 </option>
 <option><on>-minrng <ar>minrange</ar></on><od>exclude data from range gates lower than <ar>minrange</ar>.</od>
 </option>
@@ -95,15 +95,14 @@
 </description>
 
 <example>
-    <command>rtgrid -L log -tl 120 -i 120 -if pid.id <ip address/hostname> <port number></command>
-            <description>Generate a grdmap file using the real-time data stream from the specified <ip address/hostname>, served at the provided <port number>. Ignore the scan flag and use a scan length of two minutes. Generate a record every two minutes.  The process identifier is recorded in the file "<code>pid.id</code>", logs of all transactions are recorded in the file "<code>log.<em>yyyymmdd</em></code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, and <em>dd</em> is the day.
+<command>rtgrid -L log -tl 120 -i 120 -if pid.id &lt;ip address/hostname&gt; &lt;port number&gt;</command>
+<description>Generate a grdmap file using the real-time data stream from the specified &lt;ip address/hostname&gt;, served at the provided &lt;port number&gt;. Ignore the scan flag and use a scan length of two minutes. Generate a record every two minutes.  The process identifier is recorded in the file "<code>pid.id</code>", logs of all transactions are recorded in the file "<code>log.<em>yyyymmdd</em></code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, and <em>dd</em> is the day.
 </description>
 </example>
 
 <example>
-    <command>rtgrid -rpf -L log -if pid.id -p /data/rt/grd <ip address/hostname> port.<radar identifier></command>
-<description>
-    Generate a grdmap file using the real-time data stream from the specified ip address/hostname, served at the port number contained in the file "<code>port.<radar identifier></code>". The process identifier is recorded in the file "<code>pid.id</code>", and logs of all transactions are recorded in the file "<code>log.<em>yyyymmdd</em></code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, and <em>dd</em> is the day.
+<command>rtgrid -rpf -L log -if pid.id -p /data/rt/grd &lt;ip address/hostname&gt; port.&lt;radar identifier&gt;</command>
+<description> Generate a grdmap file using the real-time data stream from the specified ip address/hostname, served at the port number contained in the file "<code>port.&lt;radar identifier&gt;</code>". The process identifier is recorded in the file "<code>pid.id</code>", and logs of all transactions are recorded in the file "<code>log.<em>yyyymmdd</em></code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, and <em>dd</em> is the day.
 The daily files are stored in the directory "<code>/data/rt/grd</code>".
 </description>
 </example>

--- a/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/doc/rtgrid.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/doc/rtgrid.doc.xml
@@ -101,7 +101,7 @@
 </example>
 
 <example>
-<command>rtgrid -rpf -L log -pf port.id -if pid.id -p /data/rt/grd gbayqnx.jhuapl.edu port.gbr</command>
+<command>rtgrid -rpf -L log -if pid.id -p /data/rt/grd gbayqnx.jhuapl.edu port.gbr</command>
 <description>
 Generate a grdmap file using the real-time data stream from the host "<code>gbayqnx.jhuapl.edu</code>", served at port contained in the file "<code>port.gbr</code>". The process identifier is recorded in the file "<code>pid.id</code>", and logs of all transactions are recorded in the file "<code>log.<em>yyyymmdd</em></code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, and <em>dd</em> is the day.
 The daily files are stored in the directory "<code>/data/rt/grd</code>".


### PR DESCRIPTION
I found a typo in `rtgrid` documentation that I pointed it out in PR #186 but then merged that PR. So this PR is now focused on fixing that one typo. 

One question I do have is, do we still want to use the address in the example:  gbayqnx.jhuapl.edu?
It didn't work and APL doesn't run GoosBay anymore.  

