### PR TITLE
Feature: zenodo metadata config

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -40,6 +40,7 @@
         {
             "affiliation": "Dartmouth College",
             "name": "Shepherd, S.G.",
+            "orcid": "0000-0003-1992-4118"
         },
         {
             "affiliation": "Virginia Tech",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,44 @@
+{
+    "creators":[
+        {
+            "affiliation": "The Unviersity Centre in Svalbard",
+            "name": "Bland, Emma"
+        },
+        {
+            "affiliation": "Naval Research Laboratory",
+            "name": "Burrell, A.G."
+        },
+        {
+            "affiliation": "University of Saskatchewan",
+            "name": "Kotyk, K."
+        },
+        {
+            "affiliation": "University of Saskatchewan",
+            "name": "Ponomarenko, P.V."
+        },
+        {
+            "affiliation": "SRI International",
+            "name": "Reimer, A.S."
+        },
+        {
+            "affiliation": "University of Saskatchewan",
+            "name": "Schmidt, M."
+        },
+        {
+            "affiliation": "Dartmouth College",
+            "name": "Shepherd, S.G."
+        },
+        {
+            "affiliation": "Virginia Tech",
+            "name": "Sterne, K.T."
+        },
+        {
+            "affiliation": "Dartmouth College",
+            "name": "Thomas, E.G."
+        },
+        {
+            "affiliation": "Lancaster University",
+            "name": "Walach, M.-T."
+        }
+    ]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -10,7 +10,7 @@
         },
         {
             "affiliation": "The Unviersity Centre in Svalbard",
-            "name": "Bland, Emma",
+            "name": "Bland, E.C.",
             "orcid": "0000-0002-0252-0400"
         },
         {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -35,6 +35,7 @@
         {
             "affiliation": "University of Saskatchewan",
             "name": "Schmidt, M."
+            "orcid": "0000-0002-3265-977X"
         },
         {
             "affiliation": "Dartmouth College",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -34,7 +34,7 @@
         },
         {
             "affiliation": "University of Saskatchewan",
-            "name": "Schmidt, M."
+            "name": "Schmidt, M. T."
             "orcid": "0000-0002-3265-977X"
         },
         {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,14 @@
 {
     "creators":[
         {
+            "name": "SuperDARN Data Analysis Working Group"
+        },
+        {
+            "affiliation": "University of Saskatchewan",
+            "name": "Billett, D.D.",
+            "orcid": "0000-0002-8905-8609"
+        },
+        {
             "affiliation": "The Unviersity Centre in Svalbard",
             "name": "Bland, Emma",
             "orcid": "0000-0002-0252-0400"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -34,7 +34,7 @@
         },
         {
             "affiliation": "University of Saskatchewan",
-            "name": "Schmidt, M. T."
+            "name": "Schmidt, M.T."
             "orcid": "0000-0002-3265-977X"
         },
         {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,11 +2,13 @@
     "creators":[
         {
             "affiliation": "The Unviersity Centre in Svalbard",
-            "name": "Bland, Emma"
+            "name": "Bland, Emma",
+            "orcid": "0000-0002-0252-0400"
         },
         {
             "affiliation": "Naval Research Laboratory",
-            "name": "Burrell, A.G."
+            "name": "Burrell, A.G.",
+            "orcid": "0000-0001-8875-9326"
         },
         {
             "affiliation": "University of Saskatchewan",
@@ -14,11 +16,13 @@
         },
         {
             "affiliation": "University of Saskatchewan",
-            "name": "Ponomarenko, P.V."
+            "name": "Ponomarenko, P.V.",
+            "orcid": "0000-0001-8407-0193"
         },
         {
             "affiliation": "SRI International",
-            "name": "Reimer, A.S."
+            "name": "Reimer, A.S.",
+            "orcid": "0000-0002-4621-3453"
         },
         {
             "affiliation": "University of Saskatchewan",
@@ -26,19 +30,22 @@
         },
         {
             "affiliation": "Dartmouth College",
-            "name": "Shepherd, S.G."
+            "name": "Shepherd, S.G.",
         },
         {
             "affiliation": "Virginia Tech",
-            "name": "Sterne, K.T."
+            "name": "Sterne, K.T.",
+            "orcid": "0000-0002-1076-0009"
         },
         {
             "affiliation": "Dartmouth College",
-            "name": "Thomas, E.G."
+            "name": "Thomas, E.G.",
+            "orcid": "0000-0001-8036-8793"
         },
         {
             "affiliation": "Lancaster University",
-            "name": "Walach, M.-T."
+            "name": "Walach, M.-T.",
+            "orcid": "0000-0002-9352-0659"
         }
     ]
 }


### PR DESCRIPTION
# Feature
**Name:**
Feature: zenodo metadata config

**Issue Reference:**
#290 

## Modified (/added)

**Function Name:** *.zenodo.json*

**Location:**  top directory

## Scope
- This addresses the "bug" where some people's github usernames are showing up on Zenodo. 
- Using this file will also allow us to control authorship/contributors that have been discussed in #272.
- This PR does not address criteria on who should be listed as authors and/or contributors; it's only pulled the majority of the list from the last minor release.

### Requirements Checklist
- [ ] tested
- [ ] merge to `4.4 release`

## Test Code

### Code example with the bug

I don't really have a good place to show the bug since @egthomas has been able to modify the author listing on Zenodo in the past.  Probably best as a testimony from @egthomas and maybe @mtwalach as her name is one that doesn't seem to transfer.

### Code example with the fix

I have tested this out on a trial repo.  You can see a simple repo at: https://github.com/ksterne/zenodo-test and the subsequent sandbox Zenedo release that I made (let me know if it's not public): https://sandbox.zenodo.org/record/572676 .  Bonus points if you get the 3rd author reference.

## Extra Notes

Again, I've just kept most of the list (I think I didn't miss someone), from the v4.3 release.  Again, I've gone with the thought of the WG in front and then alphabetically order from there.  That's the best I can think of until we figure out more related to #272.  If I've missed someone or someone wants to drop out, I'm not tied to it here.