### PR TITLE
Added instructions on how to contribute to RST

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The DAWG welcomes new testers and developers to join the team. Here are some way
   - Test pull requests: to determine which [pull requests](https://github.com/SuperDARN/rst/pulls) need to be tested right away, filter them by their milestones
   - Get involved in projects: the [projects](https://github.com/SuperDARN/rst/projects) page is used to organize our priority areas. Each project board shows items which are in progress, ready for testing/review, and completed.
  - Discuss [issues](https://github.com/SuperDARN/rst/issues) and answer questions
- - Become a developer: if you would like to contribute code to RST, please contact the DAWG chairs
+ - Become a developer: if you would like to contribute code to RST, please contact the DAWG chairs: Kevin Sterne (kevintyler *at* vt *dot* edu) and Emma Bland (emmab *at* unis *dot* no)
 
 ## Historical Version Log
 

--- a/README.md
+++ b/README.md
@@ -2,19 +2,29 @@
 
 Radar Software Toolkit
 ========
+The Radar Software Toolkit (RST) is maintained by the SuperDARN Data Analysis Working Group (DAWG). To find out what we are currently working on, take a look at our [projects](https://github.com/SuperDARN/rst/projects) page, and also the current [issues](https://github.com/SuperDARN/rst/issues) and [pull requests](https://github.com/SuperDARN/rst/pulls). 
 
+## Documentation
 RST's documentation is currently hosted on two sites:
 - RST readthedocs includes the installation guide, RST Tutorials, and SuperDARN data formats (coming soon):
   https://radar-software-toolkit-rst.readthedocs.io/en/latest/
 - RST API documentation includes the software structure and binary command line description and options: 
   https://superdarn.github.io/rst/
 
-## Getting Started 
+## Installation
 
 Installation guide for:
   - [Linux](https://radar-software-toolkit-rst.readthedocs.io/en/latest/user_guide/linux_install/)
   - [MacOSX](https://radar-software-toolkit-rst.readthedocs.io/en/latest/user_guide/mac_install/)
   - <font color="grey">Windows </font> yet to be implemented
+  
+## Contribute to RST
+The DAWG welcomes new testers and developers to join the team. Here are some ways to contribute:
+
+  - Test pull requests: to determine which [pull requests](https://github.com/SuperDARN/rst/pulls) need to be tested right away, filter them by their milestones
+  - Get involved in projects: the [projects](https://github.com/SuperDARN/rst/projects) page is used to organize our priority areas. Each project board shows items which are in progress, ready for testing/review, and completed.
+ - Discuss [issues](https://github.com/SuperDARN/rst/issues) and answer questions
+ - Become a developer: if you would like to contribute code to RST, please contact the DAWG chairs
 
 ## Historical Version Log
 


### PR DESCRIPTION
This pull request adds some general information to the `README.md` file to help users find out what the DAWG is working on and how to contribute to RST. 

This is in response to feedback from the SuperDARN community obtained during the AGU Fall Meeting in 2019, and also an attempt to recruit some new developers/testers. 

@ksterne We could list our names & email addresses on line 27 (if you're happy to do that). Or is there a better way to do this?