### PR TITLE
Citing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Nishitani, N., Ruohoniemi, J.M., Lester, M. et al. Review of the accomplishments
 
 During your study, if using data from individual radars only, **please contact the Principal Investigator (PI) of that radar about potential co-authorship**. A list of radars, institutions, and their PI's information can be found [here](https://superdarn.ca/radar-info)
 
-For more information please read [citing SuperDARN data]()
+For more information please read [citing SuperDARN data](https://radar-software-toolkit-rst.readthedocs.io/en/latest/user_guide/citing.md)
 
 ## Contribute to RST
 The DAWG welcomes new testers and developers to join the team. Here are some ways to contribute:

--- a/README.md
+++ b/README.md
@@ -19,11 +19,9 @@ Installation guide for:
   - <font color="grey">Windows </font> yet to be implemented
 
 ## Citing SuperDARN Data 
-The Super Dual Auroral Radar Network (SuperDARN) is a made up of nominally 36 radars and 20 institutions, to cite general SuperDARN you can use:
+The Super Dual Auroral Radar Network (SuperDARN) consists of more than 30 radars operated by institutions in 10 different countries. The following review papers are recommended for general information about the network's scientific achievements, and for citing SuperDARN in publications:
 
 Greenwald, R.A., Baker, K.B., Dudeney, J.R. et al. Space Sci Rev (1995) 71: 761. doi:10.1007/BF00751350
-
-For the general achievements of the SuperDARN Network, you can read these papers:
 
 Chisham, G., Lester, M., Milan, S.E. et al. A decade of the Super Dual Auroral Radar Network (SuperDARN): scientific achievements, new techniques and future directions. Surv Geophys 28, 33–109 (2007) doi:10.1007/s10712-007-9017-8
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,22 @@ Installation guide for:
   - [Linux](https://radar-software-toolkit-rst.readthedocs.io/en/latest/user_guide/linux_install/)
   - [MacOSX](https://radar-software-toolkit-rst.readthedocs.io/en/latest/user_guide/mac_install/)
   - <font color="grey">Windows </font> yet to be implemented
-  
+
+## Citing SuperDARN Data 
+The Super Dual Auroral Radar Network (SuperDARN) is a made up of nominally 36 radars and 20 institutions, to cite general SuperDARN you can use:
+
+Greenwald, R.A., Baker, K.B., Dudeney, J.R. et al. Space Sci Rev (1995) 71: 761. doi:10.1007/BF00751350
+
+For the general achievements of the SuperDARN Network, you can read these papers:
+
+Chisham, G., Lester, M., Milan, S.E. et al. A decade of the Super Dual Auroral Radar Network (SuperDARN): scientific achievements, new techniques and future directions. Surv Geophys 28, 33–109 (2007) doi:10.1007/s10712-007-9017-8
+
+Nishitani, N., Ruohoniemi, J.M., Lester, M. et al. Review of the accomplishments of mid-latitude Super Dual Auroral Radar Network (SuperDARN) HF radars. Prog Earth Planet Sci 6, 27 (2019) doi:10.1186/s40645-019-0270-5
+
+During your study, if using data from individual radars only, **please contact the Principal Investigator (PI) of that radar about potential co-authorship**. A list of radars, institutions, and their PI's information can be found [here](https://superdarn.ca/radar-info)
+
+For more information please read [citing SuperDARN data]()
+
 ## Contribute to RST
 The DAWG welcomes new testers and developers to join the team. Here are some ways to contribute:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,8 @@ The software is maintained by the SuperDARN Data Analysis Working Group (DAWG) o
 	* [Linux](user_guide/linux_install.md)
 	* [MacOSX](user_guide/mac_install.md)
   - SuperDARN Data:
-    * [Accessing Data]: user_guide/data.md
-    * [Citing Data]: user_guide/citing.md
+    * [Accessing Data]: (user_guide/data.md)
+    * [Citing Data]: (user_guide/citing.md)
   -  RST Tutorials 
 	  - Data Processing
        * [RAWACF to FITACF](user_guide/make_fit.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,8 @@ The software is maintained by the SuperDARN Data Analysis Working Group (DAWG) o
 	* [Linux](user_guide/linux_install.md)
 	* [MacOSX](user_guide/mac_install.md)
   - SuperDARN Data:
-    * [Accessing Data]: (user_guide/data.md)
-    * [Citing Data]: (user_guide/citing.md)
+    * [Accessing Data](user_guide/data.md)
+    * [Citing Data](user_guide/citing.md)
   -  RST Tutorials 
 	  - Data Processing
        * [RAWACF to FITACF](user_guide/make_fit.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,9 +16,12 @@ The software is maintained by the SuperDARN Data Analysis Working Group (DAWG) o
   - Installation
 	* [Linux](user_guide/linux_install.md)
 	* [MacOSX](user_guide/mac_install.md)
+  - SuperDARN Data:
+    * [Accessing Data]: user_guide/data.md
+    * [Citing Data]: user_guide/citing.md
   -  RST Tutorials 
 	  - Data Processing
-         * [RAWACF to FITACF](user_guide/make_fit.md)
+       * [RAWACF to FITACF](user_guide/make_fit.md)
 	     * [FITACF to GRID](user_guide/make_grid.md)
 	     * [GRID to MAP](user_guide/map_grid.md)
 	  - Plotting Data

--- a/docs/user_guide/citing.md
+++ b/docs/user_guide/citing.md
@@ -1,13 +1,12 @@
 # How to cite SuperDARN
 
-Super Dual Auroral Radar Network (SuperDARN) is a made up of 36 radars 20 institutions, to cite general SuperDARN you can use: 
+The Super Dual Auroral Radar Network (SuperDARN) consists of more than 30 radars operated by institutions in 10 different countries. The following review papers are recommended for general information about the network's scientific achievements, and for citing SuperDARN in publications:
 
-- Greenwald, R.A., Baker, K.B., Dudeney, J.R. et al. Space Sci Rev (1995) 71: 761. [doi:10.1007/BF00751350](https://doi.org/10.1007/BF00751350)
+Greenwald, R.A., Baker, K.B., Dudeney, J.R. et al. Space Sci Rev (1995) 71: 761. doi:10.1007/BF00751350
 
-For the general achievements of the SuperDARN Network, you can read these papers: 
+Chisham, G., Lester, M., Milan, S.E. et al. A decade of the Super Dual Auroral Radar Network (SuperDARN): scientific achievements, new techniques and future directions. Surv Geophys 28, 33–109 (2007) doi:10.1007/s10712-007-9017-8
 
-- Chisham, G., Lester, M., Milan, S.E. et al. A decade of the Super Dual Auroral Radar Network (SuperDARN): scientific achievements, new techniques and future directions. Surv Geophys 28, 33–109 (2007) [doi:10.1007/s10712-007-9017-8](https://link.springer.com/article/10.1007/s10712-007-9017-8)
-- Nishitani, N., Ruohoniemi, J.M., Lester, M. et al. Review of the accomplishments of mid-latitude Super Dual Auroral Radar Network (SuperDARN) HF radars. Prog Earth Planet Sci 6, 27 (2019) [doi:10.1186/s40645-019-0270-5](https://progearthplanetsci.springeropen.com/articles/10.1186/s40645-019-0270-5)
+Nishitani, N., Ruohoniemi, J.M., Lester, M. et al. Review of the accomplishments of mid-latitude Super Dual Auroral Radar Network (SuperDARN) HF radars. Prog Earth Planet Sci 6, 27 (2019) doi:10.1186/s40645-019-0270-5
 
 During your study, if using data from individual radars only, please contact the Principal Investigator (PI) of that radar about potential co-authorship. 
 A list of radars, institutions, and their PI's information can be found [here](http://vt.superdarn.org/tiki-index.php?page=Radar+Overview).  

--- a/docs/user_guide/citing.md
+++ b/docs/user_guide/citing.md
@@ -1,0 +1,39 @@
+# How to cite SuperDARN
+
+Super Dual Auroral Radar Network (SuperDARN) is a made up of 36 radars 20 institutions, to cite general SuperDARN you can use: 
+
+- Greenwald, R.A., Baker, K.B., Dudeney, J.R. et al. Space Sci Rev (1995) 71: 761. [doi:10.1007/BF00751350](https://doi.org/10.1007/BF00751350)
+
+For the general achievements of the SuperDARN Network, you can read these papers: 
+
+- Chisham, G., Lester, M., Milan, S.E. et al. A decade of the Super Dual Auroral Radar Network (SuperDARN): scientific achievements, new techniques and future directions. Surv Geophys 28, 33–109 (2007) [doi:10.1007/s10712-007-9017-8](https://link.springer.com/article/10.1007/s10712-007-9017-8)
+- Nishitani, N., Ruohoniemi, J.M., Lester, M. et al. Review of the accomplishments of mid-latitude Super Dual Auroral Radar Network (SuperDARN) HF radars. Prog Earth Planet Sci 6, 27 (2019) [doi:10.1186/s40645-019-0270-5](https://progearthplanetsci.springeropen.com/articles/10.1186/s40645-019-0270-5)
+
+During your study, if using data from individual radars only, please contact the Principal Investigator (PI) of that radar about potential co-authorship. 
+A list of radars, institutions, and their PI's information can be found [here](http://vt.superdarn.org/tiki-index.php?page=Radar+Overview).  
+
+## DOI
+
+Currently SuperDARN in the process of placing DOI's on their data set. In the meantime, please use any local available services to DOI your data set. 
+Possible services:
+
+  - [FRDR](https://www.frdr.ca/repo/): Canadian resource 
+  - [zenodo](https://help.zenodo.org/features/) 
+
+# Citing RST
+
+Click on DOI badge:
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3994968.svg)](https://doi.org/10.5281/zenodo.3994968)
+
+Scroll to the bottom and copy *Share Cite as* text or clicking on the preferred *Export* type. 
+
+## Acknowledgments 
+
+RST is also built on various scientific algorithms and libraries: 
+
+- [AACGM and AACGMv2](http://superdarn.thayer.dartmouth.edu/aacgm.html)
+- IGRF
+- Chisham Virtual Hieght Model 
+- Dr. Evan Thomas Statistical Convection Map models 
+- Dr. Shepherd Elevation Angle algorithm 
+-

--- a/docs/user_guide/citing.md
+++ b/docs/user_guide/citing.md
@@ -25,14 +25,3 @@ Click on DOI badge:
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3994968.svg)](https://doi.org/10.5281/zenodo.3994968)
 
 Scroll to the bottom and copy *Share Cite as* text or clicking on the preferred *Export* type. 
-
-## Acknowledgments 
-
-RST is also built on various scientific algorithms and libraries: 
-
-- [AACGM and AACGMv2](http://superdarn.thayer.dartmouth.edu/aacgm.html)
-- IGRF
-- Chisham Virtual Hieght Model 
-- Dr. Evan Thomas Statistical Convection Map models 
-- Dr. Shepherd Elevation Angle algorithm 
--

--- a/docs/user_guide/data.md
+++ b/docs/user_guide/data.md
@@ -1,8 +1,6 @@
 # Getting SuperDARN Data 
 
-RST does not provide an interface for downloading data. However, there are other means of getting access to the data. 
-
-The Data Distribution Working Group (DDWG) manages the checking and distribution of data. If you have any inquiries, please contact the chair Kevin Krieger at superdarn@usask.ca
+RST does not provide an interface for downloading data. The Data Distribution Working Group (DDWG) manages the checking and distribution of data. If you have any inquiries, please contact the chair Kevin Krieger at superdarn@usask.ca
 
 ## Data Mirrors
 To get access to the data, there are two possible data servers: one utilizes Globus, and one uses rsync, sftp and scp: 

--- a/docs/user_guide/data.md
+++ b/docs/user_guide/data.md
@@ -1,0 +1,11 @@
+# Getting SuperDARN Data 
+
+RST does not provide an interface for downloading data. However, there are other means of getting access to the data. 
+
+The Data Distribution Working Group (DDWG) manages the checking and distribution of data. If you have any inquiries, please contact the chair Kevin Krieger at superdarn@usask.ca
+
+## Data Mirrors
+To get access to the data, there are two possible data servers: one utilizes Globus, and one uses rsync, sftp and scp: 
+
+  - [SuperDARN Canada](https://superdarn.ca/): uses [Globus](https://github.com/SuperDARNCanada/globus) to allow access to the SuperDARN data. 
+  - [BAS](https://www.bas.ac.uk/project/superdarn/#about): information on data access can be found [here](https://www.bas.ac.uk/project/superdarn/#data)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,9 @@ pages:
 - Installation:
         - Linux: user_guide/linux_install.md
         - MacOSX: user_guide/mac_install.md
+- SuperDARN Data:
+    - Accessing Data: user_guide/data.md
+    - Citing Data: user_guide/citing.md
 - RST Tutorials: 
     - Data Processing: 
             - RAWACF to FITACF: user_guide/make_fit.md


### PR DESCRIPTION
# Scope
Addressing issue #296 this documentation focuses on how to cite data and access it. Similar to pyDARN's and on our SuperDARN Canada website which is something Kathryn has okay for now until the PI's come up with one. 

## What changed? 
README now has a blurb on it (link on citing doesn't work but will when pushed to master).
Citing page on readthedocs and Data Access to read the docs.

## Help 

I added an acknowledgment section on citing for algorithms and libraries we use, something I did with pyDARN. 
We can remove if we don't want it or you can fill in the citations for the few I put in plus any others I left out. 

## Read The Docs Link 
https://radar-software-toolkit-rst.readthedocs.io/en/docs-citing_data/