### PR TITLE
Fixing bug in RawEncode for missing acfd array

### DIFF
--- a/codebase/superdarn/src.lib/tk/raw.1.22/src/rawwrite.c
+++ b/codebase/superdarn/src.lib/tk/raw.1.22/src/rawwrite.c
@@ -79,6 +79,12 @@ int RawEncode(struct DataMap *ptr,struct RadarParm *prm,struct RawData *raw) {
     xnum[1]=0;
     xnum[2]=0;
   }
+
+  if (raw->acfd[0] == NULL) {
+    DataMapStoreArray(ptr,"pwr0",DATAFLOAT,1,&p0num,raw->pwr0);
+    fprintf(stderr,"Warning: acfd array missing\n");
+    return 0;
+  }
   
   if (snum !=0) slist=DataMapStoreArray(ptr,"slist",DATASHORT,1,&snum,NULL);
   DataMapStoreArray(ptr,"pwr0",DATAFLOAT,1,&p0num,raw->pwr0);


### PR DESCRIPTION
This pull request fixes a bug in `RawEncode` of `rawwrite.c` where a segmentation fault occurs when trying to write a rawacf file (eg with `trim_raw`) if the `acfd` array is missing (and `slist` is empty).  This can be tested by using `trim_raw` on the following two files (many other examples are available):

`20080103.2201.00.inv.rawacf` (23:10:03 UT)
`20080110.2033.57.inv.rawacf` (20:51:43 UT)

On the develop branch there will be a segmentation fault, while on this branch a warning message will be printed to stderr and the `pwr0` array will be written before proceeding to the next record.