### PR TITLE
Updated IDL constants

### DIFF
--- a/codebase/analysis/src.idl/lib/aacgm.2.0/aacgm.pro
+++ b/codebase/analysis/src.idl/lib/aacgm.2.0/aacgm.pro
@@ -183,7 +183,7 @@ end
 ;
 
 pro AACGMAltitudeToCGM, r_height_in, r_lat_alt, r_lat_adj
-   eradius=6371.2
+   eradius=float(!CONST.R_earth/1000)
    eps=1e-9
    unim=0.9999999;
 
@@ -215,7 +215,7 @@ end
 ;
 
 pro AACGMCGMToAltitude, r_height_in,r_lat_in,  r_lat_adj, error
-  eradius=6371.2
+  eradius=float(!CONST.R_earth/1000)
   unim=1
   error=0
   r1 = cos(!PI*r_lat_in/180.0);

--- a/codebase/analysis/src.idl/lib/igrf.1.0/igrflib_v2.pro
+++ b/codebase/analysis/src.idl/lib/igrf.1.0/igrflib_v2.pro
@@ -76,7 +76,7 @@ pro init_common, err=err
                   cl0:0.d, sl0:0.d}
 ; DTOR        = !const.pi/180.d
   DTOR        = !dpi/180.d
-  RE          = 6371.2d     ; magnetic reference spherical radius from IGRF
+  RE          = !CONST.R_earth/1000     ; magnetic reference spherical radius from IGRF
 ;  IGRF_FIRST_EPOCH = 1900  ; these get set in IGRF_loadcoeffs
 ;  IGRF_LAST_EPOCH  = 2015
 
@@ -1128,7 +1128,7 @@ end
 function geod2geoc, lat, lon, alt
   common IGRF_v2_Com
 
-  a = 6378.1370d;             /* semi-major axis */
+  a = !CONST.R_earth/1000;    /* semi-major axis */
   f = 1.d/298.257223563d;     /* flattening */
   b = a*(1.d -f);             /* semi-minor axis */
   a2 = a*a;
@@ -1396,7 +1396,7 @@ end
 function plh2xyz, lat, lon, alt
   common IGRF_v2_Com
 
-  a = 6378.1370d              ; semi-major axis
+  a = !CONST.R_earth/1000     ; semi-major axis
   f = 1.d/298.257223563d      ; flattening
   b = a*(1.d -f)              ; semi-minor axis
   ee = (2.d - f) * f
@@ -1450,7 +1450,7 @@ end
 function geoc2geod, lat,lon,r
   common IGRF_v2_Com
 
-  a = 6378.1370d              ; semi-major axis
+  a = !CONST.R_earth/1000     ; semi-major axis
   f = 1.d/298.257223563d      ; flattening
   b = a*(1.d -f)              ; semi-minor axis
   ee = (2.d - f) * f

--- a/codebase/analysis/src.idl/lib/igrf.1.0/igrflib_v2.pro
+++ b/codebase/analysis/src.idl/lib/igrf.1.0/igrflib_v2.pro
@@ -1128,7 +1128,7 @@ end
 function geod2geoc, lat, lon, alt
   common IGRF_v2_Com
 
-  a = !CONST.R_earth/1000;    /* semi-major axis */
+  a = 6378.1370d;             /* semi-major axis */
   f = 1.d/298.257223563d;     /* flattening */
   b = a*(1.d -f);             /* semi-minor axis */
   a2 = a*a;
@@ -1396,7 +1396,7 @@ end
 function plh2xyz, lat, lon, alt
   common IGRF_v2_Com
 
-  a = !CONST.R_earth/1000     ; semi-major axis
+  a = 6378.1370d;             /* semi-major axis */
   f = 1.d/298.257223563d      ; flattening
   b = a*(1.d -f)              ; semi-minor axis
   ee = (2.d - f) * f
@@ -1450,7 +1450,7 @@ end
 function geoc2geod, lat,lon,r
   common IGRF_v2_Com
 
-  a = !CONST.R_earth/1000     ; semi-major axis
+  a = 6378.1370d;             /* semi-major axis */
   f = 1.d/298.257223563d      ; flattening
   b = a*(1.d -f)              ; semi-minor axis
   ee = (2.d - f) * f

--- a/codebase/superdarn/src.idl/app/make_grid.1.0/gtable.pro
+++ b/codebase/superdarn/src.idl/app/make_grid.1.0/gtable.pro
@@ -415,7 +415,7 @@ function GridTableAddBeam, GridTable, RadarSite, alt, tval, RadarBeam, $
         return, -1
 
     ; Velocity correction as a function of radar geodetic latitude [m/s]
-    velco = (2*!pi/86400.0)*6356.779*1000*cos(RadarSite.geolat*!pi/180.0)
+    velco = (2*!pi/86400.0)*!CONST.R_earth*cos(RadarSite.geolat*!pi/180.0)
 
     ; Get current beam from the GridTable structure
     GridBm = (*GridTable).bm[(*GridTable).bnum]

--- a/codebase/superdarn/src.idl/lib/main.1.25/radar.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/radar.pro
@@ -445,7 +445,7 @@ end
 
 pro RadarGeoTGC,iopt,gdlat,gdlon,grho,glat,glon,del
 
-   a=6378.137D
+   a=!CONST.R_earth/1000
    f=1.0D/298.257223563D
   
 
@@ -797,7 +797,7 @@ function RadarPos,center,bcrd,rcrd,site,frang,rsep,rxrise,$
 
 
                 
-  re=6356.779D
+  re=!CONST.R_earth/1000
   bm_edge=0.0D;
   range_edge=0.0D
 
@@ -939,7 +939,7 @@ function RadarPosGS,center,bcrd,rcrd,site,frang,rsep,rxrise,$
 
 
                 
-  re=6356.779D
+  re=!CONST.R_earth/1000
   bm_edge=0.0D;
   range_edge=0.0D
 

--- a/codebase/superdarn/src.idl/lib/main.1.25/radar.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/radar.pro
@@ -445,7 +445,7 @@ end
 
 pro RadarGeoTGC,iopt,gdlat,gdlon,grho,glat,glon,del
 
-   a=!CONST.R_earth/1000
+   a = 6378.1370d;             /* semi-major axis */
    f=1.0D/298.257223563D
   
 


### PR DESCRIPTION
A relatively small PR, per issue #282, which makes the usages of Earths radius consistent throughout the IDL code. I've tried to preserve floats/doubles where applicable. I've left the legacy code unchanged, as it's uhhh, legacy.

If you find any others that I missed, let me know.