### PR TITLE
combine_snd and updates to sounding library

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/snd.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/snd.c
@@ -77,7 +77,7 @@ void snd_tplot(struct SndData *snd,struct tplot *tptr) {
   int i;
 
   tptr->bmnum=snd->bmnum;
-  tptr->channel=0;
+  tptr->channel=snd->channel;
   tptr->cpid=snd->cp;
   tptr->scan=snd->scan;
   tptr->nrang=snd->nrang;

--- a/codebase/superdarn/src.bin/tk/tool/combine_snd.1.0/combine_snd.c
+++ b/codebase/superdarn/src.bin/tk/tool/combine_snd.1.0/combine_snd.c
@@ -8,6 +8,8 @@
 #include <stdlib.h>
 #include <math.h>
 #include <sys/types.h>
+#include <string.h>
+#include <time.h>
 #include <zlib.h>
 #include "rtypes.h"
 #include "option.h"
@@ -82,7 +84,11 @@ int main(int argc,char *argv[]) {
 
   double st_time=0;
 
-  int i,c=0;
+  int i,c=0,n=0;
+
+  time_t ctime;
+  char command[128];
+  char tmstr[40];
  
   OptionAdd(&opt,"-help",'x',&help);
   OptionAdd(&opt,"-option",'x',&option);
@@ -138,6 +144,14 @@ int main(int argc,char *argv[]) {
     fprintf(stderr,"Processing %d files\n",c);
   }
 
+  command[0]=0;
+  for (c=0;c<argc;c++) {
+    n+=strlen(argv[c])+1;
+    if (n>127) break;
+    if (c !=0) strcat(command," ");
+    strcat(command,argv[c]);
+  }
+
   while ((opfp=read_set()) !=0)  {
 
     /* Find the earliest sounding record */
@@ -151,6 +165,13 @@ int main(int argc,char *argv[]) {
     /* Write the next sounding record */
     for (i=0;i<fnum;i++) {
       if ( (dflg[i] !=0) && (in_time[i] == st_time) ) {
+
+        in_rcd[i]->origin.code=1;
+        ctime = time((time_t) 0);
+        strcpy(tmstr,asctime(gmtime(&ctime)));
+        tmstr[24]=0;
+        SndSetOriginTime(in_rcd[i],tmstr);
+        SndSetOriginCommand(in_rcd[i],command);
 
         SndFwrite(stdout,in_rcd[i]);
 

--- a/codebase/superdarn/src.bin/tk/tool/combine_snd.1.0/combine_snd.c
+++ b/codebase/superdarn/src.bin/tk/tool/combine_snd.1.0/combine_snd.c
@@ -1,0 +1,192 @@
+/* combine_snd.c
+   =============
+   Author: E.G.Thomas
+*/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <sys/types.h>
+#include <zlib.h>
+#include "rtypes.h"
+#include "option.h"
+#include "rtime.h"
+#include "rfile.h"
+#include "dmap.h"
+#include "snddata.h"
+#include "sndread.h"
+#include "sndwrite.h"
+
+#include "errstr.h"
+#include "hlpstr.h"
+
+
+char *fname[64];
+int fnum=4;
+
+FILE *in_fp[64];
+
+struct SndData *in_rcd[64];
+double in_time[64];
+int read_flg[64];
+int dflg[64];
+
+struct SndData *rcd;
+
+struct OptionData opt;
+
+int rst_opterr(char *txt) {
+  fprintf(stderr,"Option not recognized: %s\n",txt);
+  fprintf(stderr,"Please try: combine_snd --help\n");
+  return(-1);
+}
+
+int read_set() {
+  int c=0;
+  int i;
+  int status=0;
+  
+  for (i=0;i<fnum;i++) {
+    if ((in_fp[i] !=NULL) && (read_flg[i]==1)) {
+      status=SndFread(in_fp[i],in_rcd[i]);
+      if (status !=-1) {
+        in_time[i]=TimeYMDHMSToEpoch(in_rcd[i]->time.yr,in_rcd[i]->time.mo,
+                                     in_rcd[i]->time.dy,in_rcd[i]->time.hr,
+                                     in_rcd[i]->time.mt,
+                                     in_rcd[i]->time.sc+in_rcd[i]->time.us/1.0e6);
+        read_flg[i]=0;
+        dflg[i]=1;
+      } else {
+        dflg[i]=0;
+        fclose(in_fp[i]);
+        in_fp[i]=NULL;
+      }
+    }
+    if (in_fp[i] !=NULL) c++;
+  }
+  return c;
+}
+
+/*int get_length() { 
+  int smin=3600*24;
+  int scan;
+  int i;
+  for (i=0;i<fnum;i++) {
+    if (dflg[i] !=0) {
+       scan=in_rcd[i]->ed_time-in_rcd[i]->st_time;
+       if (scan<smin) smin=scan;
+    }
+  }
+  return smin;
+}*/
+  
+
+int main(int argc,char *argv[]) {
+
+  int arg=0;
+  unsigned char help=0;
+  unsigned char option=0;
+  unsigned char version=0;
+  unsigned char vb=0;
+ 
+  int record=0;
+  int opfp=0;
+
+  double st_time=0;
+
+  int i,c=0;
+ 
+  rcd=SndMake(); 
+ 
+  OptionAdd(&opt,"-help",'x',&help);
+  OptionAdd(&opt,"-option",'x',&option);
+  OptionAdd(&opt,"-version",'x',&version);
+
+  OptionAdd(&opt,"vb",'x',&vb);
+
+  arg=OptionProcess(1,argc,argv,&opt,rst_opterr);
+
+  if (arg==-1) {
+    exit(-1);
+  }
+
+  if (help==1) {
+    OptionPrintInfo(stdout,hlpstr);
+    exit(0);
+  }
+
+  if (option==1) {
+    OptionDump(stdout,&opt);
+    exit(0);
+  }
+
+  if (version==1) {
+    OptionVersion(stdout);
+    exit(0);
+  }
+
+
+  if (argc-arg<2) {
+    OptionPrintInfo(stderr,errstr);
+    exit(-1);
+  }
+  fnum=argc-arg;
+ 
+  for (i=0;i<fnum;i++) {
+    in_rcd[i]=SndMake();
+    dflg[i]=0;
+    in_fp[i]=fopen(argv[arg+i],"r");
+    if (in_fp[i]==NULL) fprintf(stderr,"File %s Not Found.\n",fname[i]);
+    else {
+      read_flg[i]=1;
+      c++;
+    }
+  }
+
+  if (c==0) {
+    fprintf(stderr,"No files to be processed.\n");
+    exit(-1);
+  }
+
+  if (vb) {
+    fprintf(stderr,"Processing %d files\n",c);
+  }
+
+  while ((opfp=read_set()) !=0)  {
+
+    /* Find the earliest sounding record */
+    st_time=1e31;
+    for (i=0;i<fnum;i++) {
+      if (dflg[i] !=0) {
+        if (in_time[i]<st_time) st_time=in_time[i];
+      }
+    }
+
+    /* Write the next sounding record */
+    for (i=0;i<fnum;i++) {
+      if ( (dflg[i] !=0) && (in_time[i] == st_time) ) {
+
+        SndFwrite(stdout,in_rcd[i]);
+
+        if (vb) {
+          int syr,smo,sdy,shr,smt,ssc;
+          double sec;
+          TimeEpochToYMDHMS(st_time,&syr,&smo,&sdy,&shr,&smt,&sec);
+          ssc=sec;
+
+          fprintf(stderr,"%d-%02d-%02d %02d:%02d:%02d (Scan: %d, Beam: %02d)\n",
+                  syr,smo,sdy,shr,smt,ssc,in_rcd[i]->scan,in_rcd[i]->bmnum);
+        }
+
+        /* discard old records */
+        read_flg[i]=1;
+        record++;
+      }
+    }
+
+  }
+
+  return 0;
+}
+

--- a/codebase/superdarn/src.bin/tk/tool/combine_snd.1.0/combine_snd.c
+++ b/codebase/superdarn/src.bin/tk/tool/combine_snd.1.0/combine_snd.c
@@ -68,19 +68,6 @@ int read_set() {
   return c;
 }
 
-/*int get_length() { 
-  int smin=3600*24;
-  int scan;
-  int i;
-  for (i=0;i<fnum;i++) {
-    if (dflg[i] !=0) {
-       scan=in_rcd[i]->ed_time-in_rcd[i]->st_time;
-       if (scan<smin) smin=scan;
-    }
-  }
-  return smin;
-}*/
-  
 
 int main(int argc,char *argv[]) {
 
@@ -96,8 +83,6 @@ int main(int argc,char *argv[]) {
   double st_time=0;
 
   int i,c=0;
- 
-  rcd=SndMake(); 
  
   OptionAdd(&opt,"-help",'x',&help);
   OptionAdd(&opt,"-option",'x',&option);

--- a/codebase/superdarn/src.bin/tk/tool/combine_snd.1.0/doc/combine_snd.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/combine_snd.1.0/doc/combine_snd.doc.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<binary>
+<project>superdarn</project>
+<name>combine_snd</name>
+<location>src.bin/tk/tool/combine_snd</location>
+
+<syntax>combine_snd --help</syntax>
+<syntax>combine_snd [-vb] [-r] <ar>sndnames...</ar></syntax>
+
+<option><on>--help</on><od>print the help message and exit.</od>
+</option>
+<option><on>--version</on><od>print the RST version number and exit.</od>
+</option>
+<option><on>-vb</on><od>verbose. Log information to the console.</od>
+</option>
+<option><on><ar>snddnames</ar></on><od>filenames of the <code>snd</code> format files.</od>
+</option>
+<synopsis><p>Combines together snd files from each slice of a Borealis-style radar.</p></synopsis>
+<description><p>Combines together multiple snd files from each slice of a Borealis-style radar to produce a single file written to standard output.</p>
+</description>
+
+<example>
+<command>combine_snd -vb 20201020.20.sas.?.snd &gt; 20201020.20.sas.snd</command>
+<description>Combines together all files called "<code>20201020.20.sas.?.snd</code>" to produce a file called "<code>19981020.20.sas.snd</code>". The status is logged to standard error.</description>
+</example>
+
+</binary>

--- a/codebase/superdarn/src.bin/tk/tool/combine_snd.1.0/makefile
+++ b/codebase/superdarn/src.bin/tk/tool/combine_snd.1.0/makefile
@@ -1,0 +1,17 @@
+# Makefile for combine_snd
+# ========================
+# Author: E.G.Thomas
+# by E.G.Thomas
+#
+#
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn
+OBJS = combine_snd.o
+SRC=hlpstr.h errstr.h combine_snd.c
+DSTPATH = $(BINPATH)
+OUTPUT = combine_snd
+LIBS= -lsnd.1 -lradar.1 -ldmap.1 -lopt.1 -lrtime.1 -lrcnv.1
+SLIB=-lm -lz
+
+include $(MAKEBIN).$(SYSTEM)

--- a/codebase/superdarn/src.idl/lib/main.1.25/snd.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/snd.pro
@@ -77,6 +77,7 @@ pro SndMakeSndData,snd
          tfreq: 0, $
          sky_noise: 0.0, $
          combf: '', $
+         fit_revision: {rlstr, major: 0L, minor: 0L}, $
          snd_revision: {sdstr, major: 0, minor: 0}, $
          qflg: bytarr(MAX_RANGE), $
          gflg: bytarr(MAX_RANGE), $
@@ -128,7 +129,8 @@ function SndRead,unit,snd
            'time.us','nave','lagfr','smsep','noise.search','noise.mean', $
            'channel','bmnum','bmazm','scan','rxrise','intt.sc','intt.us', $
            'nrang','frang','rsep','xcf','tfreq','noise.sky', $
-           'combf','snd.revision.major','snd.revision.minor']
+           'combf','fitacf.revision.major','fitacf.revision.minor', $
+           'snd.revision.major','snd.revision.minor']
 
   scltype=[1,1, $
            1,9,9,2,2, $
@@ -136,7 +138,8 @@ function SndRead,unit,snd
            3,2,2,2,4,4, $
            2,2,4,2,2,2,3, $
            2,2,2,2,2,4, $
-           9,2,2]
+           9,3,3, $
+           2,2]
 
   sclid=intarr(n_elements(sclname))
   sclid[*]=-1
@@ -206,8 +209,10 @@ function SndRead,unit,snd
   if (sclid[30] ne -1) then snd.tfreq=*(sclvec[sclid[30]].ptr)
   if (sclid[31] ne -1) then snd.sky_noise=*(sclvec[sclid[31]].ptr)
   if (sclid[32] ne -1) then snd.combf=*(sclvec[sclid[32]].ptr)
-  if (sclid[33] ne -1) then snd.snd_revision.major=*(sclvec[sclid[33]].ptr)
-  if (sclid[34] ne -1) then snd.snd_revision.minor=*(sclvec[sclid[34]].ptr)
+  if (sclid[33] ne -1) then snd.fit_revision.major=*(sclvec[sclid[33]].ptr)
+  if (sclid[34] ne -1) then snd.fit_revision.minor=*(sclvec[sclid[34]].ptr)
+  if (sclid[35] ne -1) then snd.snd_revision.major=*(sclvec[sclid[35]].ptr)
+  if (sclid[36] ne -1) then snd.snd_revision.minor=*(sclvec[sclid[36]].ptr)
 
   if (arrid[0] eq -1) then begin
     st=DataMapFreeScalar(sclvec)

--- a/codebase/superdarn/src.idl/lib/main.1.25/snd.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/snd.pro
@@ -64,6 +64,7 @@ pro SndMakeSndData,snd
          lagfr: 0, $
          smsep: 0, $
          noise: {nsstr, search:0.0, mean:0.0}, $
+         channel: 0, $
          bmnum: 0, $
          bmazm: 0.0, $
          scan: 0, $
@@ -125,7 +126,7 @@ function SndRead,unit,snd
            'origin.code','origin.time','origin.command','cp','stid', $
            'time.yr','time.mo','time.dy','time.hr','time.mt','time.sc', $
            'time.us','nave','lagfr','smsep','noise.search','noise.mean', $
-           'bmnum','bmazm','scan','rxrise','intt.sc','intt.us', $
+           'channel','bmnum','bmazm','scan','rxrise','intt.sc','intt.us', $
            'nrang','frang','rsep','xcf','tfreq','noise.sky', $
            'combf','snd.revision.major','snd.revision.minor']
 
@@ -133,7 +134,7 @@ function SndRead,unit,snd
            1,9,9,2,2, $
            2,2,2,2,2,2, $
            3,2,2,2,4,4, $
-           2,4,2,2,2,3, $
+           2,2,4,2,2,2,3, $
            2,2,2,2,2,4, $
            9,2,2]
 
@@ -191,21 +192,22 @@ function SndRead,unit,snd
   if (sclid[16] ne -1) then snd.smsep=*(sclvec[sclid[16]].ptr)
   if (sclid[17] ne -1) then snd.noise.search=*(sclvec[sclid[17]].ptr)
   if (sclid[18] ne -1) then snd.noise.mean=*(sclvec[sclid[18]].ptr)
-  if (sclid[19] ne -1) then snd.bmnum=*(sclvec[sclid[19]].ptr)
-  if (sclid[20] ne -1) then snd.bmazm=*(sclvec[sclid[20]].ptr)
-  if (sclid[21] ne -1) then snd.scan=*(sclvec[sclid[21]].ptr)
-  if (sclid[22] ne -1) then snd.rxrise=*(sclvec[sclid[22]].ptr)
-  if (sclid[23] ne -1) then snd.intt.sc=*(sclvec[sclid[23]].ptr)
-  if (sclid[24] ne -1) then snd.intt.us=*(sclvec[sclid[24]].ptr)
-  if (sclid[25] ne -1) then snd.nrang=*(sclvec[sclid[25]].ptr)
-  if (sclid[26] ne -1) then snd.frang=*(sclvec[sclid[26]].ptr)
-  if (sclid[27] ne -1) then snd.rsep=*(sclvec[sclid[27]].ptr)
-  if (sclid[28] ne -1) then snd.xcf=*(sclvec[sclid[28]].ptr)
-  if (sclid[29] ne -1) then snd.tfreq=*(sclvec[sclid[29]].ptr)
-  if (sclid[30] ne -1) then snd.sky_noise=*(sclvec[sclid[30]].ptr)
-  if (sclid[31] ne -1) then snd.combf=*(sclvec[sclid[31]].ptr)
-  if (sclid[32] ne -1) then snd.snd_revision.major=*(sclvec[sclid[32]].ptr)
-  if (sclid[33] ne -1) then snd.snd_revision.minor=*(sclvec[sclid[33]].ptr)
+  if (sclid[19] ne -1) then snd.channel=*(sclvec[sclid[19]].ptr)
+  if (sclid[20] ne -1) then snd.bmnum=*(sclvec[sclid[20]].ptr)
+  if (sclid[21] ne -1) then snd.bmazm=*(sclvec[sclid[21]].ptr)
+  if (sclid[22] ne -1) then snd.scan=*(sclvec[sclid[22]].ptr)
+  if (sclid[23] ne -1) then snd.rxrise=*(sclvec[sclid[23]].ptr)
+  if (sclid[24] ne -1) then snd.intt.sc=*(sclvec[sclid[24]].ptr)
+  if (sclid[25] ne -1) then snd.intt.us=*(sclvec[sclid[25]].ptr)
+  if (sclid[26] ne -1) then snd.nrang=*(sclvec[sclid[26]].ptr)
+  if (sclid[27] ne -1) then snd.frang=*(sclvec[sclid[27]].ptr)
+  if (sclid[28] ne -1) then snd.rsep=*(sclvec[sclid[28]].ptr)
+  if (sclid[29] ne -1) then snd.xcf=*(sclvec[sclid[29]].ptr)
+  if (sclid[30] ne -1) then snd.tfreq=*(sclvec[sclid[30]].ptr)
+  if (sclid[31] ne -1) then snd.sky_noise=*(sclvec[sclid[31]].ptr)
+  if (sclid[32] ne -1) then snd.combf=*(sclvec[sclid[32]].ptr)
+  if (sclid[33] ne -1) then snd.snd_revision.major=*(sclvec[sclid[33]].ptr)
+  if (sclid[34] ne -1) then snd.snd_revision.minor=*(sclvec[sclid[34]].ptr)
 
   if (arrid[0] eq -1) then begin
     st=DataMapFreeScalar(sclvec)
@@ -286,6 +288,7 @@ function SndWrite,unit,snd
   s=DataMapMakeScalar('smsep',smd.smsep,sclvec)
   s=DataMapMakeScalar('noise.search',smd.noise.search,sclvec)
   s=DataMapMakeScalar('noise.mean',snd.noise.mean,sclvec)
+  s=DataMapMakeScalar('channel',snd.channel,sclvec)
   s=DataMapMakeScalar('bmnum',snd.bmnum,sclvec)
   s=DataMapMakeScalar('bmazm',snd.bmazm,sclvec)
   s=DataMapMakeScalar('scan',snd.scan,sclvec)

--- a/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/include/sndidl.h
+++ b/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/include/sndidl.h
@@ -71,6 +71,11 @@ struct SndIDLData {
   IDL_STRING combf;
 
   struct {
+    IDL_LONG major;
+    IDL_LONG minor;
+  } fit_revision;
+
+  struct {
     short major;
     short minor;
   } snd_revision;

--- a/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/include/sndidl.h
+++ b/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/include/sndidl.h
@@ -49,6 +49,7 @@ struct SndIDLData {
     float mean;
   } noise;
 
+  short channel;
   short bmnum;
   float bmazm;
   short scan;

--- a/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
@@ -247,8 +247,8 @@ struct SndIDLData *IDLMakeSndData(IDL_VPTR *vptr) {
   snddata[1].type=IDL_MakeStruct("OGSTR",origin);
   snddata[4].type=IDL_MakeStruct("TMSTR",time);
   snddata[8].type=IDL_MakeStruct("NSSTR",noise);
-  snddata[13].type=IDL_MakeStruct("ITSTR",intt);
-  snddata[21].type=IDL_MakeStruct("SDSTR",snd_revision);
+  snddata[14].type=IDL_MakeStruct("ITSTR",intt);
+  snddata[22].type=IDL_MakeStruct("SDSTR",snd_revision);
 
   s=IDL_MakeStruct("SNDDATA",snddata);
 

--- a/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
@@ -51,6 +51,7 @@ void IDLCopySndDataFromIDL(int nrang, struct SndIDLData *isnd,
   snd->smsep = isnd->smsep;
   snd->noise.search = isnd->noise.search;
   snd->noise.mean = isnd->noise.mean;
+  snd->channel = isnd->channel;
   snd->bmnum = isnd->bmnum;
   snd->bmazm = isnd->bmazm;
   snd->scan = isnd->scan;
@@ -127,6 +128,7 @@ void IDLCopySndDataToIDL(int nrang, struct SndData *snd,
   isnd->smsep = snd->smsep;
   isnd->noise.search = snd->noise.search;
   isnd->noise.mean = snd->noise.mean;
+  isnd->channel = snd->channel;
   isnd->bmnum = snd->bmnum;
   isnd->bmazm = snd->bmazm;
   isnd->scan = snd->scan;
@@ -205,37 +207,38 @@ struct SndIDLData *IDLMakeSndData(IDL_VPTR *vptr) {
     {0}};
 
   static IDL_STRUCT_TAG_DEF snddata[]={
-    {"RADAR_REVISION",0,NULL},          /* 0 */
-    {"ORIGIN",0,NULL},                  /* 1 */
-    {"CP",0,(void *) IDL_TYP_INT},      /* 2 */
-    {"STID",0,(void *) IDL_TYP_INT},    /* 3 */
-    {"TIME",0,NULL},                    /* 4 */
-    {"NAVE",0,(void *) IDL_TYP_INT},    /* 5 */
-    {"LAGFR",0,(void *) IDL_TYP_INT},   /* 6 */
-    {"SMSEP",0,(void *) IDL_TYP_INT},   /* 7 */
-    {"NOISE",0,NULL},                   /* 8 */
-    {"BMNUM",0,(void *) IDL_TYP_INT},   /* 9 */
-    {"BMAZM",0,(void *) IDL_TYP_FLOAT}, /* 10 */
-    {"SCAN",0,(void *) IDL_TYP_INT},    /* 11 */
-    {"RXRISE",0,(void *) IDL_TYP_INT},  /* 12 */
-    {"INTT",0,NULL},                    /* 13 */
-    {"NRANG",0,(void *) IDL_TYP_INT},   /* 14 */
-    {"FRANG",0,(void *) IDL_TYP_INT},   /* 15 */
-    {"RSEP",0,(void *) IDL_TYP_INT},    /* 16 */
-    {"XCF",0,(void *) IDL_TYP_INT},     /* 17 */
-    {"TFREQ",0,(void *) IDL_TYP_INT},   /* 18 */
-    {"SKY_NOISE",0,(void *) IDL_TYP_FLOAT}, /* 19 */
-    {"COMBF",0,(void *) IDL_TYP_STRING}, /* 20 */
-    {"SND_REVISION",0,NULL},            /* 21 */
-    {"QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 22 */
-    {"GFLG",rdim,(void *) IDL_TYP_BYTE}, /* 23 */
-    {"V",rdim,(void *) IDL_TYP_FLOAT},   /* 24 */
-    {"V_E",rdim,(void *) IDL_TYP_FLOAT}, /* 25 */
-    {"P_L",rdim,(void *) IDL_TYP_FLOAT}, /* 26 */
-    {"W_L",rdim,(void *) IDL_TYP_FLOAT}, /* 27 */
-    {"X_QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 28 */
-    {"PHI0",rdim,(void *) IDL_TYP_FLOAT}, /* 29 */
-    {"PHI0_E",rdim,(void *) IDL_TYP_FLOAT}, /* 30 */
+    {"RADAR_REVISION",0,NULL},           /* 0 */
+    {"ORIGIN",0,NULL},                   /* 1 */
+    {"CP",0,(void *) IDL_TYP_INT},       /* 2 */
+    {"STID",0,(void *) IDL_TYP_INT},     /* 3 */
+    {"TIME",0,NULL},                     /* 4 */
+    {"NAVE",0,(void *) IDL_TYP_INT},     /* 5 */
+    {"LAGFR",0,(void *) IDL_TYP_INT},    /* 6 */
+    {"SMSEP",0,(void *) IDL_TYP_INT},    /* 7 */
+    {"NOISE",0,NULL},                    /* 8 */
+    {"CHANNEL",0,(void *) IDL_TYP_INT},  /* 9 */
+    {"BMNUM",0,(void *) IDL_TYP_INT},   /* 10 */
+    {"BMAZM",0,(void *) IDL_TYP_FLOAT}, /* 11 */
+    {"SCAN",0,(void *) IDL_TYP_INT},    /* 12 */
+    {"RXRISE",0,(void *) IDL_TYP_INT},  /* 13 */
+    {"INTT",0,NULL},                    /* 14 */
+    {"NRANG",0,(void *) IDL_TYP_INT},   /* 15 */
+    {"FRANG",0,(void *) IDL_TYP_INT},   /* 16 */
+    {"RSEP",0,(void *) IDL_TYP_INT},    /* 17 */
+    {"XCF",0,(void *) IDL_TYP_INT},     /* 18 */
+    {"TFREQ",0,(void *) IDL_TYP_INT},   /* 19 */
+    {"SKY_NOISE",0,(void *) IDL_TYP_FLOAT}, /* 20 */
+    {"COMBF",0,(void *) IDL_TYP_STRING}, /* 21 */
+    {"SND_REVISION",0,NULL},            /* 22 */
+    {"QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 23 */
+    {"GFLG",rdim,(void *) IDL_TYP_BYTE}, /* 24 */
+    {"V",rdim,(void *) IDL_TYP_FLOAT},   /* 25 */
+    {"V_E",rdim,(void *) IDL_TYP_FLOAT}, /* 26 */
+    {"P_L",rdim,(void *) IDL_TYP_FLOAT}, /* 27 */
+    {"W_L",rdim,(void *) IDL_TYP_FLOAT}, /* 28 */
+    {"X_QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 29 */
+    {"PHI0",rdim,(void *) IDL_TYP_FLOAT}, /* 30 */
+    {"PHI0_E",rdim,(void *) IDL_TYP_FLOAT}, /* 31 */
     {0}};
 
   static IDL_MEMINT ilDims[IDL_MAX_ARRAY_DIM];

--- a/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
@@ -68,6 +68,9 @@ void IDLCopySndDataFromIDL(int nrang, struct SndIDLData *isnd,
   if (strlen(IDL_STRING_STR(&isnd->combf)) !=0)
     SndSetCombf(snd,IDL_STRING_STR(&isnd->combf));
 
+  snd->fit_revision.major = isnd->fit_revision.major;
+  snd->fit_revision.minor = isnd->fit_revision.minor;
+
   snd->snd_revision.major = isnd->snd_revision.major;
   snd->snd_revision.minor = isnd->snd_revision.minor;
 
@@ -147,6 +150,9 @@ void IDLCopySndDataToIDL(int nrang, struct SndData *snd,
     IDL_StrStore(&isnd->combf,combftmp);
   }
 
+  isnd->fit_revision.major = snd->fit_revision.major;
+  isnd->fit_revision.minor = snd->fit_revision.minor;
+
   isnd->snd_revision.major = snd->snd_revision.major;
   isnd->snd_revision.minor = snd->snd_revision.minor;
 
@@ -201,6 +207,11 @@ struct SndIDLData *IDLMakeSndData(IDL_VPTR *vptr) {
     {"US",0,(void *) IDL_TYP_LONG},
     {0}};
 
+  static IDL_STRUCT_TAG_DEF fit_revision[]={
+    {"MAJOR",0,(void *) IDL_TYP_LONG},
+    {"MINOR",0,(void *) IDL_TYP_LONG},
+    {0}};
+
   static IDL_STRUCT_TAG_DEF snd_revision[]={
     {"MAJOR",0,(void *) IDL_TYP_INT},
     {"MINOR",0,(void *) IDL_TYP_INT},
@@ -229,16 +240,17 @@ struct SndIDLData *IDLMakeSndData(IDL_VPTR *vptr) {
     {"TFREQ",0,(void *) IDL_TYP_INT},   /* 19 */
     {"SKY_NOISE",0,(void *) IDL_TYP_FLOAT}, /* 20 */
     {"COMBF",0,(void *) IDL_TYP_STRING}, /* 21 */
-    {"SND_REVISION",0,NULL},            /* 22 */
-    {"QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 23 */
-    {"GFLG",rdim,(void *) IDL_TYP_BYTE}, /* 24 */
-    {"V",rdim,(void *) IDL_TYP_FLOAT},   /* 25 */
-    {"V_E",rdim,(void *) IDL_TYP_FLOAT}, /* 26 */
-    {"P_L",rdim,(void *) IDL_TYP_FLOAT}, /* 27 */
-    {"W_L",rdim,(void *) IDL_TYP_FLOAT}, /* 28 */
-    {"X_QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 29 */
-    {"PHI0",rdim,(void *) IDL_TYP_FLOAT}, /* 30 */
-    {"PHI0_E",rdim,(void *) IDL_TYP_FLOAT}, /* 31 */
+    {"FIT_REVISION",0,NULL},             /* 22 */
+    {"SND_REVISION",0,NULL},             /* 23 */
+    {"QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 24 */
+    {"GFLG",rdim,(void *) IDL_TYP_BYTE}, /* 25 */
+    {"V",rdim,(void *) IDL_TYP_FLOAT},   /* 26 */
+    {"V_E",rdim,(void *) IDL_TYP_FLOAT}, /* 27 */
+    {"P_L",rdim,(void *) IDL_TYP_FLOAT}, /* 28 */
+    {"W_L",rdim,(void *) IDL_TYP_FLOAT}, /* 29 */
+    {"X_QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 30 */
+    {"PHI0",rdim,(void *) IDL_TYP_FLOAT}, /* 31 */
+    {"PHI0_E",rdim,(void *) IDL_TYP_FLOAT}, /* 32 */
     {0}};
 
   static IDL_MEMINT ilDims[IDL_MAX_ARRAY_DIM];
@@ -248,7 +260,8 @@ struct SndIDLData *IDLMakeSndData(IDL_VPTR *vptr) {
   snddata[4].type=IDL_MakeStruct("TMSTR",time);
   snddata[8].type=IDL_MakeStruct("NSSTR",noise);
   snddata[14].type=IDL_MakeStruct("ITSTR",intt);
-  snddata[22].type=IDL_MakeStruct("SDSTR",snd_revision);
+  snddata[22].type=IDL_MakeStruct("RLSTR",fit_revision);
+  snddata[23].type=IDL_MakeStruct("SDSTR",snd_revision);
 
   s=IDL_MakeStruct("SNDDATA",snddata);
 

--- a/codebase/superdarn/src.lib/tk/snd.1.0/doc/snd.doc.xml
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/doc/snd.doc.xml
@@ -238,6 +238,11 @@
     </member>
 
     <member>
+      <proto>int16 channel;</proto>
+      <description>Channel number for a stereo or other multi-channel radar.</description>
+    </member>
+
+    <member>
       <proto>int16 bmnum;</proto>
       <description>Beam number.</description>
     </member>
@@ -305,6 +310,21 @@
     <member>
       <proto>char *combf;</proto>
       <description>Comment buffer.</description>
+    </member>
+
+    <member>
+      <struct>
+        <member>
+          <proto>char major;</proto>
+          <description>FITACF major revision number.</description>
+        </member>
+        <member>
+          <proto>char minor;</proto>
+          <description>FITACF minor revision number.</description>
+        </member>
+      </struct>
+      <proto>fitacf_revision;</proto>
+      <description>FITACF revision number.</description>
     </member>
 
     <member>

--- a/codebase/superdarn/src.lib/tk/snd.1.0/include/snddata.h
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/include/snddata.h
@@ -9,7 +9,7 @@
 
 
 #define SND_MAJOR_REVISION 1
-#define SND_MINOR_REVISION 0
+#define SND_MINOR_REVISION 1
 
 
 struct SndData {
@@ -47,6 +47,7 @@ struct SndData {
     float mean;
   } noise;
 
+  int16 channel;
   int16 bmnum;
   float bmazm;
   int16 scan;

--- a/codebase/superdarn/src.lib/tk/snd.1.0/include/snddata.h
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/include/snddata.h
@@ -71,6 +71,11 @@ struct SndData {
   struct {
     int major;
     int minor;
+  } fit_revision;
+
+  struct {
+    int major;
+    int minor;
   } snd_revision;
 
   struct SndRange *rng;

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
@@ -53,6 +53,8 @@ int FitToSnd(struct SndData *ptr, struct RadarParm *prm,
   ptr->tfreq = prm->tfreq;
   ptr->sky_noise = fit->noise.skynoise;
   ptr->combf = prm->combf;
+  ptr->fit_revision.major = fit->revision.major;
+  ptr->fit_revision.minor = fit->revision.minor;
   ptr->snd_revision.major = SND_MAJOR_REVISION;
   ptr->snd_revision.minor = SND_MINOR_REVISION;
 

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
@@ -39,6 +39,7 @@ int FitToSnd(struct SndData *ptr, struct RadarParm *prm,
   ptr->smsep = prm->smsep;
   ptr->noise.search = prm->noise.search;
   ptr->noise.mean = prm->noise.mean;
+  ptr->channel = prm->channel;
   ptr->bmnum = prm->bmnum;
   ptr->bmazm = prm->bmazm;
   ptr->scan = scan;

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndread.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndread.c
@@ -106,6 +106,10 @@ int SndDecode(struct DataMap *ptr, struct SndData *snd) {
       snd->sky_noise=*(s->data.fptr);
     if ((strcmp(s->name,"combf")==0) && (s->type==DATASTRING))
       SndSetCombf(snd,*((char **) s->data.vptr));
+    if ((strcmp(s->name,"fitacf.revision.major")==0) && (s->type==DATAINT))
+      snd->fit_revision.major=*(s->data.iptr);
+    if ((strcmp(s->name,"fitacf.revision.minor")==0) && (s->type==DATAINT))
+      snd->fit_revision.minor=*(s->data.iptr);
     if ((strcmp(s->name,"snd.revision.major")==0) && (s->type==DATASHORT))
       snd->snd_revision.major=*(s->data.sptr);
     if ((strcmp(s->name,"snd.revision.minor")==0) && (s->type==DATASHORT))

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndread.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndread.c
@@ -78,6 +78,8 @@ int SndDecode(struct DataMap *ptr, struct SndData *snd) {
       snd->noise.search=*(s->data.fptr);
     if ((strcmp(s->name,"noise.mean")==0) && (s->type==DATAFLOAT))
       snd->noise.mean=*(s->data.fptr);
+    if ((strcmp(s->name,"channel")==0) && (s->type==DATASHORT))
+      snd->channel=*(s->data.sptr);
     if ((strcmp(s->name,"bmnum")==0) && (s->type==DATASHORT))
       snd->bmnum=*(s->data.sptr);
     if ((strcmp(s->name,"bmazm")==0) && (s->type==DATAFLOAT))

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndscan.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndscan.c
@@ -103,7 +103,7 @@ int SndReadRadarScan(int fid, int *state,
         bm->freq=snd->tfreq;
         bm->noise=snd->noise.search;
         bm->atten=0;
-        bm->channel=0;
+        bm->channel=snd->channel;
         bm->nrang=snd->nrang;
 
         /* Set flags indicating scatter in each range gate to zero */
@@ -215,7 +215,7 @@ int SndToRadarScan(struct RadarScan *ptr,
   bm->freq=snd->tfreq;
   bm->noise=snd->noise.search;
   bm->atten=0;
-  bm->channel=0;
+  bm->channel=snd->channel;
   bm->nrang=snd->nrang;
 
   for (r=0;r<bm->nrang;r++) bm->sct[r]=0;

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
@@ -62,6 +62,7 @@ int SndWrite(int fid, struct SndData *snd) {
   DataMapAddScalar(ptr,"noise.search",DATAFLOAT,&snd->noise.search);
   DataMapAddScalar(ptr,"noise.mean",DATAFLOAT,&snd->noise.mean);
 
+  DataMapAddScalar(ptr,"channel",DATASHORT,&snd->channel);
   DataMapAddScalar(ptr,"bmnum",DATASHORT,&snd->bmnum);
   DataMapAddScalar(ptr,"bmazm",DATAFLOAT,&snd->bmazm);
 

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
@@ -82,6 +82,9 @@ int SndWrite(int fid, struct SndData *snd) {
 
   DataMapAddScalar(ptr,"combf",DATASTRING,&snd->combf);
 
+  DataMapAddScalar(ptr,"fitacf.revision.major",DATAINT,&snd->fit_revision.major);
+  DataMapAddScalar(ptr,"fitacf.revision.minor",DATAINT,&snd->fit_revision.minor);
+
   DataMapAddScalar(ptr,"snd.revision.major",DATASHORT,&snd->snd_revision.major);
   DataMapAddScalar(ptr,"snd.revision.minor",DATASHORT,&snd->snd_revision.minor);
 


### PR DESCRIPTION
Apologies for not having this ready in time before @ecbland so graciously merged the larger sounding library pull request (#315). This pull request adds a new `combine_snd` binary which combines sounding records from each slice of a Borealis-style radar into a single sounding file in chronological order.  An example might look like

`combine_snd -vb YYYYMMDD.hh.rad.*.snd > YYYYMMDD.hh.rad.snd`

I do not believe I am in a position to release any example Borealis data, so maybe one of our colleagues from USask could test this routine or provide access to the data if necessary.