### PR TITLE
Fixing DLM version of OldRawOpen

### DIFF
--- a/codebase/superdarn/src.dlm/oldrawdlm.1.7/oldrawdlm.c
+++ b/codebase/superdarn/src.dlm/oldrawdlm.1.7/oldrawdlm.c
@@ -362,29 +362,18 @@ static IDL_VPTR IDLOldRawOpen(int argc,IDL_VPTR *argv) {
   void *s;
   int st;
 
-  static IDL_MEMINT hdim[]={1,80};
-  static IDL_MEMINT ddim[]={1,32};
-  static IDL_MEMINT edim[]={1,256};
-
   static IDL_STRUCT_TAG_DEF trawfp[]={
     {"RAWUNIT",0,(void *) IDL_TYP_LONG},
     {"INXUNIT",0,(void *) IDL_TYP_LONG},
-    {"RAW_RECL",0,(void *) IDL_TYP_LONG},
-    {"INX_RECL",0,(void *) IDL_TYP_LONG},
-    {"BLEN",0,(void *) IDL_TYP_LONG},
-    {"INX_SREC",0,(void *) IDL_TYP_LONG},
-    {"INX_EREC",0,(void *) IDL_TYP_LONG},
     {"CTIME",0,(void *) IDL_TYP_DOUBLE},
     {"STIME",0,(void *) IDL_TYP_DOUBLE},
-    {"ETIME",0,(void *) IDL_TYP_DOUBLE},
-    {"TIME",0,(void *) IDL_TYP_LONG},
-    {"HEADER",hdim,(void *) IDL_TYP_BYTE},
-    {"DATE",ddim,(void *) IDL_TYP_BYTE},
-    {"EXTRA",edim,(void *) IDL_TYP_BYTE},
-    {"MAJOR_REV",0,(void *) IDL_TYP_BYTE},
-    {"MINOR_REV",0,(void *) IDL_TYP_BYTE},
+    {"FREC",0,(void *) IDL_TYP_LONG},
+    {"RLEN",0,(void *) IDL_TYP_LONG},
+    {"PTR",0,(void *) IDL_TYP_LONG},
+    {"THR",0,(void *) IDL_TYP_LONG},
+    {"MAJOR_REV",0,(void *) IDL_TYP_LONG},
+    {"MINOR_REV",0,(void *) IDL_TYP_LONG},
     {"RAWREAD",0,(void *) IDL_TYP_LONG},
-    {"BNUM",0,(void *) IDL_TYP_LONG},
     {0}};
 
   static IDL_MEMINT ilDims[IDL_MAX_ARRAY_DIM];


### PR DESCRIPTION
This pull request fixes the DLM version of `OldRawOpen` to return the correctly formatted `rawfp` structure.  Currently, the [structure returned to IDL](https://github.com/SuperDARN/rst/blob/master/codebase/superdarn/src.dlm/oldrawdlm.1.7/oldrawdlm.c#L369-L388) appears to have been at least partially copied from a comparable structure in the DLM version of [OldFitOpen](https://github.com/SuperDARN/rst/blob/master/codebase/superdarn/src.dlm/oldfitdlm.1.8/oldfitdlm.c#L569-L588), however the contents of the returned `rawfp` structure do not match the definition in the [oldrawidl.h](https://github.com/SuperDARN/rst/blob/master/codebase/superdarn/src.dlm/oldrawdlm.1.7/oldrawidl.h#L35-L52) file or [native IDL code](https://github.com/SuperDARN/rst/blob/master/codebase/superdarn/src.idl/lib/main.1.25/oldraw.pro#L72-L87).

For example, using the DLM code on the master branch to read a `dat` file in IDL will return something like

```
IDL> rawfp = OldRawOpen('1996060300h.dat')
% Loaded DLM: OLDRAWDLM.
IDL> help, rawfp
** Structure RAWFP, 18 tags, length=440, data length=434:
   RAWUNIT         LONG               100
   INXUNIT         LONG                -1
   RAW_RECL        LONG        -788529152
   INX_RECL        LONG        1103681816
   BLEN            LONG        -788529152
   INX_SREC        LONG        1103681816
   INX_EREC        LONG                53
   CTIME           DOUBLE      6.3659874e-314
   STIME           DOUBLE      1.9097962e-313
   ETIME           DOUBLE      6.9099614e-310
   TIME            LONG                 0
   HEADER          BYTE      Array[80]
   DATE            BYTE      Array[32]
   EXTRA           BYTE      Array[256]
   MAJOR_REV       BYTE         0
   MINOR_REV       BYTE         0
   RAWREAD         LONG                 0
   BNUM            LONG                 0
```

while on this branch, you should see something like this:

```
IDL> rawfp = OldRawOpen('1996060300h.dat')
% Loaded DLM: OLDRAWDLM.
IDL> help, rawfp
** Structure RAWFP, 11 tags, length=56, data length=52:
   RAWUNIT         LONG               100
   INXUNIT         LONG                -1
   CTIME           DOUBLE       8.3376170e+08
   STIME           DOUBLE       8.3376170e+08
   FREC            LONG                53
   RLEN            LONG                53
   PTR             LONG                53
   THR             LONG                 3
   MAJOR_REV       LONG                 3
   MINOR_REV       LONG                 9
   RAWREAD         LONG       -1267695168
```

which matches the structure of the above cited [oldrawidl.h](https://github.com/SuperDARN/rst/blob/master/codebase/superdarn/src.dlm/oldrawdlm.1.7/oldrawidl.h#L35-L52) file.  This can be further verified using the native IDL version of `OldRawOpen` (eg by renaming the IDL function in the oldraw.pro file so it no longer matches the DLM function):

```
IDL> rawfp = OldRawOpen2('1996060300h.dat')   
IDL> help, rawfp
** Structure OLDRAWFP, 11 tags, length=56, data length=52:
   RAWUNIT         LONG               100
   INXUNIT         LONG                -1
   CTIME           DOUBLE       8.3376170e+08
   STIME           DOUBLE       8.3376170e+08
   FREC            LONG                53
   RLEN            LONG                53
   PTR             LONG                53
   THR             LONG                 3
   MAJOR_REV       LONG                 3
   MINOR_REV       LONG                 9
   RAWREAD         LONG                 0
```

(I'm not sure why the value of RAWREAD does not match the native IDL version)