### PR TITLE
Fix max FOV range in plotting routines to 75 range gates

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/make_fov.c
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/make_fov.c
@@ -50,6 +50,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
     int rsep=45;
     struct PolygonData *ptr=NULL;
     struct RadarSite *site=NULL;
+    int maxrange=75;
 
     TimeEpochToYMDHMS(tval,&yr,&mo,&dy,&hr,&mt,&sc);
 
@@ -63,7 +64,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
         if (site==NULL) continue;
         PolygonAddPolygon(ptr,1);
 
-        for (rn=0;rn<=site->maxrange;rn++) {
+        for (rn=0;rn<=maxrange;rn++) {
             RPosGeo(0,0,rn,site,frang,rsep,
                     site->recrise,0,&rho,&lat,&lon,chisham);
             pnt[0]=lat;
@@ -72,14 +73,14 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
         }
 
         for (bm=1;bm<=site->maxbeam;bm++) {
-            RPosGeo(0,bm,site->maxrange,site,frang,rsep,
+            RPosGeo(0,bm,maxrange,site,frang,rsep,
                     site->recrise,0,&rho,&lat,&lon,chisham);
             pnt[0]=lat;
             pnt[1]=lon;
             PolygonAdd(ptr,pnt);
         }
 
-        for (rn=site->maxrange-1;rn>=0;rn--) {
+        for (rn=maxrange-1;rn>=0;rn--) {
             RPosGeo(0,site->maxbeam,rn,site,frang,rsep,
                     site->recrise,0,&rho,&lat,&lon,chisham);
             pnt[0]=lat;

--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/make_fov.c
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/make_fov.c
@@ -50,6 +50,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
     int rsep=45;
     struct PolygonData *ptr=NULL;
     struct RadarSite *site=NULL;
+    int maxrange=75;
 
     TimeEpochToYMDHMS(tval,&yr,&mo,&dy,&hr,&mt,&sc);
 
@@ -61,7 +62,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
         if (site==NULL) continue;
         PolygonAddPolygon(ptr,i);
 
-        for (rn=0;rn<=75;rn++) {
+        for (rn=0;rn<=maxrange;rn++) {
             RPosGeo(0,0,rn,site,frang,rsep,
                     site->recrise,alt,&rho,&lat,&lon,chisham);
             pnt[0]=lat;
@@ -70,14 +71,14 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
         }
 
         for (bm=1;bm<=site->maxbeam;bm++) {
-            RPosGeo(0,bm,75,site,frang,rsep,
+            RPosGeo(0,bm,maxrange,site,frang,rsep,
                     site->recrise,alt,&rho,&lat,&lon,chisham);
             pnt[0]=lat;
             pnt[1]=lon;
             PolygonAdd(ptr,pnt);
         }
 
-        for (rn=75-1;rn>=0;rn--) {
+        for (rn=maxrange-1;rn>=0;rn--) {
             RPosGeo(0,site->maxbeam,rn,site,frang,rsep,
                     site->recrise,alt,&rho,&lat,&lon,chisham);
             pnt[0]=lat;

--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/make_fov.c
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/make_fov.c
@@ -51,6 +51,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
     int rsep=45;
     struct PolygonData *ptr=NULL;
     struct RadarSite *site=NULL;
+    int maxrange=75;
 
     TimeEpochToYMDHMS(tval,&yr,&mo,&dy,&hr,&mt,&sc);
 
@@ -63,7 +64,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
         if (site==NULL) continue;
         PolygonAddPolygon(ptr,1);
 
-        for (rn=0;rn<=site->maxrange;rn++) {
+        for (rn=0;rn<=maxrange;rn++) {
             RPosMag(0,0,rn,site,frang,rsep,
                     site->recrise,0,&rho,&lat,&lon,
                     chisham,old_aacgm);
@@ -73,7 +74,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
         }
 
         for (bm=1;bm<=site->maxbeam;bm++) {
-            RPosMag(0,bm,site->maxrange,site,frang,rsep,
+            RPosMag(0,bm,maxrange,site,frang,rsep,
                     site->recrise,0,&rho,&lat,&lon,
                     chisham,old_aacgm);
             pnt[0]=lat;
@@ -81,7 +82,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
             PolygonAdd(ptr,pnt);
         }
 
-        for (rn=site->maxrange-1;rn>=0;rn--) {
+        for (rn=maxrange-1;rn>=0;rn--) {
             RPosMag(0,site->maxbeam,rn,site,frang,rsep,
                     site->recrise,0,&rho,&lat,&lon,
                     chisham,old_aacgm);

--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/make_fov.c
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/make_fov.c
@@ -52,6 +52,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
     int rsep=45;
     struct PolygonData *ptr=NULL;
     struct RadarSite *site=NULL;
+    int maxrange=75;
 
     TimeEpochToYMDHMS(tval,&yr,&mo,&dy,&hr,&mt,&sc);
 
@@ -64,7 +65,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
         if (site==NULL) continue;
         PolygonAddPolygon(ptr,1);
 
-        for (rn=0;rn<=site->maxrange;rn++) {
+        for (rn=0;rn<=maxrange;rn++) {
             RPosMag(0,0,rn,site,frang,rsep,
                     site->recrise,0,&rho,&lat,&lon,
                     chisham,old_aacgm);
@@ -74,7 +75,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
         }
 
         for (bm=1;bm<=site->maxbeam;bm++) {
-            RPosMag(0,bm,site->maxrange,site,frang,rsep,
+            RPosMag(0,bm,maxrange,site,frang,rsep,
                     site->recrise,0,&rho,&lat,&lon,
                     chisham,old_aacgm);
             pnt[0]=lat;
@@ -82,7 +83,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
             PolygonAdd(ptr,pnt);
         }
 
-        for (rn=site->maxrange-1;rn>=0;rn--) {
+        for (rn=maxrange-1;rn>=0;rn--) {
             RPosMag(0,site->maxbeam,rn,site,frang,rsep,
                     site->recrise,0,&rho,&lat,&lon,
                     chisham,old_aacgm);


### PR DESCRIPTION
This pull request addresses issue #322 by modifying the `make_fov` routines in `field_plot`, `grid_plot`, and `map_plot` plot to use 75 range gates to create representative FOV extents and avoid AACGM-v2 errrors for radars with >110 max range gates in their hardware files. Note that this was fix previously done in `fov_plot` but the implementation in that routine has been modified to match the other plotting binaries.