### PR TITLE
"Grid file not found" error message

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/map_addhmb.1.17/map_addhmb.c
+++ b/codebase/superdarn/src.bin/tk/tool/map_addhmb.1.17/map_addhmb.c
@@ -188,7 +188,7 @@ int main(int argc,char *argv[])
   if (fname==NULL) fp=stdin;
   else fp=fopen(fname,"r");
   if (fp==NULL) {
-    fprintf(stderr,"Grid file not found.\n");
+    fprintf(stderr,"File not found.\n");
     exit(-1);
   }
 

--- a/codebase/superdarn/src.bin/tk/tool/map_addmodel.1.14/map_addmodel.c
+++ b/codebase/superdarn/src.bin/tk/tool/map_addmodel.1.14/map_addmodel.c
@@ -185,7 +185,7 @@ int main(int argc,char *argv[]) {
   if (fname==NULL) fp=stdin;
   else fp=fopen(fname,"r");
   if (fp==NULL) {
-    fprintf(stderr,"Grid file not found.\n");
+    fprintf(stderr,"File not found.\n");
     exit(-1);
   }
 


### PR DESCRIPTION
This PR fixes issue #251 - confusing error message in `map_addmodel`

If `map_addmodel [file]` is called in a directory where `[file]` does not exist, the error message now reads "File not found" instead of "Grid file not found"