### PR TITLE
GPLv3 license and copyright information for developers

### DIFF
--- a/docs/developers_guide/copyright_license.md
+++ b/docs/developers_guide/copyright_license.md
@@ -176,19 +176,12 @@ If the new library was originally developed outside of RST, the author of that l
 
 
 
-__Am I allowed to copy code from the RST into my own software project? What do I have to do to comply with RST's license?__<br/>
-
-- You are free to copy or modify any portion of the RST code
-- You are free to share the software outputs (data files, plots)
-- If you choose to share the binaries for your new software: 
-    - You must also share the source code
-    - Your software must be licensed under GPL (v3 or later)
 
 
 __I've added code to the RST. Can I also release my code under a different license?__<br/>
-Yes, provided that you are the copyright holder of the code, you are free to license it under different non-exclusive licenses ([more info](https://www.gnu.org/licenses/gpl-faq.html#ReleaseUnderGPLAndNF)). Remember that:
+Yes, provided that you are the copyright holder of the code, and that it is a standalone library (developed outside of RST), you are free to license it under different non-exclusive licenses ([more info](https://www.gnu.org/licenses/gpl-faq.html#ReleaseUnderGPLAndNF)). Remember that:
 
-- Once your code is added to the RST, that version of the code is licensed under GPLv3, and you cannot revoke this
+- Once your code is added to the RST, that version of the code is licensed under GPLv3 (or LGPL - see previous question), and you cannot revoke this
 - If your software includes other code from the RST (or other GPL-licensed code), your software can only be licensed under GPL. 
 
 __Am I allowed to copy code from the RST into my own software project? What do I have to do to comply with RST's license?__<br/>

--- a/docs/developers_guide/copyright_license.md
+++ b/docs/developers_guide/copyright_license.md
@@ -172,7 +172,7 @@ Since the GPL allows users to modify and redistribute portions of the RST softwa
 
 
 __If I add a new library to the RST, can that library have a different license?__<br/>
-No, the GPL requires that the whole "work" be released with the same license.
+If the new library was originally developed outside of RST, the author of that library can choose to license it under either GPL or LGPL when adding it to the RST. Code that has been developed within RST must be licensed under GPL.
 
 
 

--- a/docs/developers_guide/copyright_license.md
+++ b/docs/developers_guide/copyright_license.md
@@ -33,7 +33,7 @@ The SuperDARN Radar Software Toolkit (RST) is licensed under the [GNU General Pu
 
 > *"Developers that use the GNU GPL protect your rights with two steps: (1) __assert copyright__ on the software, and (2) __offer you this License__ giving you legal permission to copy, distribute and/or modify it."*
 
-This license ensures that the scientific community (and everyone else) is legally permitted to use, copy, modify and redistribute the RST. In this way, the software can be maintained and improved over time to support the advancement of science. 
+This license ensures that the scientific community (and everyone else) is legally permitted to use, copy, modify and redistribute the RST software package. In this way, the software package can be maintained and improved over time to support the advancement of science. 
 
 
 ## License requirements
@@ -42,7 +42,7 @@ The GPL v3.0 License states that:
 
 - The RST source code must be distributed with the software
 - License and copyright information must be included at the top of each source code file (more info on copyright below)
-- If the code has been modified, there must be a notice stating that it has been modified and when
+- If the code has been modified, there must be a notice stating that it has been modified, by who, and when
 - Modifications must be released under the same license as RST (GPL v3.0 or later)
 
 
@@ -144,8 +144,8 @@ __Can RST be released with a different license?__<br/>
 To release RST with a different license, we would need permission from all of the copyright holders. This means that, in practice, it would be very difficult to re-license the software. This is by design of the GPL license--it ensures that the software can always be used freely. 
 
 
-__Can JHUAPL revoke the GPL license and take back control of RST?__<br/>
-No. JHUAPL gave permission for the RST to be re-licensed under the GPL in ~2012 (RST3.5), and they cannot revoke this permission. JHUAPL still owns the copyright to their own code, and RST versions 3.4 and earlier are still licensed by JHUAPL (not under GPL).
+__Can JHU/APL revoke the GPL license and take back control of RST?__<br/>
+No. JHU/APL gave permission for the RST to be re-licensed under the GPL in ~2012 (RST3.5), and they cannot revoke this permission. JHU/APL still owns the copyright to their own code, and RST versions 3.4 and earlier are still licensed by JHU/APL (not under GPL).
 
 
 __What happens if I don't include copyright information in my code?__<br/>
@@ -158,13 +158,13 @@ In most countries, authors automatically hold the copyright to their own work ev
 
 
 __Do I have to include my institution in the copyright line?__<br/>
-That depends on the terms of your employment. Check your employment contract or ask the research office. If you contribute to the RST in your free time, then just put your own name in the copyright line.
+That depends on the terms of your employment. Check your employment contract or ask the research office. If you contribute to the RST software package in your free time, then just put your own name in the copyright line.
 
 __Can I copyright code to a generic "SuperDARN" organization?__<br/>
-No, the copyright holder has to be a legal entity or a person. Your employer may also object to this. If you contribute to the RST in your free time, then just put your own name in the copyright line.
+No, the copyright holder has to be a legal entity or a person. Your employer may also object to this. If you contribute to the RST software package in your free time, then just put your own name in the copyright line.
 
 __Why does every RST source file have license notices at the top? Isn't it sufficient to include the license file in the top-level directory of RST?__<br/>
-Since the GPL allows users to modify and redistribute portions of the RST, it is possible that individual source files might become separated from the license file. If this happens, it will be unclear to users what their legal rights are to use/modify/distribute that version of the code (which is a violation of the GPL). Therefore, all source files should clearly indicate that they are licensed under the GPL (writing "see license.txt" is not sufficient).
+Since the GPL allows users to modify and redistribute portions of the RST software packages, it is possible that individual source files might become separated from the license file. If this happens, it will be unclear to users what their legal rights are to use/modify/distribute that version of the code (which is a violation of the GPL). Therefore, all source files should clearly indicate that they are licensed under the GPL (writing "see license.txt" is not sufficient).
 
 
 __If I add a new library to the RST, can that library have a different license?__<br/>
@@ -199,8 +199,7 @@ There's lots of helpful information [here](https://www.gnu.org/licenses/gpl-faq.
 
 ## History of RST licensing
 
-RST was originally developed at the Johns Hopkins University Applied Physics Laboratory (JHUAPL). Around 2012, JHUAPL granted permission for RST to be re-licensed so that the SuperDARN community could continue maintaining the software collaboratively. This process has caused confusion over the years, since even scientists who are expert programmers may not be familiar with the intricacies of software licensing and copyright.
+RST was originally developed at the Johns Hopkins University/Applied Physics Laboratory (JHU/APL). Around 2012, JHU/APL granted permission for RST to be re-licensed so that the SuperDARN community could continue maintaining the software collaboratively. This process has caused confusion over the years, since even scientists who are expert programmers may not be familiar with the intricacies of software licensing and copyright.
 
 A major source of confusion around the RST license is whether it was intended to be licensed under the [GNU General Public License](https://www.gnu.org/licenses/gpl-3.0.en.html) (GPL), or the [GNU __Lesser__ General Public License](https://www.gnu.org/licenses/lgpl-3.0.en.html) (LGPL). This confusion has arisen because, at some point, the LGPL license notice was attached to most of the RST source code. The `AstAlg` library is the exception to this, which has been [clearly marked](https://github.com/SuperDARN/rst-archive/blob/rst.3.1/codebase/analysis/src.lib/astalg/astalg.1.2/LICENSE.txt) with a GPL disclaimer since it was first added to the RST in v3.1. Since `AstAlg` is clearly licensed under the GPL, it follows that the whole of the RST should also be licensed under the GPL. It is possible that the LGPL disclaimer text was added to the remaining RST source code in error, since it is very similar to the GPL disclaimer text. To add to this confusion, RST was not distributed with any license file for several releases (v3.5 to v4.3 inclusive). The GPL license file was added in [v4.3.1](https://doi.org/10.5281/zenodo.3634732). The license information across the whole package will be corrected in RST4.6.
-
 

--- a/docs/developers_guide/copyright_license.md
+++ b/docs/developers_guide/copyright_license.md
@@ -191,7 +191,13 @@ Yes, provided that you are the copyright holder of the code, you are free to lic
 - Once your code is added to the RST, that version of the code is licensed under GPLv3, and you cannot revoke this
 - If your software includes other code from the RST (or other GPL-licensed code), your software can only be licensed under GPL. 
 
+__Am I allowed to copy code from the RST into my own software project? What do I have to do to comply with RST's license?__<br/>
 
+- You are free to copy or modify any portion of the RST code
+- You are free to share the software outputs (data files, plots)
+- If you choose to share the binaries for your new software: 
+    - You must also share the source code
+    - Your software must be licensed under GPL (v3 or later)
 __Who owns the outputs of RST (processed data files, plots)?__<br/>
 RST outputs belong to the end user who created them. The user is free to share them under any terms, and is not bound by the GPL.
 

--- a/docs/developers_guide/copyright_license.md
+++ b/docs/developers_guide/copyright_license.md
@@ -1,46 +1,206 @@
 <!---
 (C) copyright 2019 SuperDARN Canada, University of Saskatchewan 
-author: Marina Schmidt, SuperDARN Canada
--->
-# Copyrights and Licensing
+(C) copyright 2021 The University Centre in Svalbard (UNIS)
 
-## Copyrighting
-  RST is licensed under the GPL v3.0 License, which requires all developers to copyright their code. 
-  Since RST is collaboratively developed from within the SuperDARN community, copyrighting portions of the code or having multiple copyright lines at the top of the file is allowed. 
-  For example:
-  The copyright line should have the following structure:
+authors: Marina Schmidt, SuperDARN Canada
+         Emma Bland, UNIS
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+       
+Modifications:
+          Emma Bland, UNIS, 2021-02-12 : added background information about GPL, why copyright information is required, FAQ, and RST license history 
+
+-->
+
+
+# Licensing of the RST
+
+The SuperDARN Radar Software Toolkit (RST) is licensed under the [GNU General Public License (GPL) v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html). This license guarantees that end users have the freedom to use, modify and share the software. The *Free Software Foundation*, which published the GPL, explains that:
+
+> *"The licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users."*
+
+
+> *"Developers that use the GNU GPL protect your rights with two steps: (1) __assert copyright__ on the software, and (2) __offer you this License__ giving you legal permission to copy, distribute and/or modify it."*
+
+This license ensures that the scientific community (and everyone else) is legally permitted to use, copy, modify and redistribute the RST. In this way, the software can be maintained and improved over time to support the advancement of science. 
+
+
+## License requirements
+
+The GPL v3.0 License states that:
+
+- The RST source code must be distributed with the software
+- License and copyright information must be included at the top of each source code file (more info on copyright below)
+- If the code has been modified, there must be a notice stating that it has been modified and when
+- Modifications must be released under the same license as RST (GPL v3.0 or later)
+
+
+### License notices
+
+The software must include the following notices: 
+
 ``` C
 /*
-*(C) copyright <year> of <institution/entity>
-*(C) copyright <year> of <another institution/entry>
-*
-*authors: <first and last name>, <instution>
-*         <first and last name>, <instution>
-*
-* Licensed under <license name> <version>
+<one line to give the program's name and a brief idea of what it does.>
+Copyright (C) <year>  <name of author>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Modifications:
+          <fist and last name>, <institution> <year-month-day of the modification> : <comment on the change (optional)> 
 */
 ```
 
-!!! Warning 
-        Please look up/ask your facility/institution on what to put in your copyright line.  
+According to the [GPL license documentation](https://www.gnu.org/licenses/gpl-3.0.en.html): 
+
+> It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the “copyright” line and a pointer to where the full notice is found.
+
+## License permissions
+
+When developing in RST you are granting permission for your code to be licensed under the GPL. This will be ok in almost all situations. Exceptions may arise if your employer wants to make your program into its own proprietary software, or if your funding agency has restrictions on the publication of research outputs (e.g. defense contracts). If you suspect that you won't allowed to contribute code to RST under the GPL, [it is recommended](https://www.gnu.org/licenses/gpl-faq.html#WhatIfSchool) that you negotiate this with your employer/funding agency at an early stage in developing the software. 
+
+!!! IMPORTANT
+    Please make sure to review the [license]((https://www.gnu.org/licenses/gpl-3.0.en.html)), and check with your employer/funding agency that you have permission to distribute your code under the GPLv3. 
 
 
-## Licensing 
 
-RST is an open-source software package under the GPL v3.0 License which requires the following:
-    
-- Source code must be distributed with the software 
-- License and Copyright notice must be at the top of each source code file
-- Modifications must be released under the same license as RST - GPL v3.0 
-- Must include modification line in source code when large portions are altered, Example:
+## Copyright
+
+The GPL license requires that all code includes a copyright notice. The purpose of the copyright notice is to __protect the rights of developers__ by:
+
+  1. Giving them (and their employer) credit for their work
+  2. Preventing their code from being distributed under a different license without their knowledge/permission
+  3. Giving them the power to enforce the terms of the license<br>
+     *e.g. take someone to court if they violate the license*
+
+
+
+### How to copyright your code
+
+You should add copyright information if you have written new code from scratch or substantially modified someone else's code. Examples of substantial modifications to existing code include significant changes to the code's structure or functionality. This is a gray area, so use your best judgment and ask other developers at the pull request stage if you are unsure. 
+
+!!! IMPORTANT
+    Ask your employer about what to write in your copyright line. If you contribute to the RST in your free time, then just put your own name in the copyright line.
+
+
+An example copyright line structure is:
 
 ``` C
- /* 
- * (C) copyright line ...
- * Licenses …
- * Modified: 
- *           <fist and last name>, <institution> <year-month-day of the modification> : <comment on the change (optional)> 
- */
+/*
+(C) copyright <year> of <institution/entity>
+
+author: <first and last name>, <institution>
+/
 ```
 
-When developing in RST you are agreeing to the terms and conditions of the license. Please make sure to review the license and guidelines of RST. 
+Since RST is developed collaboratively by the SuperDARN community, it may be appropriate to have multiple copyright lines in a single source file, for example: 
+``` C
+/*
+(C) copyright <year> of <institution/entity>
+(C) copyright <year> of <another institution/entry>
+
+authors: <first and last name>, <institution>
+         <first and last name>, <institution>
+
+Modifications: 
+           <fist and last name>, <institution> <year-month-day of the modification> : <comment on the change (optional)> 
+*/
+```
+
+!!! IMPORTANT
+    Never remove the existing copyright information from a source file.
+
+#### Minor modifications
+
+Adding copyright notices is appropriate only for __substantial__ modifications. If you make minor modifications to someone else's code (e.g. bug fixes), then you should document this in the modification history (example above), but do not add a new copyright line. 
+
+
+
+## Frequently asked questions
+
+__Can RST be released with a different license?__<br/>
+To release RST with a different license, we would need permission from all of the copyright holders. This means that, in practice, it would be very difficult to re-license the software. This is by design of the GPL license--it ensures that the software can always be used freely. 
+
+
+__Can JHUAPL revoke the GPL license and take back control of RST?__<br/>
+No. JHUAPL gave permission for the RST to be re-licensed under the GPL in ~2012 (RST3.5), and they cannot revoke this permission. JHUAPL still owns the copyright to their own code, and RST versions 3.4 and earlier are still licensed by JHUAPL (not under GPL).
+
+
+__What happens if I don't include copyright information in my code?__<br/>
+In most countries, authors automatically hold the copyright to their own work even if they don't add a copyright notice. This is to protect the rights people who are not aware of the law. However, omitting copyright information means that:
+
+- You may be breaching your employment contract
+- You are not complying with the GPL requirement to include copyright information
+- You may not get credit for your work
+- It is more difficult for you to prove that you are the copyright holder
+
+
+__Do I have to include my institution in the copyright line?__<br/>
+That depends on the terms of your employment. Check your employment contract or ask the research office. If you contribute to the RST in your free time, then just put your own name in the copyright line.
+
+__Can I copyright code to a generic "SuperDARN" organization?__<br/>
+No, the copyright holder has to be a legal entity or a person. Your employer may also object to this. If you contribute to the RST in your free time, then just put your own name in the copyright line.
+
+__Why does every RST source file have license notices at the top? Isn't it sufficient to include the license file in the top-level directory of RST?__<br/>
+Since the GPL allows users to modify and redistribute portions of the RST, it is possible that individual source files might become separated from the license file. If this happens, it will be unclear to users what their legal rights are to use/modify/distribute that version of the code (which is a violation of the GPL). Therefore, all source files should clearly indicate that they are licensed under the GPL (writing "see license.txt" is not sufficient).
+
+
+__If I add a new library to the RST, can that library have a different license?__<br/>
+No, the GPL requires that the whole "work" be released with the same license.
+
+
+
+__What are the licensing consequences of copying code from the RST into my own software project?__
+
+- You are free to copy or modify any portion of the RST code
+- You are free to share the software outputs (data files, plots)
+- If you choose to share the binaries for your new software: 
+    - You must also share the source code
+    - The source code must be licensed under GPLv3
+
+
+__I've added code to the RST. Can I also release my code under a different license?__<br/>
+Yes, provided that you are the copyright owner of the code, you are free to license it under different non-exclusive licenses ([more info](https://www.gnu.org/licenses/gpl-faq.html#ReleaseUnderGPLAndNF)). Remember that:
+
+- Once your code is added to the RST, that version of the code is licensed under GPLv3, and you cannot revoke this
+- If your software includes other code from the RST (or other GPL-licensed code), your software can only be licensed under GPL. 
+
+
+__Who owns the outputs of RST (processed data files, plots)?__<br/>
+RST outputs belong to the end user who created them. The user is free to share them under any terms, and is not bound by the GPL.
+
+__I have more questions about the GPL__<br/>
+There's lots of helpful information [here](https://www.gnu.org/licenses/gpl-faq.html).
+
+
+
+
+## History of RST licensing
+
+RST was originally developed at the Johns Hopkins University Applied Physics Laboratory (JHUAPL). Around 2012, JHUAPL granted permission for RST to be re-licensed so that the SuperDARN community could continue maintaining the software collaboratively. This process has caused confusion over the years, since even scientists who are expert programmers may not be familiar with the intricacies of software licensing and copyright.
+
+A major source of confusion around the RST license is whether it was intended to be licensed under the [GNU General Public License](https://www.gnu.org/licenses/gpl-3.0.en.html) (GPL), or the [GNU __Lesser__ General Public License](https://www.gnu.org/licenses/lgpl-3.0.en.html) (LGPL). This confusion has arisen because, at some point, the LGPL license notice was attached to most of the RST source code. The `AstAlg` library is the exception to this, which has been [clearly marked](https://github.com/SuperDARN/rst-archive/blob/rst.3.1/codebase/analysis/src.lib/astalg/astalg.1.2/LICENSE.txt) with a GPL disclaimer since it was first added to the RST in v3.1. Since `AstAlg` is clearly licensed under the GPL, then it follows that the whole of the RST should also be licensed under the GPL. It is possible that the LGPL disclaimer text was added to the remaining RST source code in error, since it is very similar to the GPL disclaimer text. To add to this confusion, RST was not distributed with any license file for several releases (v3.5 to v4.3 inclusive). The GPL license file was added in [v4.3.1](https://doi.org/10.5281/zenodo.3634732). The license information across the whole package will be corrected in RST4.6.
+
+

--- a/docs/developers_guide/copyright_license.md
+++ b/docs/developers_guide/copyright_license.md
@@ -5,7 +5,9 @@
 authors: Marina Schmidt, SuperDARN Canada
          Emma Bland, UNIS
 
-This program is free software: you can redistribute it and/or modify
+This file is part of the Radar Software Toolkit (RST).
+
+RST is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.

--- a/docs/developers_guide/copyright_license.md
+++ b/docs/developers_guide/copyright_license.md
@@ -172,7 +172,7 @@ No, the GPL requires that the whole "work" be released with the same license.
 
 
 
-__What are the licensing consequences of copying code from the RST into my own software project?__
+__Am I allowed to copy code from the RST into my own software project? What do I have to do to comply with RST's license?__<br/>
 
 - You are free to copy or modify any portion of the RST code
 - You are free to share the software outputs (data files, plots)
@@ -202,4 +202,3 @@ There's lots of helpful information [here](https://www.gnu.org/licenses/gpl-faq.
 RST was originally developed at the Johns Hopkins University/Applied Physics Laboratory (JHU/APL). Around 2012, JHU/APL granted permission for RST to be re-licensed so that the SuperDARN community could continue maintaining the software collaboratively. This process has caused confusion over the years, since even scientists who are expert programmers may not be familiar with the intricacies of software licensing and copyright.
 
 A major source of confusion around the RST license is whether it was intended to be licensed under the [GNU General Public License](https://www.gnu.org/licenses/gpl-3.0.en.html) (GPL), or the [GNU __Lesser__ General Public License](https://www.gnu.org/licenses/lgpl-3.0.en.html) (LGPL). This confusion has arisen because, at some point, the LGPL license notice was attached to most of the RST source code. The `AstAlg` library is the exception to this, which has been [clearly marked](https://github.com/SuperDARN/rst-archive/blob/rst.3.1/codebase/analysis/src.lib/astalg/astalg.1.2/LICENSE.txt) with a GPL disclaimer since it was first added to the RST in v3.1. Since `AstAlg` is clearly licensed under the GPL, it follows that the whole of the RST should also be licensed under the GPL. It is possible that the LGPL disclaimer text was added to the remaining RST source code in error, since it is very similar to the GPL disclaimer text. To add to this confusion, RST was not distributed with any license file for several releases (v3.5 to v4.3 inclusive). The GPL license file was added in [v4.3.1](https://doi.org/10.5281/zenodo.3634732). The license information across the whole package will be corrected in RST4.6.
-

--- a/docs/developers_guide/copyright_license.md
+++ b/docs/developers_guide/copyright_license.md
@@ -77,7 +77,7 @@ Modifications:
 
 According to the [GPL license documentation](https://www.gnu.org/licenses/gpl-3.0.en.html): 
 
-> It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the “copyright” line and a pointer to where the full notice is found.
+> *"It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the “copyright” line and a pointer to where the full notice is found.*"
 
 ## License permissions
 

--- a/docs/developers_guide/copyright_license.md
+++ b/docs/developers_guide/copyright_license.md
@@ -79,7 +79,7 @@ According to the [GPL license documentation](https://www.gnu.org/licenses/gpl-3.
 
 ## License permissions
 
-When developing in RST you are granting permission for your code to be licensed under the GPL. This will be ok in almost all situations. Exceptions may arise if your employer wants to make your program into its own proprietary software, or if your funding agency has restrictions on the publication of research outputs (e.g. defense contracts). If you suspect that you won't allowed to contribute code to RST under the GPL, [it is recommended](https://www.gnu.org/licenses/gpl-faq.html#WhatIfSchool) that you negotiate this with your employer/funding agency at an early stage in developing the software. 
+When developing in RST you are granting permission for your code to be licensed under the GPL. This will be ok in almost all situations. Exceptions may arise if your employer wants to make your program into its own proprietary software, or if your funding agency has restrictions on the publication of research outputs (e.g. defense contracts). If you suspect that you won't be allowed to contribute code to RST under the GPL, [it is recommended](https://www.gnu.org/licenses/gpl-faq.html#WhatIfSchool) that you negotiate this with your employer/funding agency at an early stage in developing the software. 
 
 !!! IMPORTANT
     Please make sure to review the [license]((https://www.gnu.org/licenses/gpl-3.0.en.html)), and check with your employer/funding agency that you have permission to distribute your code under the GPLv3. 
@@ -149,7 +149,7 @@ No. JHUAPL gave permission for the RST to be re-licensed under the GPL in ~2012 
 
 
 __What happens if I don't include copyright information in my code?__<br/>
-In most countries, authors automatically hold the copyright to their own work even if they don't add a copyright notice. This is to protect the rights people who are not aware of the law. However, omitting copyright information means that:
+In most countries, authors automatically hold the copyright to their own work even if they don't add a copyright notice. This is to protect the rights of people who are not aware of the law. However, omitting copyright information means that:
 
 - You may be breaching your employment contract
 - You are not complying with the GPL requirement to include copyright information
@@ -178,11 +178,11 @@ __What are the licensing consequences of copying code from the RST into my own s
 - You are free to share the software outputs (data files, plots)
 - If you choose to share the binaries for your new software: 
     - You must also share the source code
-    - The source code must be licensed under GPLv3
+    - Your software must be licensed under GPL (v3 or later)
 
 
 __I've added code to the RST. Can I also release my code under a different license?__<br/>
-Yes, provided that you are the copyright owner of the code, you are free to license it under different non-exclusive licenses ([more info](https://www.gnu.org/licenses/gpl-faq.html#ReleaseUnderGPLAndNF)). Remember that:
+Yes, provided that you are the copyright holder of the code, you are free to license it under different non-exclusive licenses ([more info](https://www.gnu.org/licenses/gpl-faq.html#ReleaseUnderGPLAndNF)). Remember that:
 
 - Once your code is added to the RST, that version of the code is licensed under GPLv3, and you cannot revoke this
 - If your software includes other code from the RST (or other GPL-licensed code), your software can only be licensed under GPL. 
@@ -201,6 +201,6 @@ There's lots of helpful information [here](https://www.gnu.org/licenses/gpl-faq.
 
 RST was originally developed at the Johns Hopkins University Applied Physics Laboratory (JHUAPL). Around 2012, JHUAPL granted permission for RST to be re-licensed so that the SuperDARN community could continue maintaining the software collaboratively. This process has caused confusion over the years, since even scientists who are expert programmers may not be familiar with the intricacies of software licensing and copyright.
 
-A major source of confusion around the RST license is whether it was intended to be licensed under the [GNU General Public License](https://www.gnu.org/licenses/gpl-3.0.en.html) (GPL), or the [GNU __Lesser__ General Public License](https://www.gnu.org/licenses/lgpl-3.0.en.html) (LGPL). This confusion has arisen because, at some point, the LGPL license notice was attached to most of the RST source code. The `AstAlg` library is the exception to this, which has been [clearly marked](https://github.com/SuperDARN/rst-archive/blob/rst.3.1/codebase/analysis/src.lib/astalg/astalg.1.2/LICENSE.txt) with a GPL disclaimer since it was first added to the RST in v3.1. Since `AstAlg` is clearly licensed under the GPL, then it follows that the whole of the RST should also be licensed under the GPL. It is possible that the LGPL disclaimer text was added to the remaining RST source code in error, since it is very similar to the GPL disclaimer text. To add to this confusion, RST was not distributed with any license file for several releases (v3.5 to v4.3 inclusive). The GPL license file was added in [v4.3.1](https://doi.org/10.5281/zenodo.3634732). The license information across the whole package will be corrected in RST4.6.
+A major source of confusion around the RST license is whether it was intended to be licensed under the [GNU General Public License](https://www.gnu.org/licenses/gpl-3.0.en.html) (GPL), or the [GNU __Lesser__ General Public License](https://www.gnu.org/licenses/lgpl-3.0.en.html) (LGPL). This confusion has arisen because, at some point, the LGPL license notice was attached to most of the RST source code. The `AstAlg` library is the exception to this, which has been [clearly marked](https://github.com/SuperDARN/rst-archive/blob/rst.3.1/codebase/analysis/src.lib/astalg/astalg.1.2/LICENSE.txt) with a GPL disclaimer since it was first added to the RST in v3.1. Since `AstAlg` is clearly licensed under the GPL, it follows that the whole of the RST should also be licensed under the GPL. It is possible that the LGPL disclaimer text was added to the remaining RST source code in error, since it is very similar to the GPL disclaimer text. To add to this confusion, RST was not distributed with any license file for several releases (v3.5 to v4.3 inclusive). The GPL license file was added in [v4.3.1](https://doi.org/10.5281/zenodo.3634732). The license information across the whole package will be corrected in RST4.6.
 
 

--- a/docs/developers_guide/copyright_license.md
+++ b/docs/developers_guide/copyright_license.md
@@ -55,7 +55,9 @@ The software must include the following notices:
 <one line to give the program's name and a brief idea of what it does.>
 Copyright (C) <year>  <name of author>
 
-This program is free software: you can redistribute it and/or modify
+This file is part of the Radar Software Toolkit (RST).
+
+RST is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.


### PR DESCRIPTION
This PR adds some more information about the [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html) license to the RST developer guide on readthedocs. In particular:

- The purpose of the license
- The purpose of copyrighting your code
- What the license requires us to do (already written by @mts299)
- FAQ about the GPL license
- Some history about RST's license

Also very happy to answer any other questions about the license that are not answered here!