### PR TITLE
Fixing pointer freeing error in hmb_plot and pc_plot

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/hmb_plot.1.6/hmb_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/hmb_plot.1.6/hmb_plot.c
@@ -526,10 +526,12 @@ int main(int argc,char *argv[]) {
     else FrameBufferSavePNG(img,stdout);
   #endif
 
-  free(fname);
+  if ((cfname !=NULL) && (arg<optf->argc)) {
+    free(fname);
+  }
   return 0;
 
 
- }
+}
 
 

--- a/codebase/superdarn/src.bin/tk/plot/pc_plot.1.6/pc_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/pc_plot.1.6/pc_plot.c
@@ -798,10 +798,12 @@ int main(int argc,char *argv[]) {
     else FrameBufferSavePNG(img,stdout);
   #endif
 
-  free(fname);
+  if ((cfname !=NULL) && (arg<optf->argc)) {
+    free(fname);
+  }
   return 0;
 
 
- }
+}
 
 


### PR DESCRIPTION
This pull request fixes the error in `hmb_plot` and `pc_plot` identified by @ecbland in #406.  The problem was that this freeing of `fname` should only occur when command line options are provided in a separate file with the `-cf` option.