### PR TITLE
Add missing "-ftrmcol" command line option to fov_plot

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
@@ -547,6 +547,7 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"lndcol",'t',&lndcol_txt);
   OptionAdd(&opt,"seacol",'t',&seacol_txt);
   OptionAdd(&opt,"trmcol",'t',&trmcol_txt);
+  OptionAdd(&opt,"ftrmcol",'t',&ftrmcol_txt);
   OptionAdd(&opt,"tmkcol",'t',&tmkcol_txt);
  
   OptionAdd(&opt,"fovcol",'t',&fovcol_txt);


### PR DESCRIPTION
Just stumbled on a bug in `fov_plot`: the command line option `-ftrmcol` is not recognised.

On `develop` there will be an error: 
```
Option not recognized: ftrmcol
Please try: fov_plot --help
```
On this branch you should be able to produce a plot with a filled terminator.

Example test code: 
```
fov_plot -st gbr -fov -ffov -stereo -grd -grdontop -lat 90 -lon 0 -fcoast -fterm -ftrmcol 55000000 -x
```