### PR TITLE
Fix/fitacf old

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
@@ -272,7 +272,6 @@ int main(int argc,char *argv[]) {
      } else if (rawfp->error == -2) {
        /* Error case where num_bytes is less than 0 */
        OldRawClose(rawfp);
-       free(rawfp);
        free_radarstructs(network, prm, raw);
        exit(-1);
      }

--- a/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
@@ -490,7 +490,7 @@ int main(int argc,char *argv[]) {
   } while (status==0);
 
   free_radarstructs(network, prm, raw);
-  free_files(rawfp, fp, NULL, inxfp);
+  //free_files(rawfp, fp, NULL, inxfp);
   free_fitstructs(fit_prms, fit, fblk);
 
   return 0;

--- a/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
@@ -319,7 +319,6 @@ int main(int argc,char *argv[]) {
     strcat(command,argv[c]);
   }
 
-
   if (vb)
       fprintf(stderr,"%d-%d-%d %d:%d:%d beam=%d\n",prm->time.yr,prm->time.mo,
 	     prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
@@ -418,7 +417,7 @@ int main(int argc,char *argv[]) {
     {
         fprintf(stderr,"Error: cannot set Origin Command\n");
         free_radarstructs(network, prm, raw);
-        free_files(rawfp, fp, fitfp, inxfp);
+        free_files(rawfp, fp, NULL, inxfp);
         free_fitstructs(fit_prms, fit, fblk);
         exit(-1);
     }
@@ -429,7 +428,7 @@ int main(int argc,char *argv[]) {
     {
         fprintf(stderr,"Error: cannot set Origin Time\n");
         free_radarstructs(network, prm, raw);
-        free_files(rawfp, fp, fitfp, inxfp);
+        free_files(rawfp, fp, NULL, inxfp);
         free_fitstructs(fit_prms, fit, fblk);
         exit(-1);
     }
@@ -455,7 +454,7 @@ int main(int argc,char *argv[]) {
         if (Allocate_Fit_Prm(prm, fit_prms) == -1) {
             fprintf(stderr,"Error: cannot allocate space for fitacf record\n");
             free_radarstructs(network, prm, raw);
-            free_files(rawfp, fp, fitfp, inxfp);
+            free_files(rawfp, fp, NULL, inxfp);
             free_fitstructs(fit_prms, fit, fblk);            
             exit(-1);
         }
@@ -470,7 +469,7 @@ int main(int argc,char *argv[]) {
         else {
             fprintf(stderr, "Unable to allocate fit_prms!\n");
             free_radarstructs(network, prm, raw);
-            free_files(rawfp, fp, fitfp, inxfp);
+            free_files(rawfp, fp, NULL, inxfp);
             free_fitstructs(fit_prms, fit, fblk);
             exit(-1);
         }
@@ -481,7 +480,7 @@ int main(int argc,char *argv[]) {
       else {
             fprintf(stderr, "The requested fitacf version does not exist\n");
             free_radarstructs(network, prm, raw);
-            free_files(rawfp, fp, fitfp, inxfp);
+            free_files(rawfp, fp, NULL, inxfp);
             free_fitstructs(fit_prms, fit, fblk);
             exit(-1);
       }
@@ -491,7 +490,7 @@ int main(int argc,char *argv[]) {
   } while (status==0);
 
   free_radarstructs(network, prm, raw);
-  free_files(rawfp, fp, fitfp, inxfp);
+  free_files(rawfp, fp, NULL, inxfp);
   free_fitstructs(fit_prms, fit, fblk);
 
   return 0;


### PR DESCRIPTION
# Scope 
Fixing issue #338 

## Problem 
There was a double freeing of `fitfp`, so I assume one of the Old functions does the freeing. 

## Solution
Just passed in NULL into my free functions which will not free it from an if statement. 

## Test 
bug on branch `develop` 
```bash 
make_fit -old 2005050520d.dat 2005050520d.fit 2005050520d.inx
free(): double free detected in tcache 2
Aborted (core dumped)
```

fixed branch `FIX/fitacf_old`
```bash
make_fit -old 2005050520d.dat 2005050520d.fit 2005050520d.inx
time_plot -old -x -a 2005050520d.fit   #to check that there's some sensible data in the file
```

@ecbland can you add more for testing and what the bug error was? 
EDIT by @ecbland : I've edited the text to include the bug I get on `develop` and how to test :+1: 

## Note

I could not recreate this bug on my Opensuse and Ubunutu's OS on LinuxMint so far shows the error. So if you cannot get the bug then you might be the best tester :p 

@ecbland might be the only one hehe 


 
