### PR TITLE
Fixing bug in time_plot where user-defined color keys did not work

### DIFF
--- a/codebase/superdarn/src.lib/tk/binplotlib.1.0/src/key.c
+++ b/codebase/superdarn/src.lib/tk/binplotlib.1.0/src/key.c
@@ -65,6 +65,7 @@ int load_key(FILE *fp,struct key *key) {
         memset(key->g,0,num);
         memset(key->b,0,num);
         key->num=num;
+        key->max=num;
         j=0;
       }
     } else if (j<num) {


### PR DESCRIPTION
Fixed the bug in `time_plot` where user-defined color keys did not work as identifed by @ecbland in #402.  This was due to a difference in how `load_key` functioned for `time_plot` compared to the other plotting binaries, which I did not notice when consolidating everything into `binplotlib`.