### PR TITLE
Fixing bug in field_plot preventing Antarctica coast lines from being drawn

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
@@ -1737,10 +1737,10 @@ int main(int argc,char *argv[]) {
       if (mapflg) {
         MapPlotPolygon(plot,NULL,xbox+pad,ybox+pad,wbox-2*pad,hbox-2*pad,0,cstcol,0x0f,
                        0.5,NULL,rmap,1);
+        MapPlotOpenPolygon(plot,NULL,xbox+pad,ybox+pad,wbox-2*pad,hbox-2*pad,cstcol,0x0f,
+                           0.5,NULL,rmap,2);
         MapPlotPolygon(plot,NULL,xbox+pad,ybox+pad,wbox-2*pad,hbox-2*pad,0,cstcol,0x0f,
                        0.5,NULL,rmap,0);
-        MapPlotOpenPolygon(plot,NULL,0,0,wbox,hbox,cstcol,0x0f,
-                           0.5,NULL,pmap,2);
       }
 
       if (bndflg) MapPlotOpenPolygon(plot,NULL,xbox+pad,ybox+pad,wbox-2*pad,hbox-2*pad,


### PR DESCRIPTION
This pull request addresses issue #353 where the coast lines for Antarctica were not being drawn by `field_plot` when using the `-coast` option.  On the current `develop` branch, you'll see something like this for stereographic (default) and orthographic coordinates:

![mcm_dev_stereo](https://user-images.githubusercontent.com/1869073/98130926-cbe37880-1e88-11eb-9bd9-b431950f5bfd.png)
![mcm_dev_ortho](https://user-images.githubusercontent.com/1869073/98130924-cbe37880-1e88-11eb-885e-d914c7cbadeb.png)

while plotting the same data using this branch should now correctly draw the Antarctica coast lines with the `-coast` option:

![mcm_fix_stereo](https://user-images.githubusercontent.com/1869073/98130930-cbe37880-1e88-11eb-9fdf-d7df83c73a7b.png)
![mcm_fix_ortho](https://user-images.githubusercontent.com/1869073/98130929-cbe37880-1e88-11eb-9659-4ba3ead5f30c.png)
