### PR TITLE
Adding missing chisham keyword to RadarFldPnth in native IDL RadarPos function

### DIFF
--- a/codebase/superdarn/src.idl/lib/main.1.25/radar.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/radar.pro
@@ -892,7 +892,7 @@ function RadarPos,center,bcrd,rcrd,site,frang,rsep,rxrise,$
 
     if (height lt 90) then $
       height=-re+sqrt((re*re)+2*d*re*sin(!PI*height/180.0)+(d*d));
-    RadarFldPnth,site.geolat,site.geolon,psi,site.boresite,height,d,rho,lat,lng 
+    RadarFldPnth,site.geolat,site.geolon,psi,site.boresite,height,d,rho,lat,lng,chisham=chisham
   endelse
 
   return, 0


### PR DESCRIPTION
As the title says, this pull request adds a missing `chisham` keyword to the `RadarFldPnth` function call when using the native IDL version of `RadarPos` with only a single input range-beam pair (note that the `chisham` keyword is correctly passed when an array of range-beam locations are passed to `RadarPos`).  On the `develop` branch the standard virtual height model will always be used whether or not the `chisham` keyword is set, while on this branch the correct virtual height model will be selected.