### PR TITLE
grid_plot -gfov option

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/doc/grid_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/doc/grid_plot.doc.xml
@@ -112,6 +112,8 @@
 </option>
 <option><on>-ffov</on><od>plot the filled radar field of view.</od>
 </option>
+<option><on>-gfov</on><od>only plot fields of view of the radars contributing data (when using -fov and/or -ffov).</od>
+</option>
 <option><on>-tmtick <ar>tick</ar></on><od>set the grid interval for the time clock-dial to <ar>tick</ar> hours.</od>
 </option>
 <option><on>-lst</on><od>use local solar time rather than local time.</od>

--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/make_fov.c
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/make_fov.c
@@ -34,10 +34,11 @@
 #include "rfile.h"
 #include "radar.h"
 #include "rpos.h"
+#include "griddata.h"
 #include "polygon.h"
 
 
-
+/* This function returns FOVs for all operational radars */
 struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
                              int chisham,int old_aacgm) {
 
@@ -101,3 +102,79 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
 
     return ptr;
 }
+
+
+/* This function returns only the radar FOVs that are contributing grid vectors */
+struct PolygonData *make_fov_data(struct GridData *gptr,struct RadarNetwork *network,
+                                  int chisham,int old_aacgm) {
+
+    double rho,lat,lon;
+    int i,j,rn,bm;
+    float pnt[2];
+    int yr,mo,dy,hr,mt;
+    double sc;
+    int frang=180;
+    int rsep=45;
+    struct PolygonData *ptr=NULL;
+    struct RadarSite *site=NULL;
+    int st_id;
+    int maxrange=75;
+
+    TimeEpochToYMDHMS(gptr->st_time,&yr,&mo,&dy,&hr,&mt,&sc);
+
+    ptr=PolygonMake(sizeof(float)*2,NULL);
+
+    for (j=0;j<gptr->stnum;j++) {
+
+        if (gptr->sdata[j].npnt==0) continue;
+
+        st_id=gptr->sdata[j].st_id;
+
+        for (i=0;i<network->rnum;i++) {
+
+            if (network->radar[i].id !=st_id) continue;
+            site=RadarYMDHMSGetSite(&(network->radar[i]),yr,mo,dy,hr,mt,(int) sc);
+            if (site==NULL) continue;
+            PolygonAddPolygon(ptr,1);
+
+            for (rn=0;rn<=maxrange;rn++) {
+                RPosMag(0,0,rn,site,frang,rsep,
+                        site->recrise,0,&rho,&lat,&lon,
+                        chisham,old_aacgm);
+                pnt[0]=lat;
+                pnt[1]=lon;
+                PolygonAdd(ptr,pnt);
+            }
+
+            for (bm=1;bm<=site->maxbeam;bm++) {
+                RPosMag(0,bm,maxrange,site,frang,rsep,
+                        site->recrise,0,&rho,&lat,&lon,
+                        chisham,old_aacgm);
+                pnt[0]=lat;
+                pnt[1]=lon;
+                PolygonAdd(ptr,pnt);
+            }
+
+            for (rn=maxrange-1;rn>=0;rn--) {
+                RPosMag(0,site->maxbeam,rn,site,frang,rsep,
+                        site->recrise,0,&rho,&lat,&lon,
+                        chisham,old_aacgm);
+                pnt[0]=lat;
+                pnt[1]=lon;
+                PolygonAdd(ptr,pnt);
+            }
+
+            for (bm=site->maxbeam-1;bm>0;bm--) {
+                RPosMag(0,bm,0,site,frang,rsep,
+                        site->recrise,0,&rho,&lat,&lon,
+                        chisham,old_aacgm);
+                pnt[0]=lat;
+                pnt[1]=lon;
+                PolygonAdd(ptr,pnt);
+            }
+        }
+    }
+
+    return ptr;
+}
+

--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/make_fov.h
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/make_fov.h
@@ -26,3 +26,5 @@
 
 struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
                              int chisham,int old_aacgm);
+struct PolygonData *make_fov_data(struct GridData *ptr,struct RadarNetwork *network,
+                                  int chisham,int old_aacgm);


### PR DESCRIPTION
In response to #302 and similar to #187 for `map_plot`, this pull request adds a `-gfov` option which tells `grid_plot` to only draw and/or fill FOVs for the radars which provided grid vectors for that particular record (in combination with `-fov` and/or `-ffov`).

To test, you can use something like `grid_plot -x -def -fov [your_favorite_grid_file]` both with and without the `-gfov` option.  Without `-gfov`, the FOVs of all radars will be drawn, while with `-gfov` only the contributing radars' FOVs will be drawn.