### PR TITLE
removed ansi C90 and added pedantic

### DIFF
--- a/build/make/makebin.darwin
+++ b/build/make/makebin.darwin
@@ -7,7 +7,7 @@
 # Darwin (GCC)
 #
 
-CFLAGS = -Wall -O3 -ansi -D_GNU_SOURCE -D_DARWIN -I/opt/local/include
+CFLAGS = -Wall -pedantic -O3 -D_GNU_SOURCE -D_DARWIN -I/opt/local/include
 
 ifdef XPATH
   ifdef XLIB

--- a/build/make/makebin.linux
+++ b/build/make/makebin.linux
@@ -7,7 +7,7 @@
 # Linux (GCC)
 #
 
-CFLAGS+=-fPIC -Wall -O3 -ansi -D_GNU_SOURCE -D_LINUX
+CFLAGS+=-fPIC -Wall -pedantic -O3 -D_GNU_SOURCE -D_LINUX
 
 ifdef XPATH
   ifdef XLIB

--- a/build/make/makedlm.darwin
+++ b/build/make/makedlm.darwin
@@ -7,7 +7,7 @@
 # Linux (GCC)
 #
 
-CFLAGS = -fPIC -Wall -O3 -ansi \
+CFLAGS = -fPIC -Wall -pedantic -O3 \
          -D_GNU_SOURCE -D_LINUX $(INCLUDE)
  
 SUF=so

--- a/build/make/makedlm.linux
+++ b/build/make/makedlm.linux
@@ -7,7 +7,7 @@
 # Linux (GCC)
 #
 
-CFLAGS = -fPIC -Wall -O3 -ansi \
+CFLAGS = -fPIC -Wall -pedantic -O3 \
          -D_GNU_SOURCE -D_LINUX $(INCLUDE)
 
 LFLAGS = -shared -lm -lz 

--- a/build/make/makelib.darwin
+++ b/build/make/makelib.darwin
@@ -7,7 +7,7 @@
 # Linux (GCC)
 #
 
-CFLAGS = -Wall -O3 -ansi -D_GNU_SOURCE -D_DARWIN -I/opt/local/include $(INCLUDE)  
+CFLAGS = -Wall -pedantic -O3 -D_GNU_SOURCE -D_DARWIN -I/opt/local/include $(INCLUDE)  
 SUF=so
 
 VSTR=$(shell get.version ${CURDIR}/..)

--- a/build/make/makelib.linux
+++ b/build/make/makelib.linux
@@ -7,7 +7,7 @@
 # Linux (GCC)
 #
 
-CFLAGS += -fPIC -Wall -O3 -ansi \
+CFLAGS += -fPIC -Wall -pedantic -O3 \
          -D_GNU_SOURCE -D_LINUX $(INCLUDE)
 
 LFLAGS += -shared -lm -lz 


### PR DESCRIPTION
## Scope
To further aid in elevation code I raised the issue #289 to switch to C99. 
Thus this PR is removing the `ansi` option for compile and adding `pedantic`

## Reason
More flexibility including some the RST code was actually coded for C99 and `pedantic` is good practice for enforcing more restrictions. 

## Test 
Compile on Linux or MacOS. 
I did see how many warnings I got via: 
```bash
make.build; make.code 2>&1 | grep -i "warning" | wc -l 
```
Got 128 on `develop` and 200 on this branch.

```bash
gcc --version
gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```