### PR TITLE
Fixing bug in grid_plot and map_plot preventing power or spectral width cells from being drawn for SH data

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
@@ -1354,10 +1354,10 @@ int main(int argc,char *argv[]) {
  
     if (celflg) {
       if (avflg) 
-        plot_cell(plot,rgridavg,0,magflg,pad,pad,wdt-2*pad,
+        plot_cell(plot,rgridavg,latmin,magflg,pad,pad,wdt-2*pad,
                     hgt-2*pad,tfunc,marg,mag_color,&xkey,cprm,old_aacgm);
       else 
-        plot_cell(plot,rgrid,0,magflg,pad,pad,wdt-2*pad,
+        plot_cell(plot,rgrid,latmin,magflg,pad,pad,wdt-2*pad,
                     hgt-2*pad,tfunc,marg,mag_color,&xkey,cprm,old_aacgm);
     }
 

--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/plot_cell.c
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/plot_cell.c
@@ -98,7 +98,7 @@ void plot_cell(struct Plot *plot,
     }
     lon=ptr->data[i].mlon;
     lat=ptr->data[i].mlat;
-    if (abs(lat)<latmin) continue;
+    if (abs(lat)<abs(latmin)) continue;
     nlon=(int) (360*cos((lat-0.5)*PI/180)+0.5);
     lstp=360.0/nlon; 
     s=cell_convert(xoff,yoff,wdt,hgt,lat-0.5,lon-lstp/2,&px[0],&py[0],

--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/plot_cell.c
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/plot_cell.c
@@ -98,7 +98,7 @@ void plot_cell(struct Plot *plot,
     }
     lon=ptr->data[i].mlon;
     lat=ptr->data[i].mlat;
-    if (lat<latmin) continue;
+    if (abs(lat)<latmin) continue;
     nlon=(int) (360*cos((lat-0.5)*PI/180)+0.5);
     lstp=360.0/nlon; 
     s=cell_convert(xoff,yoff,wdt,hgt,lat-0.5,lon-lstp/2,&px[0],&py[0],

--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/plot_cell.c
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/plot_cell.c
@@ -97,7 +97,7 @@ void plot_cell(struct Plot *plot, struct GridData *ptr,float latmin,int magflg,
 
     lon = ptr->data[i].mlon;
     lat = ptr->data[i].mlat;
-    if (lat < latmin) continue;
+    if (abs(lat) < abs(latmin)) continue;
     nlon = (int) (360*cos((lat-0.5)*PI/180)+0.5);
     lstp = 360.0/nlon; 
     s = cell_convert(xoff,yoff,wdt,hgt,lat-0.5,lon-lstp/2,&px[0],&py[0],


### PR DESCRIPTION
This pull request addresses the bug reported in #330 by correctly passing the latmin value from `grid_plot.c` to the `plot_cell` function. Previously, southern hemisphere grid vectors were skipped over because their latitude was always below the hardcoded `latmin` value of 0 passed to the `plot_cell` function.

edit - this pull request also addresses a similar bug in `map_plot` causing the same behavior.