### PR TITLE
Fix bug in trim_raw

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/trim_raw.1.15/trim_raw.c
+++ b/codebase/superdarn/src.bin/tk/tool/trim_raw.1.15/trim_raw.c
@@ -347,6 +347,7 @@ int main (int argc,char *argv[]) {
       strcpy(tmstr,asctime(gmtime(&ctime)));
       tmstr[24]=0;
       RadarParmSetOriginTime(prm,tmstr);
+      RawFwrite(stdout,prm,raw);
      }
 
      TimeEpochToYMDHMS(atime,&yr,&mo,&dy,&hr,&mt,&sc);


### PR DESCRIPTION
This PR fixes #392. This was a silly mistake that crept in when adding comments to `trim_raw.c` in #320, where the line `RawFwrite(stdout,prm,raw);` was accidentally removed after the code itself had been tested. That's the line that writes the output file :stuck_out_tongue_winking_eye: 

To test:
```
trim_raw -st 08:00 -ex 00:30 20140220.0802.00.bks.rawacf > out.rawacf

#check output file size
ls -lh out.rawacf
```
On this branch the output file will contain the trimmed data; on develop the file will be empty