### PR TITLE
Fixing bug in IDL DLM code when acfd array is missing

### DIFF
--- a/codebase/superdarn/src.lib/tk/idl/rawidl.1.5/src/rawidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/rawidl.1.5/src/rawidl.c
@@ -70,12 +70,14 @@ void IDLCopyRawDataToIDL(int nrang,int mplgs, int xcf,struct RawData *raw,
 
   for (n=0;n<nrang;n++) {
     iraw->pwr0[n]=raw->pwr0[n];
-    for (x=0;x<mplgs;x++) {
-      iraw->acfd[x*MAX_RANGE+n]=raw->acfd[0][n*mplgs+x];
-      iraw->acfd[LAG_SIZE*MAX_RANGE+MAX_RANGE*x+n]=raw->acfd[1][n*mplgs+x];
-      if ((xcf !=0) && (raw->xcfd !=NULL)) {
-        iraw->xcfd[x*MAX_RANGE+n]=raw->xcfd[0][n*mplgs+x];
-        iraw->xcfd[LAG_SIZE*MAX_RANGE+MAX_RANGE*x+n]=raw->xcfd[1][n*mplgs+x];
+    if (raw->acfd[0] !=NULL) {
+      for (x=0;x<mplgs;x++) {
+        iraw->acfd[x*MAX_RANGE+n]=raw->acfd[0][n*mplgs+x];
+        iraw->acfd[LAG_SIZE*MAX_RANGE+MAX_RANGE*x+n]=raw->acfd[1][n*mplgs+x];
+        if ((xcf !=0) && (raw->xcfd !=NULL)) {
+          iraw->xcfd[x*MAX_RANGE+n]=raw->xcfd[0][n*mplgs+x];
+          iraw->xcfd[LAG_SIZE*MAX_RANGE+MAX_RANGE*x+n]=raw->xcfd[1][n*mplgs+x];
+        }
       }
     }
   }


### PR DESCRIPTION
This pull request addresses the segmentation fault identified by @ecbland in #344 when using the IDL DLM code to read a RAWACF file with a missing acfd array (similar to #291).  One can test this fix by following the example provided by @ecbland in #344.

Note that this pull request does not address the subsequently identified issue with incorrect lag table array sizes present in certain RAWACF files, which appears to cause an error in the native IDL code.