### PR TITLE
Updating iqdat analysis tools

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
@@ -16,6 +16,26 @@
 </option>
 <option><on>-h <ar>height</ar></on><od>set the height of the plot to <ar>height</ar>.</od>
 </option>
+<option><on>-r</on><od>plot the real (I) component of the I&Q samples.</od>
+</option>
+<option><on>-i</on><od>plot the imaginary (Q) component of the I&Q samples.</od>
+</option>
+<option><on>-p</on><od>plot the power of the I&Q samples on a logarithmic scale.</od>
+</option>
+<option><on>-m <ar>ymax</ar></on><od>set the extent of the Y-axis to +/-<ar>ymax</ar> when plotting I&Q components.</od>
+</option>
+<option><on>-s <ar>xmin</ar></on><od>set the first I&Q sample plotted to <ar>xmin</ar>.</od>
+</option>
+<option><on>-n <ar>xnum</ar></on><od>set the number of I&Q samples plotted to <ar>xnum</ar>.</od>
+</option>
+<option><on>-xmaj <ar>xmajor</ar></on><od>set the number of X-axis major tick marks to <ar>xmajor</ar>.</od>
+</option>
+<option><on>-xmin <ar>xminor</ar></on><od>set the number of X-axis minor tick marks to <ar>xminor</ar>.</od>
+</option>
+<option><on>-ymaj <ar>ymajor</ar></on><od>set the number of Y-axis major tick marks to <ar>ymajor</ar>.</od>
+</option>
+<option><on>-ymin <ar>yminor</ar></on><od>set the number of Y-axis minor tick marks to <ar>yminor</ar>.</od>
+</option>
 <option><on><ar>name</ar></on><od>the filename of the <code>iqdat</code> format file to plot.</od>
 </option>
 <option><on>-display <ar>display</ar></on><od>connect to the xterminal named <ar>display</ar>.</od>

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
@@ -34,6 +34,8 @@
 </option>
 <option><on>-p</on><od>plot the power of the I&Q samples on a logarithmic scale.</od>
 </option>
+<option><on>-b <ar>bmnum</ar></on><od>only plot the I&Q samples from beam number <ar>bmnum</ar>.</od>
+</option>
 <option><on>-int</on><od>plot I&Q samples from the interferometer array instead of the main array.</od>
 </option>
 <option><on>-rcol <ar>rrggbb</ar></on><od>set the color of the real (I) component to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color [default is teal].</od>

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
@@ -12,9 +12,9 @@
 </option>
 <option><on>-cf <ar>cfname</ar></on><od>read command line options from the file <ar>cfname</ar>.</od>
 </option>
-<option><on>-w <ar>width</ar></on><od>set the width of the plot to <ar>width</ar>.</od>
+<option><on>-wdt <ar>width</ar></on><od>set the width of the plot to <ar>width</ar>.</od>
 </option>
-<option><on>-h <ar>height</ar></on><od>set the height of the plot to <ar>height</ar>.</od>
+<option><on>-hgt <ar>height</ar></on><od>set the height of the plot to <ar>height</ar>.</od>
 </option>
 <option><on>-r</on><od>plot the real (I) component of the I&Q samples.</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
@@ -24,6 +24,8 @@
 </option>
 <option><on>-yoff <ar>yoff</ar></on><od>open the window <ar>ypad</ar> pixels from the top edge of the screen.</od>
 </option>
+<option><on>-delay <ar>delay</ar></on><od>set the delay between frames to <ar>delay</ar> milliseconds, a value of 0 will pause the frame until a mouse button is pressed.</od>
+</option>
 
 <synopsis><p>Plot raw I&Q samples from a <code>iqdat</code> format file.</p></synopsis>
 <description><p>Plot raw I&Q <code>iqdat</code> format files.</p>

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
@@ -34,6 +34,8 @@
 </option>
 <option><on>-p</on><od>plot the power of the I&Q samples on a logarithmic scale.</od>
 </option>
+<option><on>-int</on><od>plot I&Q samples from the interferometer array instead of the main array.</od>
+</option>
 <option><on>-rcol <ar>rrggbb</ar></on><od>set the color of the real (I) component to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color [default is teal].</od>
 </option>
 <option><on>-icol <ar>rrggbb</ar></on><od>set the color of the imaginary (Q) component to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color [default is red].</od>

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
@@ -34,6 +34,10 @@
 </option>
 <option><on>-p</on><od>plot the power of the I&Q samples on a logarithmic scale.</od>
 </option>
+<option><on>-rcol <ar>rrggbb</ar></on><od>set the color of the real (I) component to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color [default is teal].</od>
+</option>
+<option><on>-icol <ar>rrggbb</ar></on><od>set the color of the imaginary (Q) component to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color [default is red].</od>
+</option>
 <option><on>-m <ar>ymax</ar></on><od>set the extent of the Y-axis to +/-<ar>ymax</ar> when plotting I&Q components.</od>
 </option>
 <option><on>-s <ar>xmin</ar></on><od>set the first I&Q sample plotted to <ar>xmin</ar>.</od>

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
@@ -10,6 +10,8 @@
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
+<option><on>--version</on><od>print the RST version number and exit.</od>
+</option>
 <option><on>-cf <ar>cfname</ar></on><od>read command line options from the file <ar>cfname</ar>.</od>
 </option>
 <option><on>-sd <ar>yyyymmdd</ar></on><od>plot starting from the date <ar>yyyymmdd</ar>.</od>

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
@@ -36,6 +36,8 @@
 </option>
 <option><on>-b <ar>bmnum</ar></on><od>only plot the I&Q samples from beam number <ar>bmnum</ar>.</od>
 </option>
+<option><on>-c <ar>chnum</ar></on><od>only plot the I&Q samples from channel <ar>chnum</ar> for stereo mode data.</od>
+</option>
 <option><on>-int</on><od>plot I&Q samples from the interferometer array instead of the main array.</od>
 </option>
 <option><on>-rcol <ar>rrggbb</ar></on><od>set the color of the real (I) component to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color [default is teal].</od>

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
@@ -12,6 +12,16 @@
 </option>
 <option><on>-cf <ar>cfname</ar></on><od>read command line options from the file <ar>cfname</ar>.</od>
 </option>
+<option><on>-sd <ar>yyyymmdd</ar></on><od>plot starting from the date <ar>yyyymmdd</ar>.</od>
+</option>
+<option><on>-st <ar>hr:mn</ar></on><od>plot starting from the time <ar>hr:mn</ar>.</od>
+</option>
+<option><on>-ed <ar>yyyymmdd</ar></on><od>stop plotting at the date <ar>yyyymmdd</ar>.</od>
+</option>
+<option><on>-et <ar>hr:mn</ar></on><od>stop plotting at the time <ar>hr:mn</ar>.</od>
+</option>
+<option><on>-ex <ar>hr:mn</ar></on><od>plot an interval whose extent is <ar>hr:mn</ar>.</od>
+</option>
 <option><on>-wdt <ar>width</ar></on><od>set the width of the plot to <ar>width</ar>.</od>
 </option>
 <option><on>-hgt <ar>height</ar></on><od>set the height of the plot to <ar>height</ar>.</od>

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
@@ -321,6 +321,9 @@ int main(int argc,char *argv[]) {
   unsigned rcol=0xff00ffff;
   unsigned icol=0xffff0000;
 
+  char *rcol_txt=NULL;
+  char *icol_txt=NULL;
+
   prm=RadarParmMake();
   iq=IQMake();
  
@@ -358,6 +361,9 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"sd",'t',&sdtestr);
   OptionAdd(&opt,"ed",'t',&edtestr);
   OptionAdd(&opt,"ex",'t',&exstr);
+
+  OptionAdd(&opt,"rcol",'t',&rcol_txt);
+  OptionAdd(&opt,"icol",'t',&icol_txt);
 
   OptionAdd(&opt,"xmaj",'i',&xmajor);
   OptionAdd(&opt,"xmin",'i',&xminor);
@@ -413,6 +419,9 @@ int main(int argc,char *argv[]) {
   if (etmestr !=NULL) etime=strtime(etmestr);
   if (sdtestr !=NULL) sdate=strdate(sdtestr);
   if (edtestr !=NULL) edate=strdate(edtestr);
+
+  if (rcol_txt !=NULL) rcol=PlotColorStringRGBA(rcol_txt);
+  if (icol_txt !=NULL) icol=PlotColorStringRGBA(icol_txt);
 
   if (arg<argc) fp=fopen(argv[arg],"r");
   else fp=stdin;

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
@@ -552,6 +552,7 @@ int main(int argc,char *argv[]) {
 
     for (n=0;n<iq->seqnum;n++) {
       tval=iq->tval[n].tv_sec+(1.0*iq->tval[n].tv_nsec)/1.0e9;
+      if (tval == 0) tval=atime;
       PlotPlotStart(plot,"image",wdt,hgt,24);
       PlotRectangle(plot,NULL,0,0,wdt,hgt,1,bgcol,0x0f,0,NULL);
       pxmin=xmin;

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
@@ -270,6 +270,7 @@ int main(int argc,char *argv[]) {
 
   unsigned char help=0;
   unsigned char option=0;
+  unsigned char version=0;
 
   int status=0;
   double atime;
@@ -337,6 +338,7 @@ int main(int argc,char *argv[]) {
 
   OptionAdd(&opt,"-help",'x',&help);
   OptionAdd(&opt,"-option",'x',&option);
+  OptionAdd(&opt,"-version",'x',&version);
 
   OptionAdd(&opt,"wdt",'f',&wdt);
   OptionAdd(&opt,"hgt",'f',&hgt);
@@ -398,6 +400,11 @@ int main(int argc,char *argv[]) {
 
   if (option==1) {
     OptionDump(stdout,&opt);
+    exit(0);
+  }
+
+  if (version==1) {
+    OptionVersion(stdout);
     exit(0);
   }
 

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
@@ -205,7 +205,7 @@ int main(int argc,char *argv[]) {
   float lne=0.5;
 
   struct timeval tmout;
-  float delay=0;
+  float delay=0.001;
 
   int xdf=0;
   struct XwinDisplay *dp;
@@ -281,6 +281,7 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"display",'t',&display_name);
   OptionAdd(&opt,"xoff",'i',&xdoff);
   OptionAdd(&opt,"yoff",'i',&ydoff);
+  OptionAdd(&opt,"delay",'f',&delay);
   OptionAdd(&opt,"m",'i',&ymax);
   OptionAdd(&opt,"s",'i',&xmin);
   OptionAdd(&opt,"n",'i',&xnum);
@@ -458,7 +459,7 @@ int main(int argc,char *argv[]) {
       tmout.tv_sec=(int) delay;
       tmout.tv_usec=(delay-(int) delay)*1e6;
       if (delay !=0) XwinDisplayEvent(dp,1,&win,1,&tmout);
-      else XwinDisplayEvent(dp,1,&win,1,&tmout);
+      else XwinDisplayEvent(dp,1,&win,1,NULL);
      
       FrameBufferFree(img);
       img=NULL;

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
@@ -266,6 +266,7 @@ int main(int argc,char *argv[]) {
   unsigned char rflg=0;
   unsigned char iflg=0;
 
+  int bmnum=-1;
   unsigned char interfer=0;
 
   unsigned char help=0;
@@ -356,6 +357,7 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"i",'x',&iflg);
   OptionAdd(&opt,"p",'x',&pflg);
 
+  OptionAdd(&opt,"b",'i',&bmnum);
   OptionAdd(&opt,"int",'x',&interfer);
 
   OptionAdd(&opt,"st",'t',&stmestr);
@@ -539,6 +541,7 @@ int main(int argc,char *argv[]) {
   while(IQFread(fp,prm,iq,&badtr,&samples)==0) {
 
     if ((interfer) && (prm->xcf==0)) continue;
+    if ((bmnum !=-1) && (prm->bmnum !=bmnum)) continue;
 
     atime=TimeYMDHMSToEpoch(prm->time.yr,prm->time.mo,prm->time.dy,
                             prm->time.hr,prm->time.mt,prm->time.sc+prm->time.us/1.0e6);

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
@@ -267,6 +267,7 @@ int main(int argc,char *argv[]) {
   unsigned char iflg=0;
 
   int bmnum=-1;
+  int chnum=-1;
   unsigned char interfer=0;
 
   unsigned char help=0;
@@ -358,6 +359,7 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"p",'x',&pflg);
 
   OptionAdd(&opt,"b",'i',&bmnum);
+  OptionAdd(&opt,"c",'i',&chnum);
   OptionAdd(&opt,"int",'x',&interfer);
 
   OptionAdd(&opt,"st",'t',&stmestr);
@@ -542,6 +544,7 @@ int main(int argc,char *argv[]) {
 
     if ((interfer) && (prm->xcf==0)) continue;
     if ((bmnum !=-1) && (prm->bmnum !=bmnum)) continue;
+    if ((chnum !=-1) && (prm->channel !=chnum)) continue;
 
     atime=TimeYMDHMSToEpoch(prm->time.yr,prm->time.mo,prm->time.dy,
                             prm->time.hr,prm->time.mt,prm->time.sc+prm->time.us/1.0e6);

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
@@ -276,6 +276,7 @@ int main(int argc,char *argv[]) {
 
   int status=0;
   double atime;
+  int offset;
 
   char *stmestr=NULL;
   char *etmestr=NULL;
@@ -560,8 +561,11 @@ int main(int argc,char *argv[]) {
       if (pxmax>=iq->smpnum) pxmax=iq->smpnum;
       if (pxmin>=iq->smpnum) pxmin=iq->smpnum;
 
-      if (interfer) ptr=samples+iq->offset[n]+2*iq->smpnum;
-      else          ptr=samples+iq->offset[n];
+      if (iq->offset[n] == 0) offset=n*iq->smpnum;
+      else                    offset=iq->offset[n];
+
+      if (interfer) ptr=samples+offset+2*iq->smpnum;
+      else          ptr=samples+offset;
 
       GrplotXaxis(plt,0,xmin,xmax,xmajor,xminor,0x08,dgcol,0x0f,lne);
       GrplotYaxis(plt,0,ymin,ymax,ymajor,yminor,0x08,dgcol,0x0f,lne);

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
@@ -248,6 +248,7 @@ int main(int argc,char *argv[]) {
 
   float ax,ay,bx,by;
   int n;
+  char *cfname=NULL;
   FILE *fp=NULL;
   double tval;
 
@@ -296,11 +297,33 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"ymaj",'i',&ymajor);
   OptionAdd(&opt,"ymin",'i',&yminor);
 
+  OptionAdd(&opt,"cf",'t',&cfname);
  
   arg=OptionProcess(1,argc,argv,&opt,rst_opterr);
 
   if (arg==-1) {
     exit(-1);
+  }
+
+  if (cfname !=NULL) { /* load the configuration file */
+    int farg;
+    do {
+      fp=fopen(cfname,"r");
+      if (fp==NULL) break;
+      free(cfname);
+      cfname=NULL;
+      optf=OptionProcessFile(fp);
+      if (optf !=NULL) {
+        farg=OptionProcess(0,optf->argc,optf->argv,&opt,rst_opterr);
+        if (farg==-1) {
+          fclose(fp);
+          OptionFreeFile(optf);
+          exit(-1);
+        }
+        OptionFreeFile(optf);
+       }
+       fclose(fp);
+    } while (cfname !=NULL);
   }
 
   if (help==1) {

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
@@ -70,12 +70,12 @@
 struct OptionData opt;
 struct OptionFile *optf=NULL;
 
-
 struct RadarParm *prm;
 struct IQ *iq;
 unsigned int *badtr;
 int16 *samples;
 int16 *ptr;
+
 
 char *mktext(double value,double min,double max,void *data) {
   char *txt=NULL;
@@ -83,6 +83,7 @@ char *mktext(double value,double min,double max,void *data) {
   sprintf(txt,"%g",value);
   return txt;
 }
+
 
 int txtbox(char *fntname,float sze,int num,char *txt,float *box,void *data) {
   struct FrameBufferFontDB *fontdb;
@@ -92,13 +93,13 @@ int txtbox(char *fntname,float sze,int num,char *txt,float *box,void *data) {
   fontdb=(struct FrameBufferFontDB *)data;
   if (fontdb==NULL) return -1;
   fnt=FrameBufferFontDBFind(fontdb,fntname,sze);
-  
+
   FrameBufferTextBox(fnt,num,txt,tbox);
-  
+
   box[0]=tbox[0];
   box[1]=tbox[1];
   box[2]=tbox[2];
- 
+
   return 0;
 }
 
@@ -115,7 +116,7 @@ void plot_time(struct Plot *plot,
   char *month[]={"Jan","Feb","Mar","Apr","May","Jun",
                "Jul","Aug","Sep","Oct","Nov","Dec",0};
   char *tmeA="00:00:00.0000 UT";
- 
+
   char *tmeC="0";
   float cwdt;
   float x,y;
@@ -141,11 +142,11 @@ void plot_time(struct Plot *plot,
     if (isdigit(txt[i])) x+=cwdt;
     else x+=txbox[0];
   }
- 
+
   sprintf(txt,"%.2d:%.2d:%.2d.%.4d UT",shr,smt,ssc,fsec);
-  
+
   txtbox(fontname,fontsize,strlen(tmeA),tmeA,txbox,txtdata);
-  
+
   x=xoff+wdt-txbox[0];
   y=yoff+txbox[2];
   for (i=0;txt[i] !=0;i++) {
@@ -156,12 +157,11 @@ void plot_time(struct Plot *plot,
     else x+=txbox[0];
   }
 }
-  
 
 
 void plot_ephem(struct Plot *plot,
                float xoff,float yoff,float wdt,float hgt,
-	       int bmnum,int channel,int tfreq,float noise,int nave,int ave,
+               int bmnum,int channel,int tfreq,float noise,int nave,int ave,
                unsigned int color,unsigned char mask,
                char *fontname,float fontsize,
                void *txtdata) {
@@ -173,7 +173,6 @@ void plot_ephem(struct Plot *plot,
 
   float cwdt;
   float x,y;
-
 
   txtbox(fontname,fontsize,strlen(dig),dig,txbox,txtdata);
   cwdt=txbox[0];
@@ -237,8 +236,8 @@ int rst_opterr(char *txt) {
   return(-1);
 }
 
-int main(int argc,char *argv[]) {
 
+int main(int argc,char *argv[]) {
 
   char *fntdbfname;
   struct FrameBufferFontDB *fontdb=NULL;
@@ -260,11 +259,10 @@ int main(int argc,char *argv[]) {
   float xoff=0,yoff=0;
 
   struct Splot *splot=NULL;
-  struct Plot *plot=NULL;  
+  struct Plot *plot=NULL;
   struct Grplot *plt;
 
   unsigned char pflg=0;
-
   unsigned char rflg=0;
   unsigned char iflg=0;
 
@@ -296,7 +294,7 @@ int main(int argc,char *argv[]) {
   int xnum=300;
   int xmin=0,xmax=0;
   int x;
- 
+
   int pxmin,pxmax;
 
   int xmajor=0;
@@ -326,14 +324,14 @@ int main(int argc,char *argv[]) {
 
   prm=RadarParmMake();
   iq=IQMake();
- 
+
   fntdbfname=getenv("FONTDB");
   fp=fopen(fntdbfname,"r");
   if (fp !=NULL) {
     fontdb=FrameBufferFontDBLoad(fp);
     fclose(fp);
   }
- 
+
   if (fontdb==NULL) {
     fprintf(stderr,"Could not load fonts.\n");
     exit(-1);
@@ -371,7 +369,7 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"ymin",'i',&yminor);
 
   OptionAdd(&opt,"cf",'t',&cfname);
- 
+
   arg=OptionProcess(1,argc,argv,&opt,rst_opterr);
 
   if (arg==-1) {
@@ -449,14 +447,12 @@ int main(int argc,char *argv[]) {
   splot=SplotMake();
 
   SplotSetFrameBuffer(splot,&img,fontdb,NULL,NULL);
-  
+
   plot=PlotMake();
   SplotSetPlot(plot,splot);
 
-  
-
   dp=XwinOpenDisplay(display_name,&xdf);
- 
+
   if (dp==NULL) {
     fprintf(stderr,"Could not open display.\n");
     exit(-1);
@@ -464,7 +460,6 @@ int main(int argc,char *argv[]) {
 
   if (xdoff==-1) xdoff=(dp->wdt-wdt)/2;
   if (ydoff==-1) ydoff=(dp->hgt-hgt)/2;
-
 
   win=XwinMakeWindow(xdoff,ydoff,wdt,hgt,0,
                      dp,wname,
@@ -475,13 +470,11 @@ int main(int argc,char *argv[]) {
   }
   XwinShowWindow(win);
 
-  PlotDocumentStart(plot,"image",NULL,wdt,hgt,24);      
+  PlotDocumentStart(plot,"image",NULL,wdt,hgt,24);
 
   plt=GrplotMake(wdt,hgt,xpnum,ypnum,lpad,rpad,bpad,tpad,xoff,yoff);
   GrplotSetPlot(plt,plot);
-  GrplotSetTextBox(plt,txtbox,fontdb);  
-
-
+  GrplotSetTextBox(plt,txtbox,fontdb);
 
   plt->major_hgt=8;
   plt->minor_hgt=5;
@@ -540,7 +533,7 @@ int main(int argc,char *argv[]) {
     atime=TimeYMDHMSToEpoch(prm->time.yr,prm->time.mo,prm->time.dy,
                             prm->time.hr,prm->time.mt,prm->time.sc+prm->time.us/1.0e6);
     if ((etime !=-1) && (atime>=etime)) break;
-   
+
     for (n=0;n<iq->seqnum;n++) {
       tval=iq->tval[n].tv_sec+(1.0*iq->tval[n].tv_nsec)/1.0e9;
       PlotPlotStart(plot,"image",wdt,hgt,24);
@@ -559,7 +552,7 @@ int main(int argc,char *argv[]) {
       if (pflg) {
         for (x=pxmin+1;x<pxmax;x++) {
           ax=x-1;
-        
+
           ay=ptr[2*(x-1)+1]*ptr[2*(x-1)+1]+ptr[2*(x-1)]*ptr[2*(x-1)];
           if (ay !=0) ay=log10(ay);
           bx=x;
@@ -569,8 +562,6 @@ int main(int argc,char *argv[]) {
         }
       }
 
-      
-       
       if (iflg) {
         for (x=pxmin+1;x<pxmax;x++) {
           ax=x-1;
@@ -601,27 +592,27 @@ int main(int argc,char *argv[]) {
                      "Helvetica",10.0,fgcol,0x0f);
 
       plot_time(plot,2,2,wdt-4,hgt-4,tval,fgcol,0x0f,"Helvetica",12.0,fontdb);
-     
+
       plot_ephem(plot,100+2,2,wdt-4,hgt-4,prm->bmnum,prm->channel,prm->tfreq,
                  prm->noise.search,
                  prm->nave,n,fgcol,0x0f,"Helvetica",12.0,fontdb);
-     
 
-      PlotPlotEnd(plot);  
+      PlotPlotEnd(plot);
       PlotDocumentEnd(plot);
       if (img==NULL) continue;
-   
+
       XwinFrameBufferWindow(img,win);
       tmout.tv_sec=(int) delay;
       tmout.tv_usec=(delay-(int) delay)*1e6;
       if (delay !=0) XwinDisplayEvent(dp,1,&win,1,&tmout);
       else XwinDisplayEvent(dp,1,&win,1,NULL);
-     
+
       FrameBufferFree(img);
       img=NULL;
     }
 
-  } 
+  }
+
   PlotDocumentEnd(plot);
   XwinFreeWindow(win);
   XwinCloseDisplay(dp);

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
@@ -231,7 +231,7 @@ int main(int argc,char *argv[]) {
   unsigned char help=0;
   unsigned char option=0;
 
-  int wdt=WIDTH,hgt=HEIGHT;
+  float wdt=WIDTH,hgt=HEIGHT;
   int ymin=-200,ymax=200;
   int xnum=300;
   int xmin=0,xmax=0;
@@ -278,6 +278,8 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"-help",'x',&help);
   OptionAdd(&opt,"-option",'x',&option);
 
+  OptionAdd(&opt,"wdt",'f',&wdt);
+  OptionAdd(&opt,"hgt",'f',&hgt);
   OptionAdd(&opt,"display",'t',&display_name);
   OptionAdd(&opt,"xoff",'i',&xdoff);
   OptionAdd(&opt,"yoff",'i',&ydoff);
@@ -314,7 +316,11 @@ int main(int argc,char *argv[]) {
   if (arg<argc) fp=fopen(argv[arg],"r");
   else fp=stdin;
 
- 
+  if ((wdt==0) || (hgt==0)) {
+    fprintf(stderr,"Invalid plot size.\n");
+    exit(-1);
+  }
+
   if ((rflg==0) && (iflg==0) && (pflg==0)) {
     rflg=1;
     iflg=1;

--- a/codebase/superdarn/src.dlm/iqdlm.1.6/iqdlm.c
+++ b/codebase/superdarn/src.dlm/iqdlm.1.6/iqdlm.c
@@ -203,8 +203,8 @@ static IDL_VPTR IDLIQRead(int argc,IDL_VPTR *argv) {
 
   if (samples !=NULL) {
     int n=0;
-    if (prm->xcf == 1) adim[0]=iq->seqnum*iq->chnnum*iq->smpnum*2*2;
-    else               adim[0]=iq->seqnum*iq->chnnum*iq->smpnum*2;
+    if (prm->xcf == 1) adim[0]=iq->seqnum*iq->smpnum*2*2;
+    else               adim[0]=iq->seqnum*iq->smpnum*2;
     isamples=(short *) 
            IDL_MakeTempArray(IDL_TYP_INT,1,adim,IDL_ARR_INI_ZERO,&vsamples);
     for (n=0;n<adim[0];n++) {

--- a/codebase/superdarn/src.dlm/iqdlm.1.6/iqdlm.c
+++ b/codebase/superdarn/src.dlm/iqdlm.1.6/iqdlm.c
@@ -203,7 +203,8 @@ static IDL_VPTR IDLIQRead(int argc,IDL_VPTR *argv) {
 
   if (samples !=NULL) {
     int n=0;
-    adim[0]=iq->seqnum*iq->chnnum*iq->smpnum*2;
+    if (prm->xcf == 1) adim[0]=iq->seqnum*iq->chnnum*iq->smpnum*2*2;
+    else               adim[0]=iq->seqnum*iq->chnnum*iq->smpnum*2;
     isamples=(short *) 
            IDL_MakeTempArray(IDL_TYP_INT,1,adim,IDL_ARR_INI_ZERO,&vsamples);
     for (n=0;n<adim[0];n++) {

--- a/codebase/superdarn/src.dlm/iqdlm.1.6/iqidl.c
+++ b/codebase/superdarn/src.dlm/iqdlm.1.6/iqidl.c
@@ -81,7 +81,7 @@ void IDLCopyIQToIDL(struct IQ *iq,struct IQIDL *iiq) {
     iiq->noise[n]=iq->noise[n];
     iiq->offset[n]=iq->offset[n];
     iiq->size[n]=iq->size[n];
-    iiq->badtr[n]=iq->badtr[n];
+    if (iq->badtr !=NULL) iiq->badtr[n]=iq->badtr[n];
   }
 }
 

--- a/codebase/superdarn/src.dlm/iqdlm.1.6/iqidl.c
+++ b/codebase/superdarn/src.dlm/iqdlm.1.6/iqidl.c
@@ -114,9 +114,7 @@ struct IQIDL *IDLMakeIQ(IDL_VPTR *vptr) {
     {"OFFSET",ndim,(void *) IDL_TYP_LONG}, /* 9 */
     {"SIZE",ndim,(void *) IDL_TYP_LONG}, /* 10 */
     {"BADTR",ndim,(void *) IDL_TYP_LONG}, /* 11 */
-
-
-  };
+    {0}};
 
   static IDL_MEMINT ilDims[IDL_MAX_ARRAY_DIM];
  

--- a/codebase/superdarn/src.idl/lib/main.1.25/iq.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/iq.pro
@@ -215,9 +215,6 @@ function IQRead,unit,prm,iq,badtr,samples
  
 
   if (iq.seqnum gt 0) then begin
-     if (prm.xcf eq 0) then samples=intarr(iq.seqnum*iq.chnnum*iq.smpnum*2) $
-     else samples=intarr(iq.seqnum*iq.chnnum*iq.smpnum*2*2)
-
      iq.tval[0:iq.seqnum-1].sec=*(arrvec[arrid[0]].ptr)
      iq.tval[0:iq.seqnum-1].nsec=*(arrvec[arrid[1]].ptr)*1000
      iq.atten[0:iq.seqnum-1]=*(arrvec[arrid[2]].ptr)

--- a/codebase/superdarn/src.idl/lib/main.1.25/iq.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/iq.pro
@@ -215,7 +215,7 @@ function IQRead,unit,prm,iq,badtr,samples
  
 
   if (iq.seqnum gt 0) then begin
-     samples=intarr(iq.seqnum*iq.chnnum*iq.smpnum*2)
+     ;samples=intarr(iq.seqnum*iq.chnnum*iq.smpnum*2)
 
      iq.tval[0:iq.seqnum-1].sec=*(arrvec[arrid[0]].ptr)
      iq.tval[0:iq.seqnum-1].nsec=*(arrvec[arrid[1]].ptr)*1000

--- a/codebase/superdarn/src.idl/lib/main.1.25/iq.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/iq.pro
@@ -215,7 +215,8 @@ function IQRead,unit,prm,iq,badtr,samples
  
 
   if (iq.seqnum gt 0) then begin
-     ;samples=intarr(iq.seqnum*iq.chnnum*iq.smpnum*2)
+     if (prm.xcf eq 0) then samples=intarr(iq.seqnum*iq.chnnum*iq.smpnum*2) $
+     else samples=intarr(iq.seqnum*iq.chnnum*iq.smpnum*2*2)
 
      iq.tval[0:iq.seqnum-1].sec=*(arrvec[arrid[0]].ptr)
      iq.tval[0:iq.seqnum-1].nsec=*(arrvec[arrid[1]].ptr)*1000


### PR DESCRIPTION
This pull request updates various routines for reading and plotting `iqdat` files.  Previously, both the native IDL and DLM versions of IQRead were unable to initialize the `samples` array to the correct size when reading a record from an `iqdat` file - this has been fixed by doubling the size of the array if the XCF flag is set in the parameter block.

Probably more significant are updates to the `iqplot` binary.  New command line options have been added which allow the user to control the delay time between frames, select start and/or end times, plot samples from the interferometer array instead of the main array, plot values from only a single beam, etc.  The documentation has also undergone significant revisions to include these new options as well as to describe previously existing options.

Unfortunately I don't have many different `iqdat` files available to me, so some of these changes may not work with `iqdat` files recorded by radars with analog receivers or other designs.  @asreimer may be able to comment on that, as it looks like he did a lot of work on `make_raw` several years ago on his fork of the RSTLite repository.