### PR TITLE
feature/rtsnd

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/doc/rtsnd.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/doc/rtsnd.doc.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<binary>
+<project>superdarn</project>
+<name>rtsnd</name>
+<location>src.bin/tk/tool/rtsnd</location>
+
+<syntax>rtcsnd --help</syntax>
+<syntax>rtsnd [-L <ar>logname</ar>] [-p <ar>pathname</ar>] [-if <ar>pidname</ar>] <ar>host</ar> <ar>port</ar></syntax>
+<syntax>rtsnd -rpf [-L <ar>logname</ar>] [-p <ar>pathname</ar>] [-if <ar>pidname</ar>] <ar>host</ar> <ar>portname</ar></syntax>
+
+<option><on>--help</on><od>print the help message and exit.</od>
+</option>
+<option><on>--version</on><od>print the RST version number and exit.</od>
+</option>
+<option><on>-noscan</on><od>ignore scan flag and process all data (usually sounding mode data is indicated by a scan flag of -2).</od>
+</option>
+<option><on>-cn <ar>channel</ar></on><od>process data from a specific channel number for stereo mode data.</od>
+</option>
+<option><on>-L <ar>logname</ar></on><od>log connections and information in the file <ar>logname</ar>. By default, connections are recorded in <code>snd.rt.log</code>.</od>
+</option>
+<option><on>-p <ar>pathname</ar></on><od>store the 2-hour files in the directory <ar>pathname</ar>.</od>
+</option>
+<option><on>-if <ar>pidname</ar></on><od>record the process Identifier (PID) of the server in the file <ar>pidname</ar>. By default, the PID is recorded in <code>snd.rt.pid</code>.</od>
+</option>
+<option><on><ar>host</ar></on><od>hostname or IP number of the system to connect to.</od>
+</option>
+<option><on><ar>rport</ar></on><od>port number to connect to on the server.</od>
+</option>
+<option><on>-rpf</on><od>The remote port number is stored in a text file.</od>
+</option>
+<option><on><ar>rportname</ar></on><od>filename of the text file containing the remote port number.</od>
+</option>
+<synopsis><p>Creates 2-hour <code>snd</code> format files from a <code>fitacf</code> TCP/IP data stream.</p></synopsis>
+<description><p>Creates 2-hour <code>snd</code> format files from a <code>fitacf</code> TCP/IP data stream.</p>
+<p>The data is written to a file called "<code><em>yyyymmdd.hh.iii</em>.snd</code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, <em>dd</em> is the day, <em>hh</em> is the hour, and <em>iii</em> is the radar identifier code.</p>
+</description>
+
+<example>
+<command>make_snd -L log -if pid.id kapqnx.jhuapl.edu 1024</command>
+<description>Generates <code>snd</code> files from the host "<code>kapqnx.jhuapl.edu</code>", served at port 1024. The process identifier is recorded in the file "<code>pid.id</code>", and logs of all transactions are recorded in the file "<code>log.<em>yyyymmdd</em></code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, and <em>dd</em> is the day.</description>
+</example>
+
+<example>
+<command>make_snd -L log -if pid.id -rpf port.kap kapqnx.jhuapl.edu</command>
+<description>Generates <code>snd</code> files from the host "<code>kapqnx.jhuapl.edu</code>", served at port contained in the file "<code>port.kap</code>". The process identifier is recorded in the file "<code>pid.id</code>", and logs of all transactions are recorded in the file "<code>log.<em>yyyymmdd</em></code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, and <em>dd</em> is the day.</description>
+</example>
+
+</binary>

--- a/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/doc/rtsnd.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/doc/rtsnd.doc.xml
@@ -4,7 +4,7 @@
 <name>rtsnd</name>
 <location>src.bin/tk/tool/rtsnd</location>
 
-<syntax>rtcsnd --help</syntax>
+<syntax>rtsnd --help</syntax>
 <syntax>rtsnd [-L <ar>logname</ar>] [-p <ar>pathname</ar>] [-if <ar>pidname</ar>] <ar>host</ar> <ar>port</ar></syntax>
 <syntax>rtsnd -rpf [-L <ar>logname</ar>] [-p <ar>pathname</ar>] [-if <ar>pidname</ar>] <ar>host</ar> <ar>portname</ar></syntax>
 

--- a/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/loginfo.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/loginfo.c
@@ -1,0 +1,70 @@
+/* loginfo.c
+   =========
+   Author: R.J.Barnes
+*/
+
+/*
+ LICENSE AND DISCLAIMER
+ 
+ Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+ 
+ This file is part of the Radar Software Toolkit (RST).
+ 
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ any later version.
+ 
+ RST is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with RST.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ 
+ 
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+
+
+int dotflag=0;
+
+void loginfo(char *fname,char *str) {
+  FILE *fp;
+  char *date;
+  char logpath[256];
+  time_t ltime;
+  struct tm *time_of_day;
+
+  time(&ltime);
+  time_of_day=localtime(&ltime);
+
+  date=asctime(time_of_day);
+
+  date[strlen(date)-1]=':';
+
+  if (dotflag==1) fprintf(stderr,"\n");
+  fprintf(stderr,"%s",date);
+  fprintf(stderr,"%s",str);
+  fprintf(stderr,"\n");
+  dotflag=0;
+  sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
+          time_of_day->tm_year,time_of_day->tm_mon+1,
+          time_of_day->tm_mday);
+  fp=fopen(logpath,"a");
+  if (fp==NULL) {
+    fprintf(stderr,"WARNING:Log failed.\n");
+    return;
+  }
+  fprintf(fp,"%s",date);
+  fprintf(fp,"%s",str);
+  fprintf(fp,"\n");
+  fclose(fp);
+}

--- a/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/loginfo.h
+++ b/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/loginfo.h
@@ -1,0 +1,7 @@
+/* loginfo.h
+   =========
+   Author: R.J.Barnes
+*/
+
+void loginfo(char *fname,char *str);
+

--- a/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/makefile
+++ b/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/makefile
@@ -1,0 +1,18 @@
+# Makefile for rtsnd
+# ==================
+# Author: E.G.Thomas
+# by E.G.Thomas
+#
+#
+include $(MAKECFG).$(SYSTEM)
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn \
+        -DPOSIX -D__EXTENSIONS__
+
+OBJS=loginfo.o rtsnd.o
+SRC=hlpstr.h errstr.h rtsnd.c loginfo.c loginfo.h
+LIBS=-lfitcnx.1 -lcnx.1 -lsnd.1 -lfit.1 -lrscan.1 -lradar.1 -ldmap.1 -lrtime.1 -lopt.1 -lrcnv.1  
+SLIB=-lm -lz
+DSTPATH = $(BINPATH)
+OUTPUT = rtsnd
+
+include $(MAKEBIN).$(SYSTEM)

--- a/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/rtsnd.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/rtsnd.c
@@ -373,16 +373,16 @@ int main(int argc,char *argv[]) {
                   path,yr,mo,dy,(hr/2)*2,RadarGetCode(network,snd->stid,0));
         }
 
-        fp=fopen(dname,"a");
-        SndFwrite(fp,snd);
-        fclose(fp);
-
         if ((now-hstart) >= 2*3600) { /* advance to the next 2-hour block */
           hstart=now-(int) now % (2*3600); /* start of 2-hour block */
           TimeEpochToYMDHMS(hstart,&yr,&mo,&dy,&hr,&mt,&sc);
           sprintf(dname,"%s/%.4d%.2d%.2d.%.2d.%s.snd",
                   path,yr,mo,dy,(hr/2)*2,RadarGetCode(network,snd->stid,0));
         }
+
+        fp=fopen(dname,"a");
+        SndFwrite(fp,snd);
+        fclose(fp);
 
         cnt++;
 

--- a/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/rtsnd.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/rtsnd.c
@@ -1,0 +1,400 @@
+/* rtsnd.c
+   =======
+   Author: E.G.Thomas
+*/
+
+/*
+ LICENSE AND DISCLAIMER
+ 
+ Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+ 
+ This file is part of the Radar Software Toolkit (RST).
+ 
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ any later version.
+ 
+ RST is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with RST.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ 
+ 
+*/
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <netinet/in.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <time.h>
+#include <string.h>
+#include <zlib.h>
+#include "rtypes.h"
+#include "option.h"
+#include "rtime.h"
+#include "radar.h" 
+#include "rmath.h"
+
+#include "dmap.h"
+#include "rprm.h"
+#include "fitdata.h"
+#include "snddata.h"
+
+#include "fitsnd.h"
+#include "sndread.h"
+#include "sndwrite.h"
+
+#include "connex.h"
+#include "fitcnx.h"
+
+#include "loginfo.h"
+
+#include "errstr.h"
+#include "hlpstr.h"
+
+int resetflg;
+
+
+#define PATH "."
+#define PIDFILE "snd.rt.pid"
+#define FNAME "rt.snd"
+#define LOGNAME "snd.rt.log"
+
+extern int dotflag;
+char logfname[256]={LOGNAME};
+
+struct OptionData opt;
+
+struct RadarParm *prm;
+struct FitData *fit;
+struct SndData *snd;
+
+struct RadarNetwork *network;
+struct Radar *radar;
+struct RadarSite *site;
+
+
+void trapsignal(int signal) {
+  resetflg=2;
+}
+
+
+double strtime(char *text) {
+  int hr,mn;
+  int i;
+  for (i=0;(text[i] !=':') && (text[i] !=0);i++);
+  if (text[i]==0) return atoi(text)*3600L;
+  text[i]=0;
+  hr=atoi(text);
+  mn=atoi(text+i+1);
+  return hr*3600L+mn*60L;
+}
+
+
+int rst_opterr(char *txt) {
+  fprintf(stderr,"Option not recognized: %s\n",txt);
+  fprintf(stderr,"Please try: rtsnd --help\n");
+  return(-1);
+}
+
+
+int main(int argc,char *argv[]) {
+
+  int arg;
+  unsigned char help=0;
+  unsigned char option=0;
+  unsigned char version=0;
+
+  unsigned char noscan=0;
+  char *chnstr=NULL;
+
+  char *logstr=NULL;
+  char *fnamestr=NULL;
+  char *pathstr=NULL;
+  char *pidstr=NULL;
+
+  char *envstr;
+
+  int sock;
+
+  int remote_port=0;
+  char dname[256];
+  char logbuf[256];
+
+  pid_t pid;
+  FILE *fp;
+  char host[256];
+  int flag,status;
+
+  sigset_t set;
+  struct sigaction act;
+
+  struct timeval tv;
+  int reset=60;
+  int cnt=0;
+
+  int channel=-1;
+
+  char path[256]={PATH};
+  char pidfile[256]={PIDFILE};
+  char fname[256]={FNAME};
+  char tmpname[256];
+  char *port_fname=NULL;
+  unsigned char port_flag=0;
+  double now=-1;
+  double hstart=0;
+
+  int yr,mo,dy,hr,mt;
+  double sc;
+
+  float offset;
+  time_t ctime;
+  int c,n;
+  char command[128];
+  char tmstr[40]; 
+
+  prm=RadarParmMake();
+  fit=FitMake();
+  snd=SndMake();
+
+  pid=getpid();
+
+  envstr=getenv("SD_RADAR");
+  if (envstr==NULL) {
+    fprintf(stderr,"Environment variable 'SD_RADAR' must be defined.\n");
+    exit(-1);
+  }
+
+  fp=fopen(envstr,"r");
+
+  if (fp==NULL) {
+    fprintf(stderr,"Could not locate radar information file.\n");
+    exit(-1);
+  }
+
+  network=RadarLoad(fp);
+  fclose(fp);
+  if (network==NULL) {
+    fprintf(stderr,"Failed to read radar information.\n");
+    exit(-1);
+  }
+
+  envstr=getenv("SD_HDWPATH");
+  if (envstr==NULL) {
+    fprintf(stderr,"Environment variable 'SD_HDWPATH' must be defined.\n");
+    exit(-1);
+  }
+
+  RadarLoadHardware(envstr,network);
+  OptionAdd(&opt,"-help",'x',&help);
+  OptionAdd(&opt,"-option",'x',&option);
+  OptionAdd(&opt,"-version",'x',&version);
+
+  OptionAdd(&opt,"noscan",'x',&noscan);
+  OptionAdd(&opt,"cn",'t',&chnstr);
+
+  OptionAdd(&opt,"rpf",'x',&port_flag);
+  OptionAdd(&opt,"L",'t',&logstr);
+  OptionAdd(&opt,"f",'t',&fnamestr);
+  OptionAdd(&opt,"p",'t',&pathstr);
+  OptionAdd(&opt,"if",'t',&pidstr);
+
+  arg=OptionProcess(1,argc,argv,&opt,rst_opterr);
+
+  if (arg==-1) {
+    exit(-1);
+  }
+
+  if (help==1) {
+    OptionPrintInfo(stdout,hlpstr);
+    exit(0);
+  }
+
+  if (option==1) {
+    OptionDump(stdout,&opt);
+    exit(0);
+  }
+
+  if (version==1) {
+    OptionVersion(stdout);
+    exit(0);
+  }
+
+  if (argc-arg<2) {
+    OptionPrintInfo(stderr,errstr);
+    exit(-1);
+  }
+
+  if (chnstr !=NULL) {
+    if (tolower(chnstr[0])=='a') channel=1;
+    if (tolower(chnstr[0])=='b') channel=2;
+  }
+
+  if (logstr !=NULL) strcpy(logfname,logstr);
+  if (pathstr !=NULL) strcpy(path,pathstr);
+  if (pidstr !=NULL) strcpy(pidfile,pidstr);
+
+  strcpy(host,argv[argc-2]);
+  if (port_flag==0) remote_port=atoi(argv[argc-1]);
+  else port_fname=argv[argc-1];
+
+  strcpy(tmpname,fname);
+  strcat(tmpname,"~");
+
+  if (port_flag==0) sprintf(logbuf,"Host:%s %d",host,remote_port);
+  else sprintf(logbuf,"Host:%s Port File:%s",host,port_fname);
+  loginfo(logfname,logbuf);
+
+  sprintf(logbuf,"File path:%s",path);
+  loginfo(logfname,logbuf);
+  sprintf(logbuf,"pid file:%s",pidfile);
+  loginfo(logfname,logbuf);
+  sprintf(logbuf,"pid:%d",(int) pid);
+  loginfo(logfname,logbuf);
+
+  fp=fopen(pidfile,"w");
+  fprintf(fp,"%d\n",pid);
+  fclose(fp);
+  sigemptyset(&set);
+  sigaddset(&set,SIGUSR1);
+
+  act.sa_flags=0;
+  act.sa_mask=set;
+  act.sa_handler=trapsignal;
+  sigaction(SIGUSR1,&act,NULL);
+
+  now=0;
+
+  command[0]=0;
+  n=0;
+  for (c=0;c<argc;c++) {
+    n+=strlen(argv[c])+1;
+    if (n>127) break;
+    if (c !=0) strcat(command," ");
+    strcat(command,argv[c]);
+  }
+
+  do {
+    resetflg=0;
+
+    if (port_flag==1) {
+      fp=fopen(port_fname,"r");
+      if (fp !=NULL) {
+        if (fscanf(fp,"%d",&remote_port) !=1) {
+          fclose(fp);
+          exit(-1);
+        }
+        fclose(fp);
+      } else remote_port=1024;
+    }
+
+    sprintf(logbuf,"Connecting to host:%s %d",host,remote_port);
+
+    loginfo(logfname,logbuf);
+
+    sock=ConnexOpen(host,remote_port,NULL);
+    if (sock<0) {
+      loginfo(logfname,"Could not connect to host - retrying.");
+      sleep(10);
+      continue;
+    }
+
+    resetflg=0;
+    do {
+
+      tv.tv_sec=reset;
+
+      status=FitCnxRead(1,&sock,prm,fit,&flag,&tv);
+
+      if ((status==-1) || (flag==-1) || (resetflg !=0)) break;
+      if (status==0) resetflg=1;
+
+      if ((status==1) && (flag==1)) {
+
+        /* Look for scan flag of -2 for sounding data (unless -noscan is set) */
+        if ((!noscan) && (prm->scan != -2)) continue;
+
+        if (channel !=-1) {
+          if ((channel==1) && (prm->channel==2)) continue;
+          if ((channel==2) && (prm->channel!=2)) continue;
+        }
+
+        fprintf(stderr,".");
+        fflush(stderr);
+        dotflag=1;
+
+        if (site==NULL) {
+          radar=RadarGetRadar(network,prm->stid);
+          if (radar==NULL) {
+            fprintf(stderr,"Failed to get radar information.\n");
+            exit(-1);
+          }
+          site=RadarYMDHMSGetSite(radar,prm->time.yr,prm->time.mo,prm->time.dy,
+                                  prm->time.hr,prm->time.mt,(int) prm->time.sc);
+        }
+
+        /* calculate beam azimuth */
+        if (prm->bmazm == 0) {
+          offset = site->maxbeam/2.0 - 0.5;
+          prm->bmazm = site->boresite + site->bmsep*(prm->bmnum-offset);
+        }
+
+        snd->origin.code=1;
+        ctime = time((time_t) 0);
+        strcpy(tmstr,asctime(gmtime(&ctime)));
+        tmstr[24]=0;
+        SndSetOriginTime(snd,tmstr);
+        SndSetOriginCommand(snd,command);
+
+        FitToSnd(snd,prm,fit,prm->scan);
+
+        now=TimeYMDHMSToEpoch(snd->time.yr,snd->time.mo,snd->time.dy,
+                              snd->time.hr,snd->time.mt,
+                              snd->time.sc+snd->time.us/1.0e6);
+
+        if (hstart==0) {
+          hstart=now-(int) now % (2*3600); /* start of 2-hour block */
+          TimeEpochToYMDHMS(hstart,&yr,&mo,&dy,&hr,&mt,&sc);
+          sprintf(dname,"%s/%.4d%.2d%.2d.%.2d.%s.snd",
+                  path,yr,mo,dy,(hr/2)*2,RadarGetCode(network,snd->stid,0));
+        }
+
+        fp=fopen(dname,"a");
+        SndFwrite(fp,snd);
+        fclose(fp);
+
+        if ((now-hstart) >= 2*3600) { /* advance to the next 2-hour block */
+          hstart=now-(int) now % (2*3600); /* start of 2-hour block */
+          TimeEpochToYMDHMS(hstart,&yr,&mo,&dy,&hr,&mt,&sc);
+          sprintf(dname,"%s/%.4d%.2d%.2d.%.2d.%s.snd",
+                  path,yr,mo,dy,(hr/2)*2,RadarGetCode(network,snd->stid,0));
+        }
+
+        cnt++;
+
+      } 
+
+    } while (1);
+
+    if (resetflg==0) loginfo(logfname,"Connection failed.");
+    if (resetflg==1) loginfo(logfname,"Connection timed out.");
+    if (resetflg==2) loginfo(logfname,"Connection reset by signal.");
+    ConnexClose(sock);
+  } while(1);
+
+  return 0;
+}


### PR DESCRIPTION
This pull request is the last of the new `snd` libraries and binaries, and allows the user to collect frequency sounding data in real-time from an ROS-style radar operating one of the new [normalsound or interleavesound](https://github.com/SuperDARN/control_programs/tree/interleavesound/qnx4) control programs.  To test, you can use something like

`rtsnd [host] [port]`

where `[host]` and `[port]` are the address and port number of the server providing real-time radar data, respectively.  The output `snd` file will have the naming structure `YYYYMMDD.hh.rad.snd`, where new files are produced every 2 hours.  If you are working with data from a Stereo radar, the `-cn` option can be used to specify the channel number operating the frequency sounding mode.

Because not many radars are currently running a frequency sounding mode (at least after today's Special Time experiment ends), the `-noscan` option can be used to produce a `snd`-format file from a standard real-time stream of `FITACF`-level data for testing purposes by ignoring the scan flag (typically real-time frequency sounding data is indicated by a scan flag of -2).  And if you don't have access to a real-time data stream, you should be able to use `fitacfserver` to serve one of your own `FITACF`-format files on a local port to replicate a real-time stream (eg #273):

```
fitacfserver -r YYYYMMDD.hhmm.ss.rad.fitacf
rtsnd localhost [port number from port.id file]
```