### PR TITLE
Fix double free error in lmfit

### DIFF
--- a/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
+++ b/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
@@ -249,9 +249,9 @@ int singlefit(int m, int n, double *p, double *deviates,
 		else
 			deviates[i] = re-lag0mag*exp(-1.*tau/ti)*sin(wi*tau);
   }
-  free(ey);
-  free(x);
-  free(y);
+  //free(ey);
+  //free(x);
+  //free(y);
   return 0;
 }
 

--- a/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
+++ b/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
@@ -229,17 +229,13 @@ int singlefit(int m, int n, double *p, double *deviates,
 
   struct datapoints *v = (struct datapoints *) private;
   double lag0mag = v->mag;
-  double *x, *y, *ey;
+  double *x, *y;
   x = v->x;
   y = v->y;
-  //TODO:  without sig this is also not used
-  ey = v->ey;
   for (i=0; i<m; i++)
   {
     tau=x[i];
     re=y[i];
-    // TODO: this is not used can I remove it? 
-    //sig=ey[i];
     ti=p[0];
     wi=p[1];
     lag0mag = p[2];

--- a/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
+++ b/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
@@ -249,9 +249,6 @@ int singlefit(int m, int n, double *p, double *deviates,
 		else
 			deviates[i] = re-lag0mag*exp(-1.*tau/ti)*sin(wi*tau);
   }
-  //free(ey);
-  //free(x);
-  //free(y);
   return 0;
 }
 


### PR DESCRIPTION
Looks like I didn't catch this one while testing #337 
It's the same double free error that @mts299 and I fixed earlier with `make_fit -old`(#340)

On `develop` we get a core dump:
```
make_lmfit [rawfile] > /dev/null
free(): double free detected in tcache 2
Aborted (core dumped)
```

There should be no error on this branch.

Note that you may not get the error with newer versions of gcc. I get the error with `gcc (Ubuntu 9.3.0-10ubuntu2) 9.3.0`