### PR TITLE
fixed the bug in stdkey makefile

### DIFF
--- a/codebase/general/src.lib/stdkey.1.5/src/makefile
+++ b/codebase/general/src.lib/stdkey.1.5/src/makefile
@@ -5,10 +5,6 @@
 #
 include $(MAKECFG).$(SYSTEM)
 
-INCLUDE=-I$(IPATH)/base -I$(IPATH)/general
-SRC=make_palette.c
-SLIB=-lm
-LIBS=-lm
 OUTPUT=stdkey
 DSTPATH=$(LIBPATH)
 OBJS=paltable.o


### PR DESCRIPTION
Not sure how this slipped through the cracks but I think it is fixed. 

I needed to `include rmath.h` in make_pallette.c to make constants consistent. However, this makefile was different than others and I think I was trying to fix the error I got with it not finding `rmath.h`. That fix was including the base.  

## Test

``` bash 
git checkout master 
make.build; make.code
```
should get this error 
``` bash
paltable.o -Bstatic -L/home/marina/superdarn/rst_dev/rst//lib -lm -lm
ld: cannot find -lm
ld: cannot find -lm
make: *** [/home/marina/superdarn/rst_dev/rst//build/make/makelib.linux:25: stdkey] Error 1
``` 

```bash
git checkout FIX/stdkey_makefile
make.build; make.code 
```
should be a complete build 
