### PR TITLE
Bug/make fit free

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
@@ -60,7 +60,7 @@ int rst_opterr(char *txt) {
   return(-1);
 }
 
-/*Folloowing coding style: https://www.cs.swarthmore.edu/~newhall/unixhelp/c_codestyle.html*/
+/*Following coding style: https://www.cs.swarthmore.edu/~newhall/unixhelp/c_codestyle.html*/
 
 /*
  *Function: free_files
@@ -266,13 +266,13 @@ int main(int argc,char *argv[]) {
   if (prm == NULL)
   {
       RadarFree(network);
-      fprintf(stderr,"Error: cannot create Radar parameter\n");
+      fprintf(stderr,"Error: cannot create Radar parameter block\n");
       exit(-1);
   }
   raw=RawMake();
   if (raw == NULL)
   {
-      fprintf(stderr,"Error: cannot cread Rawacf structure\n");
+      fprintf(stderr,"Error: cannot read Rawacf structure\n");
       free_radarstructs(network, prm, raw);
       exit(-1);
   }
@@ -371,7 +371,7 @@ int main(int argc,char *argv[]) {
       }
             
       if (Allocate_Fit_Prm(prm, fit_prms) == -1) { 
-          fprintf(stderr,"Error: Could not allocate space for FITACF 3.0 Parameter\n");
+          fprintf(stderr,"Error: Could not allocate space for FITACF 3.0 Parameter structure\n");
           free_radarstructs(network, prm, raw);
           free_files(rawfp, fp, fitfp, inxfp);
           free_fitstructs(fit_prms, fit, fblk);
@@ -430,7 +430,7 @@ int main(int argc,char *argv[]) {
     ctime = time((time_t) 0);
     if (RadarParmSetOriginCommand(prm,command) == -1) 
     {
-        fprintf(stderr,"Error: cannot set Origin Coommand\n");
+        fprintf(stderr,"Error: cannot set Origin Command\n");
         free_radarstructs(network, prm, raw);
         free_files(rawfp, fp, fitfp, inxfp);
         free_fitstructs(fit_prms, fit, fblk);
@@ -467,7 +467,7 @@ int main(int argc,char *argv[]) {
       if (fitacf_version == 30) {
 
         if (Allocate_Fit_Prm(prm, fit_prms) == -1) {
-            fprintf(stderr,"Error: allocatte space for fitacf record\n");
+            fprintf(stderr,"Error: cannot allocate space for fitacf record\n");
             free_radarstructs(network, prm, raw);
             free_files(rawfp, fp, fitfp, inxfp);
             free_fitstructs(fit_prms, fit, fblk);            
@@ -511,7 +511,6 @@ int main(int argc,char *argv[]) {
   if (old) OldRawClose(rawfp);
   return 0;
 }
-
 
 
 

--- a/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
@@ -400,7 +400,7 @@ int main(int argc,char *argv[]) {
         fprintf(stderr,"Error: cannot set Origin Coommand\n");
         free_radarstructs(network, prm, raw);
         free_files(rawfp, fp, fitfp, inxfp);
-        free_fitstructs('' fit_prms, fit, fblk);
+        free_fitstructs(fit_prms, fit, fblk);
         exit(-1);
     }
     
@@ -411,7 +411,7 @@ int main(int argc,char *argv[]) {
         fprintf(stderr,"Error: cannot set Origin Time\n");
         free_radarstructs(network, prm, raw);
         free_files(rawfp, fp, fitfp, inxfp);
-        free_fitstructs('' fit_prms, fit, fblk);
+        free_fitstructs(fit_prms, fit, fblk);
         exit(-1);
     }
 
@@ -437,7 +437,7 @@ int main(int argc,char *argv[]) {
             fprintf(stderr,"Error: allocatte space for fitacf record\n");
             free_radarstructs(network, prm, raw);
             free_files(rawfp, fp, fitfp, inxfp);
-            free_fitstructs('' fit_prms, fit, fblk);            
+            free_fitstructs(fit_prms, fit, fblk);            
             exit(-1);
         }
 
@@ -452,7 +452,7 @@ int main(int argc,char *argv[]) {
             fprintf(stderr, "Unable to allocate fit_prms!\n");
             free_radarstructs(network, prm, raw);
             free_files(rawfp, fp, fitfp, inxfp);
-            free_fitstructs('' fit_prms, fit, fblk);
+            free_fitstructs(fit_prms, fit, fblk);
             exit(-1);
         }
       }
@@ -463,7 +463,7 @@ int main(int argc,char *argv[]) {
             fprintf(stderr, "The requested fitacf version does not exist\n");
             free_radarstructs(network, prm, raw);
             free_files(rawfp, fp, fitfp, inxfp);
-            free_fitstructs('' fit_prms, fit, fblk);
+            free_fitstructs(fit_prms, fit, fblk);
             exit(-1);
       }
     }
@@ -473,7 +473,7 @@ int main(int argc,char *argv[]) {
 
   free_radarstructs(network, prm, raw);
   free_files(rawfp, fp, fitfp, inxfp);
-  free_fitstructs('' fit_prms, fit, fblk);
+  free_fitstructs(fit_prms, fit, fblk);
 
   if (old) OldRawClose(rawfp);
   return 0;

--- a/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
@@ -6,6 +6,8 @@
 /*
  (c) 2010 JHU/APL & Others - Please Consult LICENSE.superdarn-rst.3.2-beta-4-g32f7302.txt for more information.
 
+Modifitactions: 
+2020-05-07 Marina Schmidt Added Free functioons
 
 
 */
@@ -58,6 +60,19 @@ int rst_opterr(char *txt) {
   return(-1);
 }
 
+/*Folloowing coding style: https://www.cs.swarthmore.edu/~newhall/unixhelp/c_codestyle.html*/
+
+/*
+ *Function: free_files
+ *---------------------
+ *Frees file types used in make_fit
+ *  rawfp: old RAWACF file pointer 
+ *  fp: new RAWACF file pointer
+ *  fitfp: FITACF file pointer
+ *  inxfp: Index file pointer
+ *
+ *  returns: nothing
+ */
 void free_files(struct OldRawFp *rawfp, FILE *fp, FILE *fitfp, FILE *inxfp)
 {
     if (rawfp != NULL) OldRawClose(rawfp);
@@ -66,6 +81,15 @@ void free_files(struct OldRawFp *rawfp, FILE *fp, FILE *fitfp, FILE *inxfp)
     if (inxfp != NULL) fclose(inxfp);
 }
 
+/*
+ *Function: free_fitstructs
+ *-----------------------------
+ *  fit_prms: fitacf parameters used in FITACF 3.0 algorithm
+ *  fit: fitacf data structure
+ *  FitBlock: fitacf block used in FITACF 2.5 algorithm
+ * 
+ *  returns: nothing
+ */
 void free_fitstructs(FITPRMS *fit_prms, struct FitData *fit, struct FitBlock *fblk)
 {
     if (fit != NULL) FitFree(fit);
@@ -73,6 +97,15 @@ void free_fitstructs(FITPRMS *fit_prms, struct FitData *fit, struct FitBlock *fb
     if (fblk != NULL) FitACFFree(fblk); 
 }
 
+/*
+ *Function: free_radarstructs
+ *---------------------------
+ *  network: Radar network structure
+ *  RadarParam: radar parameter structure
+ *  RawData: rawacf data structure
+ *
+ *  return: nothing
+ */
 void free_radarstructs(struct RadarNetwork *network, struct RadarParm *prm, struct RawData *raw)
 {
     if (network != NULL) RadarFree(network);


### PR DESCRIPTION
This is one of many PR's leading to me re-coding of getting Simon's elevation code into Fitacf 3.0. 
- [x] make_fit updates
- [ ] fitacf 2.5 using function pointer
- [ ] fitacf 3.0 using function pointer

## Scope
Best practices with freeing structures. 

## Reason
during testing the elevation_library I ran into many memory issues this helps clear some of them up and I added some error messages for problems arise. 

## How to test
Compare `develop` FITACF 2.5 and 3.0 files to this branch. I made a python script using 
```bash 
cd <rst dir>
git checkout develop
make.build; make.code 
cd <where fitacf files are>
make_fit make_fit 20170410.1801.00.sas.rawacf > 20170410.1801.00.sas.fitacf_dev_25
make_fit -fitacf-version 3.0 20170410.1801.00.sas.rawacf > 20170410.1801.00.sas.fitacf_dev_30
cd <rst dir>
git checkout BUG/make_fit_free
make.buil; make.code
cd <where fitacf files are>
make_fit make_fit 20170410.1801.00.sas.rawacf > 20170410.1801.00.sas.fitacf_25
make_fit -fitacf-version 3.0 20170410.1801.00.sas.rawacf > 20170410.1801.00.sas.fitacf_30
```
pyDARN to test this:

```python
import pydarn
import bz2 
import numpy as np

reader = pydarn.SDarnRead('20170410.1801.00.sas.fitacf_dev_25')
develop_fitacf25 = reader.read_fitacf()

reader = pydarn.SDarnRead('20170410.1801.00.sas.fitacf_dev_30')
develop_fitacf3 = reader.read_fitacf()

reader = pydarn.SDarnRead('20170410.1801.00.sas.fitacf_25')
constant_fitacf25 = reader.read_fitacf()

reader = pydarn.SDarnRead('20170410.1801.00.sas.fitacf_30')
constant_fitacf3 = reader.read_fitacf()
for rec_num in range(0,len(develop_fitacf25)):
    try:
        if np.array_equal(develop_fitacf25[rec_num]['v'], constant_fitacf25[rec_num]['v']):
            pass
        else:
            print('velocity record number: {}'.format(rec_num))
            print(develop_fitacf25[rec_num]['v'] - constant_fitacf25[rec_num]['v'])

        if np.array_equal(develop_fitacf25[rec_num]['elv'], constant_fitacf25[rec_num]['elv']):
            pass
        else:
            print('elevation record number: {}'.format(rec_num))
            print(develop_fitacf25[rec_num]['elv'] - constant_fitacf25[rec_num]['elv'])

        if np.array_equal(develop_fitacf25[rec_num]['p_l'], constant_fitacf25[rec_num]['p_l']):
            pass
        else:
            print('power record number: {}'.format(rec_num))
            print(develop_fitacf25[rec_num]['p_l'] - constant_fitacf25[rec_num]['p_l'])
    except KeyError:
        continue
print("="*30)
print("     FITACF 3.0 comparison")
print("="*30)
for rec_num in range(0,len(develop_fitacf3)):
    try:
        if np.array_equal(develop_fitacf3[rec_num]['v'], constant_fitacf3[rec_num]['v']):
            pass
        else:
            print('velocit record number: {}'.format(rec_num))
            print(develop_fitacf3[rec_num]['v'] - constant_fitacf3[rec_num]['v'])

        if np.array_equal(develop_fitacf3[rec_num]['elv'], constant_fitacf3[rec_num]['elv']):
            pass
        else:
            print('elevation record number: {}'.format(rec_num))
            print(develop_fitacf3[rec_num]['elv'] - constant_fitacf3[rec_num]['elv'])

        if np.array_equal(develop_fitacf3[rec_num]['p_l'], constant_fitacf3[rec_num]['p_l']):
            pass
        else:
            print('power record number: {}'.format(rec_num))
            print(develop_fitacf3[rec_num]['p_l'] - constant_fitacf3[rec_num]['p_l'])
    except KeyError:
        continue

```
The same script I used for testing constants PR. 
To run the script: 
```bash
 python3 pydarn_fitacf_checker.py 
==============================
     FITACF 3.0 comparison
==============================
```
No output means no changes :) 