### PR TITLE
Fix/make grid

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/doc/make_grid.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/doc/make_grid.doc.xml
@@ -106,7 +106,7 @@
 </option>
 <option><on><ar>cfitfname</ar></on><od>filename of the <code>cfit</code> format file.</od>
 </option>
-<option><on>-c</on><od>concatenate multiple input files (from the same radar site). WARNING: This option will be deprecated in the next RST release.</od>
+<option><on>-c</on><od>concatenate multiple input files (from the same radar site). WARNING: This option will be deprecated in the next RST release. Multiple input files from one radar are now detected and concatenated automatically.</od>
 </option>
 <option><on><ar>fitnames</ar></on><od>filenames of the <code>fit</code> format files.</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/doc/make_grid.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/doc/make_grid.doc.xml
@@ -120,7 +120,7 @@
 <p>The algorithm optionally applies a median filter to the scan data to remove noise. Each range-beam cell together with its immediate neighbors in the current, preceding and following scans is examined. A weighted sum of all the cells containing scatter is calculated and if this sum exceeds a certain threshold, the median data value of the cells is substituted for the central cell. Various command line options control how the filter is applied.</p> 
 <p>Once the data has been filtered, the geo-magnetic location of each line of sight velocity measurement is calculated.  The vectors are then fixed to an equi-area grid to ensure that the data is not biased according to its location in the radar field of view.</p>
 <p>The vectors in each cell are averaged together over a fixed period of time to generate a data record, which is then written to standard output.</p>
-<p>The program operates in two modes. Note that only fit files from a single radar site may be concatenated with this second option; the "combine_grid" routine is still necessary for combining data from different radar sites into a single grid file.</p>
+<p>The program accepts multiple fit files as input. If more than one input file is provided, the program will concatenate them together for processing. Note that only fit files from a single radar site may be concatenated; the "combine_grid" routine is still necessary for combining data from different radar sites into a single grid file.</p>
 <p>In addition to the regular grid file output, the program can also produce "extended" grid files that contain information about the spectral width, power and composition of each data point by specifying the "<code>-xtd</code>" command line option.</p>
 </description>
 

--- a/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/doc/make_grid.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/doc/make_grid.doc.xml
@@ -9,10 +9,10 @@
 <syntax>make_grid -old  [<ar>options</ar>] <ar>fitname</ar> [<ar>inxname</ar>]</syntax>
 <syntax>make_grid -cfit [<ar>options</ar>] <ar>cfitname</ar></syntax>
 <syntax>make_grid -cfit -old [<ar>options</ar>] <ar>cfitname</ar></syntax>
-<syntax>make_grid -c [<ar>options</ar>] <ar>fitacfnames...</ar></syntax>
-<syntax>make_grid -c -old [<ar>options</ar>] <ar>fitnames...</ar></syntax>
-<syntax>make_grid -c -cfit [<ar>options</ar>] <ar>cfitnames...</ar></syntax>
-<syntax>make_grid -c -cfit -old [<ar>options</ar>] <ar>cfitnames...</ar></syntax>
+<syntax>make_grid [<ar>options</ar>] <ar>fitacfnames...</ar></syntax>
+<syntax>make_grid  -old [<ar>options</ar>] <ar>fitnames...</ar></syntax>
+<syntax>make_grid  -cfit [<ar>options</ar>] <ar>cfitnames...</ar></syntax>
+<syntax>make_grid  -cfit -old [<ar>options</ar>] <ar>cfitnames...</ar></syntax>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
@@ -106,7 +106,7 @@
 </option>
 <option><on><ar>cfitfname</ar></on><od>filename of the <code>cfit</code> format file.</od>
 </option>
-<option><on>-c</on><od>concatenate multiple input files (from the same radar site).</od>
+<option><on>-c</on><od>concatenate multiple input files (from the same radar site). WARNING: This option will be deprecated in the next RST release.</od>
 </option>
 <option><on><ar>fitnames</ar></on><od>filenames of the <code>fit</code> format files.</od>
 </option>
@@ -120,7 +120,7 @@
 <p>The algorithm optionally applies a median filter to the scan data to remove noise. Each range-beam cell together with its immediate neighbors in the current, preceding and following scans is examined. A weighted sum of all the cells containing scatter is calculated and if this sum exceeds a certain threshold, the median data value of the cells is substituted for the central cell. Various command line options control how the filter is applied.</p> 
 <p>Once the data has been filtered, the geo-magnetic location of each line of sight velocity measurement is calculated.  The vectors are then fixed to an equi-area grid to ensure that the data is not biased according to its location in the radar field of view.</p>
 <p>The vectors in each cell are averaged together over a fixed period of time to generate a data record, which is then written to standard output.</p>
-<p>The program operates in two modes. The first operates on a single fit file. The second, specified by the "<code>-c</code>" option will concatenate multiple fit files together for processing. Note that only fit files from a single radar site may be concatenated with this second option; the "combine_grid" routine is still necessary for combining data from different radar sites into a single grid file.</p>
+<p>The program operates in two modes. Note that only fit files from a single radar site may be concatenated with this second option; the "combine_grid" routine is still necessary for combining data from different radar sites into a single grid file.</p>
 <p>In addition to the regular grid file output, the program can also produce "extended" grid files that contain information about the spectral width, power and composition of each data point by specifying the "<code>-xtd</code>" command line option.</p>
 </description>
 
@@ -130,7 +130,7 @@
 </example>
 
 <example>
-<command>make_grid -c -i 240 -old 20000510.*.kod.fit &gt; 20000510.kod.grd</command>
+<command>make_grid -i 240 -old 20000510.*.kod.fit &gt; 20000510.kod.grd</command>
 <description>Concatenate all the fit files in the current directory to create a grid file with a 4-minute record length. Store the output in the file "<code>20000510.kod.grd</code>".</description>
 </example>
 

--- a/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/make_grid.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/make_grid.c
@@ -8,7 +8,7 @@
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
  Modifications:
- 2021-01-11 Marina Schmidt fixing concatenation bug with start time
+ 2021-01-11 Marina Schmidt fixing concatenation bug with start/end time, and deprecated -c flag
 
  This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/make_grid.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/make_grid.c
@@ -584,7 +584,7 @@ int main(int argc,char *argv[]) {
 
                 /* Verify that the fit file was properly opened */
                 if (oldfitfp==NULL) {
-                    fprintf(stderr,"File not found. Error: %s\n", strerror(errno));
+                    fprintf(stderr,"Error: %s\n", strerror(errno));
                     continue;
                 }
 
@@ -604,7 +604,7 @@ int main(int argc,char *argv[]) {
 
                 /* Verify that the fitacf file was properly opened */
                 if (fitfp==NULL) {
-                    fprintf(stderr,"File not found. Error: %s\n", strerror(errno));
+                    fprintf(stderr,"Error: %s\n", strerror(errno));
                     continue;
                 }
                 /* Read first available radar scan in fitacf file (will use scan

--- a/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/make_grid.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/make_grid.c
@@ -677,7 +677,7 @@ int main(int argc,char *argv[]) {
                 else s=FitFseek(fitfp,yr,mo,dy,hr,mt,sc,NULL,inx);
                 /* If a matching record could not be found then exit*/ 
                 if (s ==-1) {
-                    fprintf(stderr,"File does not contain the requested start time, ignoring this file.\n");
+                    fprintf(stderr,"File ends before requested start time, ignoring this file.\n");
                     stime = tmp_stime;
                     continue;
                 }

--- a/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/make_grid.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/make_grid.c
@@ -744,25 +744,29 @@ int main(int argc,char *argv[]) {
             }
         }
         /* If end time provided then determine end date */
-        if (etime !=-1) {
+        if (found_record == 1){
+            if (etime !=-1){
 
             /* If end date not provided then use date of first record
              * in input file */
             if (edate==-1) etime+=src[0]->st_time -
                             ( (int) src[0]->st_time % (24*3600));
             else etime+=edate;
+            }
+            
+            /* If time extent provided then use that to calculate end time */
+            if (extime !=0) etime=stime+extime;
 
+            /* If end time is set and median filtering is to be applied then need
+             * to load data after the usual end time, so etime must be adjusted */
+            if ((etime !=-1) && (bxcar==1)) {
+                if (tlen !=0) etime+=tlen;
+                else etime+=15+src[0]->ed_time-src[0]->st_time;
+            }
+
+            found_record = 2;
         }
 
-        /* If time extent provided then use that to calculate end time */
-        if (extime !=0) etime=stime+extime;
-
-        /* If end time is set and median filtering is to be applied then need
-         * to load data after the usual end time, so etime must be adjusted */
-        if ((etime !=-1) && (bxcar==1)) {
-            if (tlen !=0) etime+=tlen;
-            else etime+=15+src[0]->ed_time-src[0]->st_time;
-        }
 
         /* Calculate year, month, day, hour, minute, and second of 
          * grid start time (needed to load AACGM_v2 coefficients) */
@@ -886,6 +890,8 @@ int main(int argc,char *argv[]) {
             num++;
 
         } while (s!=-1);
+        /* If scan data is beyond end of gridding time then break out of loop */
+        if ((etime !=-1) && (src[index]->st_time>etime)) break;
 
         /* Close the input file */
         if (fitflg) {

--- a/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/make_grid.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_grid.2.0/make_grid.c
@@ -363,6 +363,7 @@ int main(int argc,char *argv[]) {
     unsigned char xtd=0;
 
     unsigned char cfitflg=0;
+    unsigned char catflg=0;
     unsigned char fitflg=0;
 
     int found_record=0;
@@ -471,7 +472,7 @@ int main(int argc,char *argv[]) {
 
     OptionAdd(&opt,"fit",'x',&fitflg);   /* Input file is in the fit format */
     OptionAdd(&opt,"cfit",'x',&cfitflg); /* Input file is in the cfit format */
-
+    OptionAdd(&opt, "c", 'x', &catflg);
     /* Process command line options */
     farg=OptionProcess(1,argc,argv,&opt,rst_opterr);
 
@@ -515,6 +516,9 @@ int main(int argc,char *argv[]) {
         if (tolower(chnstr_fix[0])=='c') channel_fix=3;
         if (tolower(chnstr_fix[0])=='d') channel_fix=4;
     }
+
+    if (catflg == 0) 
+        fprintf(stderr, "Deprecation Warning: -c option will removed next release. This will not change the functionality of make_grid and will be able to read multiple fitacf files of one radar still\n");
 
     if (bmstr !=NULL)  parse_ebeam(bmstr);
 

--- a/codebase/superdarn/src.lib/tk/cnvmodel.1.0/include/cnvmodel.h
+++ b/codebase/superdarn/src.lib/tk/cnvmodel.1.0/include/cnvmodel.h
@@ -21,7 +21,7 @@
  * 2020-11-12 Marina Schmidt switched out RST defined complex structs to complex.h
  * 2020-11-12 Marina Schmidt modified cmult
  *
- * /
+ */
 
 #ifndef _CNVMODEL_H
 #define _CNVMODEL_H

--- a/docs/user_guide/make_grid.md
+++ b/docs/user_guide/make_grid.md
@@ -20,7 +20,7 @@ The `make_grid` routine provides a lot of options for customizing the gridding p
 ## Full-day grid files
 The standard practice is to generate 24-hour grid files. If you have already made a concatenated 24-hour fitacf file, then use that file in the manner shown above. Otherwise, you can use the `-c` flag to get RST to concatenate the input fitacf files on-the-fly. This works only when the input files are all from the same radar; the method for combining data from multiple radars into a single grid file is shown in the next section.
 ```
-make_grid -vb -tl 60 -xtd -c 20181001.*.lyr.fitacf > 20181001.lyr.grd
+make_grid -vb -tl 60 -xtd 20181001.*.lyr.fitacf > 20181001.lyr.grd
 ```
 
 ## Multi-Channel Data 
@@ -65,8 +65,6 @@ do
 done
 ```
 
-*The `-c` flag will concatenate the `fitacf` files together during the gridding process.*
-
 *The `-f 4` option extracts the 3-letter radar code `rad` from the filename `YYYYMMDD.hhmm.ss.rad.fitacf`.*
 
 ```
@@ -77,7 +75,7 @@ radarlist="$(ls | cut -d "." -f 4 | sort -u)"
 
 for radar in $radarlist
 do
-  make_grid -tl 60 -xtd -vb -c 20181001*.$radar.fitacf > 20181001.$radar.grd
+  make_grid -tl 60 -xtd -vb 20181001*.$radar.fitacf > 20181001.$radar.grd
 done
 ```
 


### PR DESCRIPTION
# Scope 

Fixing `make_grid` problem with `-c -st` combination highlighted in #370 

## Changes 

`make_grid.c` and `make_grid.md` was changed. 
 
- [x] added  errno start of #314 
- [ ] removed `-c`
- [x] got `-st` to work for multiple files 

Note: I removed `-c` because:
- Reduce code in `make_grid`
- Reduced copied code in `make_grid` which was probably why this bug happened in the first place
- keep consistent with `combine_grd` didn't use `-c`
- Less user mistake by forgetting the `-c` option

## Test Reading In Multiple Files with a Start Time

Pull and compile the branch `FIX/make_grid`

`make_grid -tl 60 -st 04:06 -xtd 20100101.*.tig.fitacf > tmp.grd`

**Output**

```
Opening file:20100101.0000.00.tig.fitacf
File does not contain the requested start time, ignoring this file.
Opening file:20100101.0200.00.tig.fitacf
File does not contain the requested start time, ignoring this file.
Opening file:20100101.0400.00.tig.fitacf
Opening file:20100101.0600.00.tig.fitacf
Opening file:20100101.0800.00.tig.fitacf
Opening file:20100101.1000.00.tig.fitacf
Opening file:20100101.1200.00.tig.fitacf
Opening file:20100101.1400.00.tig.fitacf
Opening file:20100101.1600.00.tig.fitacf
Opening file:20100101.1800.00.tig.fitacf
Opening file:20100101.2000.00.tig.fitacf
Opening file:20100101.2200.00.tig.fitacf
```

`dmapdump tmp.grd | less`

```  
      short   "start.hour" = 4
      short   "start.minute" = 6
```

## Test File not Found

```
make_grid -tl 60 -st 04:05 -xtd 20100101.*.dog.fitacf > tmp.grd
Opening file:20100101.*.dog.fitacf
Error: No such file or directory
```


