### PR TITLE
More iqdat fixes

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
@@ -160,7 +160,7 @@ void plot_time(struct Plot *plot,
 
 
 void plot_ephem(struct Plot *plot,
-               float xoff,float yoff,float wdt,float hgt,
+               float xoff,float yoff,float wdt,float hgt,int interfer,
                int bmnum,int channel,int tfreq,float noise,int nave,int ave,
                unsigned int color,unsigned char mask,
                char *fontname,float fontsize,
@@ -168,6 +168,7 @@ void plot_ephem(struct Plot *plot,
   int i;
   char txt[256];
   float txbox[3]={0,0,0};
+  char antenna[256];
 
   char *dig="0";
 
@@ -177,9 +178,11 @@ void plot_ephem(struct Plot *plot,
   txtbox(fontname,fontsize,strlen(dig),dig,txbox,txtdata);
   cwdt=txbox[0];
 
-  sprintf(txt,"bmnum=%.2d channel=%.1d tfreq=%.5d noise=%4.2f smp=%.3d/%.3d",
-          bmnum,channel,
-          tfreq,noise,ave,nave);
+  if (interfer) sprintf(antenna,"Interferometer");
+  else          sprintf(antenna,"Main Array");
+
+  sprintf(txt,"bmnum=%.2d channel=%.1d tfreq=%.5d noise=%4.2f smp=%.3d/%.3d (%s)",
+          bmnum,channel,tfreq,noise,ave,nave,antenna);
   txtbox(fontname,fontsize,strlen(txt),txt,txbox,txtdata);
   x=xoff;
   y=yoff+txbox[2];
@@ -616,7 +619,8 @@ int main(int argc,char *argv[]) {
 
       plot_time(plot,2,2,wdt-4,hgt-4,tval,fgcol,0x0f,"Helvetica",12.0,fontdb);
 
-      plot_ephem(plot,100+2,2,wdt-4,hgt-4,prm->bmnum,prm->channel,prm->tfreq,
+      plot_ephem(plot,100+2,2,wdt-4,hgt-4,interfer,
+                 prm->bmnum,prm->channel,prm->tfreq,
                  prm->noise.search,
                  prm->nave,n,fgcol,0x0f,"Helvetica",12.0,fontdb);
 

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/iqplot.c
@@ -561,7 +561,7 @@ int main(int argc,char *argv[]) {
       if (pxmax>=iq->smpnum) pxmax=iq->smpnum;
       if (pxmin>=iq->smpnum) pxmin=iq->smpnum;
 
-      if (iq->offset[n] == 0) offset=n*iq->smpnum;
+      if (iq->offset[n] == 0) offset=n*iq->smpnum*2*2;
       else                    offset=iq->offset[n];
 
       if (interfer) ptr=samples+offset+2*iq->smpnum;

--- a/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/doc/make_raw.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/doc/make_raw.doc.xml
@@ -10,21 +10,27 @@
 </option>
 <option><on>--version</on><od>print the RST version number and exit.</od>
 </option>
-
 <option><on>-vb</on><od>verbose. Log information to the console.</od>
 </option>
-
-<option><on><ar>iqdatname</ar></on><od>filename of the <code>iqdat</code>  format file. If this is omitted the file is read from standard input.</od>
+<option><on>-qi</on><od>the I&Q samples of the input <code>iqdat</code> format file are reversed.</od>
+</option>
+<option><on>-d</on><od>the input <code>iqdat</code> format file originated from a digital receiver.</od>
+</option>
+<option><on>-skip <ar>skpval</ar></on><od>set the number of samples to skip at the start of each sequence to <ar>skpval</ar>. The default value is taken from the IQ structure of the input <code>iqdat</code> format file.</od>
+</option>
+<option><on>-chnnum <ar>chnnum</ar></on><od>set the number of receiver channels to <ar>chnnum</ar>. The default value si taken from the IQ structure of the input <code>iqdat</code> format file.</od>
+</option>
+<option><on><ar>iqdatname</ar></on><od>filename of the <code>iqdat</code> format file. If this is omitted the file is read from standard input.</od>
 </option>
 
-<synopsis><p>Creates a <code>rawacf</code> format file from a <code>iqdat</code> format file.</p></synopsis>
-
-<description><p>Creates a <code>rawacf</code> format file from a <code>iqdat</code> format file.</p>
-<p>The <code>rawacf</code> format file  is written to standard output.</p>
+<synopsis><p>Creates a <code>rawacf</code> format file from an <code>iqdat</code> format file.</p></synopsis>
+<description><p>Creates a <code>rawacf</code> format file from an <code>iqdat</code> format file.</p>
+<p>The <code>rawacf</code> format file is written to standard output.</p>
 </description>
+
 <example>
 <command>make_raw 20040830.gbr.iqdat &gt; 20040830.gbr.rawacf</command>
-<description>Create an <code>rawacf</code> format file from the <code>iqdat</code> format file "<code>20040830.gbr.iqdat</code>".The <code>rawacf</code> format ile is written to "<code>20040830.gbr.rawacf</code>".</description>
+<description>Create a <code>rawacf</code> format file from the <code>iqdat</code> format file "<code>20040830.gbr.iqdat</code>".The <code>rawacf</code> format file is written to "<code>20040830.gbr.rawacf</code>".</description>
 </example>
 
 

--- a/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/make_raw.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/make_raw.c
@@ -308,7 +308,11 @@ int main (int argc,char *argv[]) {
     }
 
     if (digital) {
-      xcfoff = 2*iq->smpnum;
+      if (prm->xcf==1) {
+        xcfoff = 2*iq->smpnum;
+      } else {
+        xcfoff = 0;
+      }
     } else {
       if (prm->xcf==1) {
         xcfoff = 2;

--- a/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/make_raw.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/make_raw.c
@@ -55,14 +55,12 @@
 #include "errstr.h"
 #include "hlpstr.h"
 
-
-
 #define ACF_PART 0
 #define XCF_PART 1
 #define REAL_BUF_OFFSET 0
 #define IMAG_BUF_OFFSET 1
 
-struct RadarNetwork *network;  
+struct RadarNetwork *network;
 struct Radar *radar;
 struct RadarSite *site;
 
@@ -82,7 +80,7 @@ int loadlag(FILE *fp,int *lag[2]) {
     if (txt[c]=='#') continue;
     if (sscanf(txt,"%d %d\n",&real,&imag) !=2) continue;
     lag[0][lagnum]=real;
-    lag[1][lagnum]=imag; 
+    lag[1][lagnum]=imag;
     lagnum++;
   }
   return lagnum-1;
@@ -108,7 +106,7 @@ int main (int argc,char *argv[]) {
   struct IQ *iq;
   struct RawData *raw;
   unsigned int *badtr=NULL;
-  int16 *samples=NULL;  
+  int16 *samples=NULL;
   int16 *ptr;
 
   void *tmp=NULL;
@@ -123,12 +121,11 @@ int main (int argc,char *argv[]) {
   int *lag[2]={NULL,NULL};
   int *pulse=NULL;
 
-
   int mplgs=0;
 
   int roff=REAL_BUF_OFFSET;
   int ioff=IMAG_BUF_OFFSET;
-  
+
   float thrsh=0;
   int qiflg=0;
   int skpval=0;
@@ -153,7 +150,7 @@ int main (int argc,char *argv[]) {
   }
 
   network=RadarLoad(fp);
-  fclose(fp); 
+  fclose(fp);
   if (network==NULL) {
     fprintf(stderr,"Failed to read radar information.\n");
     exit(-1);
@@ -210,22 +207,20 @@ int main (int argc,char *argv[]) {
   }
 
   while (IQFread(fp,prm,iq,&badtr,&samples) !=-1) {
-    if (vb) 
+    if (vb)
       fprintf(stderr,"%d-%d-%d %d:%d:%d beam=%d\n",prm->time.yr,prm->time.mo,
-	     prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
+              prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
 
-    
     /* get the hardware info */
 
-     radar=RadarGetRadar(network,prm->stid);
-     if (radar==NULL) {
+    radar=RadarGetRadar(network,prm->stid);
+    if (radar==NULL) {
       fprintf(stderr,"Failed to get radar information.\n");
       break;
     }
 
-    site=RadarYMDHMSGetSite(radar,prm->time.yr,prm->time.mo,
-	  	          prm->time.dy,prm->time.hr,prm->time.mt,
-                          prm->time.sc);
+    site=RadarYMDHMSGetSite(radar,prm->time.yr,prm->time.mo,prm->time.dy,
+                            prm->time.hr,prm->time.mt,prm->time.sc);
 
     if (site==NULL) {
       fprintf(stderr,"Failed to get site information.\n");
@@ -263,28 +258,26 @@ int main (int argc,char *argv[]) {
     memset(tmp,0,sizeof(float)*2*prm->nrang*prm->mplgs);
     xcfd=tmp;
 
-  
     for (i=0;i<2;i++) {
       if (lag[i]==NULL) tmp=malloc(sizeof(int)*(prm->mplgs+1));
       else tmp=realloc(lag[i],sizeof(int)*(prm->mplgs+1));
       if (tmp==NULL) break;
       lag[i]=tmp;
       for (j=0;j<=prm->mplgs;j++) lag[i][j]=prm->lag[i][j];
-   }
-   if (i !=2) {
-     s=-1;
-     break;
-   }
-   mplgs=prm->mplgs;
- 
+    }
+    if (i !=2) {
+      s=-1;
+      break;
+    }
+    mplgs=prm->mplgs;
 
-   if (skpval==0) skpval=iq->skpnum;   
+    if (skpval==0) skpval=iq->skpnum;
 
     if (pulse==NULL) tmp=malloc(sizeof(int)*prm->mppul);
     else tmp=realloc(pulse,sizeof(int)*prm->mppul);
     if (tmp==NULL) {
-       s=-1;
-       break;
+      s=-1;
+      break;
     }
     pulse=tmp;
 
@@ -298,46 +291,41 @@ int main (int argc,char *argv[]) {
     tprm.mppul=prm->mppul;
     tprm.smdelay=skpval;
     tprm.pat=pulse;
-    
+
     badrng=ACFBadLagZero(&tprm,prm->mplgs,lag);
-    
+
     for (n=0;n<iq->seqnum;n++) {
 
       ptr=samples+iq->offset[n];
 
       ACFSumPower(&tprm,mplgs,lag,pwr0,
-		       ptr,2*iq->chnnum,skpval !=0,
-                       roff,ioff,badrng,
-                       iq->noise[n],prm->mxpwr,prm->atten*atstp,
-                       thr,lmt,&abflg);
-       
-      
-      ACFCalculate(&tprm,ptr,2*iq->chnnum,skpval !=0,
-		   roff,ioff,mplgs,
-	  	   lag,acfd,ACF_PART,2,badrng,iq->atten[n]*atstp,NULL);
+                  ptr,2*iq->chnnum,skpval !=0,
+                  roff,ioff,badrng,
+                  iq->noise[n],prm->mxpwr,prm->atten*atstp,
+                  thr,lmt,&abflg);
 
-      if (prm->xcf==1) ACFCalculate(&tprm,ptr,
-				     2*iq->chnnum,skpval !=0,
-                                     roff,ioff,prm->mplgs,
-	  	                     lag,xcfd,XCF_PART,2,badrng,
-				     iq->atten[n]*atstp,NULL);
+      ACFCalculate(&tprm,ptr,2*iq->chnnum,skpval !=0,
+                   roff,ioff,mplgs,
+                   lag,acfd,ACF_PART,2,badrng,iq->atten[n]*atstp,NULL);
+
+      if (prm->xcf==1) ACFCalculate(&tprm,ptr,2*iq->chnnum,skpval !=0,
+                                    roff,ioff,prm->mplgs,
+                                    lag,xcfd,XCF_PART,2,badrng,
+                                    iq->atten[n]*atstp,NULL);
 
       if ((n>0) && (iq->atten[n] !=iq->atten[n-1]))
-              ACFNormalize(pwr0,acfd,xcfd,prm->nrang,prm->mplgs,atstp); 
-          
+              ACFNormalize(pwr0,acfd,xcfd,prm->nrang,prm->mplgs,atstp);
 
-    }   
-   
-     
+    }
+
     ACFAverage(pwr0,acfd,xcfd,prm->nave,prm->nrang,prm->mplgs);
-    
+
     RawSetPwr(raw,prm->nrang,pwr0,0,NULL);
     RawSetACF(raw,prm->nrang,prm->mplgs,acfd,0,NULL);
     RawSetXCF(raw,prm->nrang,prm->mplgs,xcfd,0,NULL);
-     
+
     raw->thr=thrsh;
     RawFwrite(stdout,prm,raw);
-   
 
   }
   if (fp !=stdin) fclose(fp);
@@ -346,5 +334,5 @@ int main (int argc,char *argv[]) {
     return -1;
   }
   return 0;
-} 
+}
 

--- a/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/make_raw.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/make_raw.c
@@ -136,6 +136,7 @@ int main (int argc,char *argv[]) {
   int rngoff;
   int xcfoff;
   int chnnum=0;
+  int offset;
 
   prm=RadarParmMake();
   iq=IQMake();
@@ -323,7 +324,10 @@ int main (int argc,char *argv[]) {
 
     for (n=0;n<iq->seqnum;n++) {
 
-      ptr=samples+iq->offset[n];
+      if (iq->offset[n] == 0) offset=n*iq->smpnum*2*2;
+      else                    offset=iq->offset[n];
+
+      ptr=samples+offset;
 
       ACFSumPower(&tprm,mplgs,lag,pwr0,
                   ptr,rngoff,skpval !=0,

--- a/codebase/superdarn/src.bin/tk/tool/trim_iq.1.5/trim_iq.c
+++ b/codebase/superdarn/src.bin/tk/tool/trim_iq.1.5/trim_iq.c
@@ -245,6 +245,12 @@ int main (int argc,char *argv[]) {
  
    do {
 
+     atime=TimeYMDHMSToEpoch(prm->time.yr,prm->time.mo,prm->time.dy,
+                             prm->time.hr,prm->time.mt,
+                             prm->time.sc+prm->time.us/1.0e6);
+
+     if ((etime !=-1) && (atime>=etime)) break;
+
      fprintf(stderr,"%s\n",prm->origin.time);
      fprintf(stderr,"%s\n",prm->origin.command);
      fprintf(stderr,"%s\n",prm->combf);
@@ -260,16 +266,9 @@ int main (int argc,char *argv[]) {
          
      IQFwrite(stdout,prm,iq,badtr,samples);
      
-     atime=TimeYMDHMSToEpoch(prm->time.yr,
-		    prm->time.mo,
-                    prm->time.dy,
-                    prm->time.hr,
-		    prm->time.mt,
-                    prm->time.sc+prm->time.us/1.0e6);
      TimeEpochToYMDHMS(atime,&yr,&mo,&dy,&hr,&mt,&sc);
      if (vb==1) fprintf(stderr,"%d-%d-%d %d:%d:%d\n",yr,mo,dy,hr,mt,(int) sc);
 
-      if ((etime !=-1) && (atime>=etime)) break;
       status=IQFread(fp,prm,iq,&badtr,&samples);
  
   } while (status !=-1);  

--- a/codebase/superdarn/src.bin/tk/tool/trim_iq.1.5/trim_iq.c
+++ b/codebase/superdarn/src.bin/tk/tool/trim_iq.1.5/trim_iq.c
@@ -50,15 +50,11 @@
 #include "errstr.h"
 #include "hlpstr.h"
 
-
-
-
 struct RadarParm *prm=NULL;
 struct IQ *iq=NULL;
 struct IQIndex *inx=NULL;
 unsigned int *badtr=NULL;
 int16 *samples=NULL;
-
 
 struct OptionData opt;
 
@@ -70,7 +66,7 @@ double strdate(char *text) {
   dy=val % 100;
   mo=(val / 100) % 100;
   yr=(val / 10000);
-  if (yr<1970) yr+=1900;  
+  if (yr<1970) yr+=1900;
   tme=TimeYMDHMSToEpoch(yr,mo,dy,0,0,0);
 
   return tme;
@@ -93,7 +89,7 @@ double strtime(char *text) {
   mn=atoi(text+i+1);
   sc=atof(text+j+1);
   return (double) hr*3600L+mn*60L+sc;
-}   
+}
 
 int rst_opterr(char *txt) {
   fprintf(stderr,"Option not recognized: %s\n",txt);
@@ -104,7 +100,6 @@ int rst_opterr(char *txt) {
 int main (int argc,char *argv[]) {
 
   int arg=0;
-
 
   int status=0;
   double atime;
@@ -129,7 +124,6 @@ int main (int argc,char *argv[]) {
   unsigned char option=0;
   unsigned char version=0;
 
-
   FILE *fp=NULL;
 
   int n;
@@ -140,8 +134,6 @@ int main (int argc,char *argv[]) {
   OptionAdd(&opt,"-help",'x',&help);
   OptionAdd(&opt,"-option",'x',&option);
   OptionAdd(&opt,"-version",'x',&version);
-
-
   OptionAdd(&opt,"vb",'x',&vb);
   OptionAdd(&opt,"st",'t',&stmestr);
   OptionAdd(&opt,"et",'t',&etmestr);
@@ -176,8 +168,6 @@ int main (int argc,char *argv[]) {
   if (sdtestr !=NULL) sdate=strdate(sdtestr);
   if (edtestr !=NULL) edate=strdate(edtestr);
 
-
-
   if ((argc-arg)>1) {
     fp=fopen(argv[arg+1],"r");
     if (fp==NULL) {
@@ -185,7 +175,7 @@ int main (int argc,char *argv[]) {
       exit(-1);
     }
     inx=IQIndexFload(fp);
-   
+
     fclose(fp);
     if (inx==NULL) {
       fprintf(stderr,"Error loading index.\n");
@@ -198,105 +188,77 @@ int main (int argc,char *argv[]) {
     fprintf(stderr,"File not found.\n");
     exit(-1);
   }
-  
 
-  if (IQFread(fp,prm,iq,&badtr,&samples)==-1)  {
+  if (IQFread(fp,prm,iq,&badtr,&samples)==-1) {
     fprintf(stderr,"Error reading file\n");
     exit(-1);
   }
 
-  atime=TimeYMDHMSToEpoch(prm->time.yr,
-	   	           prm->time.mo,
-                           prm->time.dy,
-                           prm->time.hr,
-		           prm->time.mt,
-                           prm->time.sc+prm->time.us/1.0e6);
+  atime=TimeYMDHMSToEpoch(prm->time.yr,prm->time.mo,prm->time.dy,
+                          prm->time.hr,prm->time.mt,
+                          prm->time.sc+prm->time.us/1.0e6);
 
    /* skip here */
 
-    if ((stime !=-1) || (sdate !=-1)) { 
-      /* we must skip the start of the files */
-      int yr,mo,dy,hr,mt;
-      double sc; 
-      if (stime==-1) stime= ( (int) atime % (24*3600));
-      if (sdate==-1) stime+=atime - ( (int) atime % (24*3600));
-      else stime+=sdate;
+  if ((stime !=-1) || (sdate !=-1)) {
+    /* we must skip the start of the files */
+    int yr,mo,dy,hr,mt;
+    double sc;
+    if (stime==-1) stime= ( (int) atime % (24*3600));
+    if (sdate==-1) stime+=atime - ( (int) atime % (24*3600));
+    else stime+=sdate;
 
-      TimeEpochToYMDHMS(stime,&yr,&mo,&dy,&hr,&mt,&sc);
-      status=IQFseek(fp,yr,mo,dy,hr,mt,sc,NULL,inx); 
-    
-      if (status ==-1) {
-        fprintf(stderr,"File does not contain the requested interval.\n");
-        exit(-1);
-      }
-      if (IQFread(fp,prm,iq,&badtr,&samples)==-1)  {
-         fprintf(stderr,"Error reading file\n");
-         exit(-1);
-      }
-  
-    } else stime=atime;
-   
-    if (etime !=-1) {
-       if (edate==-1) etime+=atime - ( (int) atime % (24*3600));
-       else etime+=edate;
+    TimeEpochToYMDHMS(stime,&yr,&mo,&dy,&hr,&mt,&sc);
+    status=IQFseek(fp,yr,mo,dy,hr,mt,sc,NULL,inx);
+
+    if (status ==-1) {
+      fprintf(stderr,"File does not contain the requested interval.\n");
+      exit(-1);
     }
 
-   if (extime !=0) etime=stime+extime;
- 
-   do {
+    if (IQFread(fp,prm,iq,&badtr,&samples)==-1) {
+      fprintf(stderr,"Error reading file\n");
+      exit(-1);
+    }
+  } else stime=atime;
 
-     atime=TimeYMDHMSToEpoch(prm->time.yr,prm->time.mo,prm->time.dy,
-                             prm->time.hr,prm->time.mt,
-                             prm->time.sc+prm->time.us/1.0e6);
+  if (etime !=-1) {
+    if (edate==-1) etime+=atime - ( (int) atime % (24*3600));
+    else etime+=edate;
+  }
 
-     if ((etime !=-1) && (atime>=etime)) break;
+  if (extime !=0) etime=stime+extime;
 
-     fprintf(stderr,"%s\n",prm->origin.time);
-     fprintf(stderr,"%s\n",prm->origin.command);
-     fprintf(stderr,"%s\n",prm->combf);
-     fprintf(stderr,"%d:",prm->mppul);
-     for (n=0;n<prm->mppul;n++) fprintf(stderr,"%d ",prm->pulse[n]);
-     fprintf(stderr,"\n");
-     fprintf(stderr,"%d\n",prm->mplgs);
-     for (n=0;n<=prm->mplgs;n++) fprintf(stderr,"%d,%d ",
-          prm->lag[0][n],prm->lag[1][n]);
-     fprintf(stderr,"\n");
+  do {
 
+    atime=TimeYMDHMSToEpoch(prm->time.yr,prm->time.mo,prm->time.dy,
+                            prm->time.hr,prm->time.mt,
+                            prm->time.sc+prm->time.us/1.0e6);
 
-         
-     IQFwrite(stdout,prm,iq,badtr,samples);
-     
-     TimeEpochToYMDHMS(atime,&yr,&mo,&dy,&hr,&mt,&sc);
-     if (vb==1) fprintf(stderr,"%d-%d-%d %d:%d:%d\n",yr,mo,dy,hr,mt,(int) sc);
+    if ((etime !=-1) && (atime>=etime)) break;
 
-      status=IQFread(fp,prm,iq,&badtr,&samples);
- 
-  } while (status !=-1);  
- 
+    TimeEpochToYMDHMS(atime,&yr,&mo,&dy,&hr,&mt,&sc);
+    if (vb==1) fprintf(stderr,"%d-%d-%d %d:%d:%d\n",yr,mo,dy,hr,mt,(int) sc);
+
+    fprintf(stderr,"%s\n",prm->origin.time);
+    fprintf(stderr,"%s\n",prm->origin.command);
+    fprintf(stderr,"%s\n",prm->combf);
+    fprintf(stderr,"%d:",prm->mppul);
+    for (n=0;n<prm->mppul;n++) fprintf(stderr,"%d ",prm->pulse[n]);
+    fprintf(stderr,"\n");
+    fprintf(stderr,"%d\n",prm->mplgs);
+    for (n=0;n<=prm->mplgs;n++) fprintf(stderr,"%d,%d ",prm->lag[0][n],prm->lag[1][n]);
+    fprintf(stderr,"\n");
+
+    IQFwrite(stdout,prm,iq,badtr,samples);
+
+    status=IQFread(fp,prm,iq,&badtr,&samples);
+
+  } while (status !=-1);
+
   if (fp !=stdin) fclose(fp);
+
   return 0;
 
-
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 


### PR DESCRIPTION
This pull request makes a few more bug fixes to the `iqplot` and `make_raw` code.  Using the changes adopted from @asreimer's fork of the RSTLite repository, `make_raw` on this branch is capable of reproducing a rawacf file from an iqdat file for the Christmas Valley East and West radars with the `-d` option.  This can be tested by following a procedure such as

```
make_raw -d yyyymmdd.cve.iqdat > yyyymmdd.cve.rawacf
make_fit yyyymmdd.cve.rawacf > yyyymmdd.cve.fitacf
time_plot -x -b 11 -a -e yyyymmdd.cve.fitacf
```

and compare with the output from the corresponding rawacf file distributed via the data mirrors.

Unfortunately, there is an issue with the other set of iqdat files most readily available to me (Fort Hays East / West) where the sequence offset and size values in the IQ structure appear to be incorrect based on the number of samples per sequence, so `make_raw` does not correctly reproduce the rawacf files for those sites.  I think there may be a similar issue with reproducing Stereo rawacf files from the LYR iqdat files @ecbland shared with me (although the LOS data was somewhat noisy that day so it's hard to say).