### PR TITLE
Modifying time_plot to more accurately plot range-time cells for SND-format data

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/snd.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/snd.c
@@ -100,6 +100,8 @@ void snd_tplot(struct SndData *snd,struct tplot *tptr) {
     tptr->p_l[i]=snd->rng[i].p_l;
     tptr->w_l[i]=snd->rng[i].w_l;
     tptr->v_e[i]=snd->rng[i].v;
+    if (snd->rng[i].x_qflg == 1) tptr->phi0[i]=snd->rng[i].phi0;
+    else tptr->phi0[i]=-4;
   }
 
 }

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -1365,6 +1365,8 @@ int main(int argc,char *argv[]) {
 
     if ((atime-otime)>120) otime=atime-120;
 
+    if ((sndflg) && (atime-otime)>2) otime=atime-2;
+
     lft=bwdt*(otime-stime)/(etime-stime);
     rgt=bwdt*(atime-stime)/(etime-stime);
     if (rgt==lft) rgt++;

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -1365,7 +1365,9 @@ int main(int argc,char *argv[]) {
 
     if ((atime-otime)>120) otime=atime-120;
 
-    if ((sndflg) && (atime-otime)>2) otime=atime-2;
+    /* SND-format data collected at the end of a scan typically has
+     * an integration time of only ~1.5 to 2.0 seconds */
+    if ((sndflg) && (atime-otime)>4) otime=atime-2;
 
     lft=bwdt*(otime-stime)/(etime-stime);
     rgt=bwdt*(atime-stime)/(etime-stime);


### PR DESCRIPTION
As the title implies, this pull request addresses the issue mentioned by @ecbland in #327 where `time_plot` did not correctly draw the range-time cells for SND-format data.  This is because for most radars, the sounding data are collected for only a few seconds at the end of each scan, rather than with the regular cadence of normal scan data.

For example, on the current develop branch `time_plot -snd` will produce something like this (using only ~15 minutes of real frequency sounding data from today's experiment):

![cve snd old](https://user-images.githubusercontent.com/1869073/95802772-63134100-0ccc-11eb-85ed-a01f5c267f66.png)

while on this branch, the same `time_plot` command will produce this:

![cve snd new](https://user-images.githubusercontent.com/1869073/95802796-6dcdd600-0ccc-11eb-9123-0d9ae95aabcd.png)
