### PR TITLE
Fix sim_* compilation on Catalina

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/makefile
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/makefile
@@ -13,6 +13,6 @@ DSTPATH = $(BINPATH)
 OUTPUT = make_sim
 LIBS=-lsim_data.1 -loldraw.1 -loldfit.1 -lcfit.1 -lrscan.1 -lradar.1 -lfitacf.1 -lraw.1 -lfit.1 -ldmap.1 -lopt.1 -lrtime.1 -lrcnv.1 -lrmath.1 -liqdata.1
 SLIB=-lm -lz
- 
+CFLAGS=-Wno-gnu-anonymous-struct 
 
 include $(MAKEBIN).$(SYSTEM)

--- a/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/makefile
+++ b/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/makefile
@@ -13,6 +13,6 @@ DSTPATH = $(BINPATH)
 OUTPUT = sim_real
 LIBS=-lsim_data.1 -lradar.1 -lfitacf.1 -lraw.1 -lfit.1 -ldmap.1 -lrtime.1 -lrcnv.1 -lrmath.1 -liqdata.1
 SLIB=-lm -lz
- 
+CFLAGS=-Wno-gnu-anonymous-struct 
 
 include $(MAKEBIN).$(SYSTEM)

--- a/codebase/superdarn/src.lib/tk/sim_data.1.0/src/makefile
+++ b/codebase/superdarn/src.lib/tk/sim_data.1.0/src/makefile
@@ -12,7 +12,7 @@ INC=$(IPATH)/superdarn
 DSTPATH=$(LIBPATH)
 OUTPUT=sim_data
 LINK="1"
-
+CFLAGS=-Wno-gnu-anonymous-struct
 
 
 include $(MAKELIB).$(SYSTEM)


### PR DESCRIPTION
This PR implements @asreimer's proposed "bandaid" solution to the compilation issue on MacOS/Catalina (#350):

> You might be able to add `-Wno-gnu-anonymous-struct` to the makefile for the `sim_*` code as a bandaid work around. (https://github.com/SuperDARN/rst/issues/350#issuecomment-709560674)

I'm not able to test this myself, but I'm hoping that @mtwalach can try it 😄

If someone wants to offer a better solution to #350 before we make the release branch, then please go ahead.