### PR TITLE
Fix elevation angle error bounds in FITACF2.5

### DIFF
--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/do_fit.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/do_fit.c
@@ -368,30 +368,30 @@ int do_fit(struct FitBlock *iptr, int lag_lim, int goose,
           xptr[k].phi0 = xptr[k].phi0*iptr->prm.phidiff;
 
 
-      /* phi_sign indicates whether interferometer array is in front (+) or behind (-) main array
+      /* Y_offset_sign indicates whether interferometer array is in front (+) or behind (-) main array
          used for elv_low and elv_high calculation */
-      int phi_sign;
+      int interfer_sign;
       if (iptr->prm.interfer[1] > 0.0)
-        phi_sign= 1.0;
+        Y_offset_sign= 1.0;
       else
-        phi_sign= -1.0;
+        Y_offset_sign= -1.0;
 
       if (iptr->prm.old_elev) {
         /* use old elevation angle routines */
         if (goose == 0) {
           elv[k].normal = elevation(&iptr->prm, xptr[k].phi0);
-          elv[k].low = elevation(&iptr->prm, xptr[k].phi0 + phi_sign*xptr[k].phi0_err);
-          elv[k].high = elevation(&iptr->prm, xptr[k].phi0 - phi_sign*xptr[k].phi0_err);
+          elv[k].low = elevation(&iptr->prm, xptr[k].phi0 + Y_offset_sign*xptr[k].phi0_err);
+          elv[k].high = elevation(&iptr->prm, xptr[k].phi0 - Y_offset_sign*xptr[k].phi0_err);
         } else {
           elv[k].normal = elev_goose(&iptr->prm, xptr[k].phi0);
-          elv[k].low = elev_goose(&iptr->prm, xptr[k].phi0 + phi_sign*xptr[k].phi0_err);
-          elv[k].high = elev_goose(&iptr->prm, xptr[k].phi0 - phi_sign*xptr[k].phi0_err);
+          elv[k].low = elev_goose(&iptr->prm, xptr[k].phi0 + Y_offset_sign*xptr[k].phi0_err);
+          elv[k].high = elev_goose(&iptr->prm, xptr[k].phi0 - Y_offset_sign*xptr[k].phi0_err);
         }
       } else {
         /* use the correct elevation angle routine */
         elv[k].normal = elevation_v2(&iptr->prm, xptr[k].phi0);
-        elv[k].low = elevation_v2(&iptr->prm, xptr[k].phi0 + phi_sign*xptr[k].phi0_err);
-        elv[k].high = elevation_v2(&iptr->prm, xptr[k].phi0 - phi_sign*xptr[k].phi0_err);
+        elv[k].low = elevation_v2(&iptr->prm, xptr[k].phi0 + Y_offset_sign*xptr[k].phi0_err);
+        elv[k].high = elevation_v2(&iptr->prm, xptr[k].phi0 - Y_offset_sign*xptr[k].phi0_err);
       }
     }
     if (ptr[k].qflg == 1) i++;

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/do_fit.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/do_fit.c
@@ -23,6 +23,8 @@
  You should have received a copy of the GNU Lesser General Public License
  along with RST.  If not, see <http://www.gnu.org/licenses/>.
 
+  Modifications:
+    Emma Bland, UNIS, 20/04/2021, Check whether interferometer array is in front or behind main array when calculating elv_low/elv_high
 
 
 */
@@ -365,22 +367,31 @@ int do_fit(struct FitBlock *iptr, int lag_lim, int goose,
       if (iptr->prm.phidiff != 0)
           xptr[k].phi0 = xptr[k].phi0*iptr->prm.phidiff;
 
+
+      /* phi_sign indicates whether interferometer array is in front (+) or behind (-) main array
+         used for elv_low and elv_high calculation */
+      int phi_sign;
+      if (iptr->prm.interfer[1] > 0.0)
+        phi_sign= 1.0;
+      else
+        phi_sign= -1.0;
+
       if (iptr->prm.old_elev) {
         /* use old elevation angle routines */
         if (goose == 0) {
           elv[k].normal = elevation(&iptr->prm, xptr[k].phi0);
-          elv[k].low = elevation(&iptr->prm, xptr[k].phi0+xptr[k].phi0_err);
-          elv[k].high = elevation(&iptr->prm, xptr[k].phi0-xptr[k].phi0_err);
+          elv[k].low = elevation(&iptr->prm, xptr[k].phi0 + phi_sign*xptr[k].phi0_err);
+          elv[k].high = elevation(&iptr->prm, xptr[k].phi0 - phi_sign*xptr[k].phi0_err);
         } else {
           elv[k].normal = elev_goose(&iptr->prm, xptr[k].phi0);
-          elv[k].low = elev_goose(&iptr->prm, xptr[k].phi0+xptr[k].phi0_err);
-          elv[k].high = elev_goose(&iptr->prm, xptr[k].phi0-xptr[k].phi0_err);
+          elv[k].low = elev_goose(&iptr->prm, xptr[k].phi0 + phi_sign*xptr[k].phi0_err);
+          elv[k].high = elev_goose(&iptr->prm, xptr[k].phi0 - phi_sign*xptr[k].phi0_err);
         }
       } else {
         /* use the correct elevation angle routine */
         elv[k].normal = elevation_v2(&iptr->prm, xptr[k].phi0);
-        elv[k].low = elevation_v2(&iptr->prm, xptr[k].phi0+xptr[k].phi0_err);
-        elv[k].high = elevation_v2(&iptr->prm, xptr[k].phi0-xptr[k].phi0_err);
+        elv[k].low = elevation_v2(&iptr->prm, xptr[k].phi0 + phi_sign*xptr[k].phi0_err);
+        elv[k].high = elevation_v2(&iptr->prm, xptr[k].phi0 - phi_sign*xptr[k].phi0_err);
       }
     }
     if (ptr[k].qflg == 1) i++;


### PR DESCRIPTION
This PR fixes #410 reported by @alexchartier, where the elevation angle error bounds (`elv_low` and `elv_high`) are flipped for some radars. The problem occurs for radars with the interferometer array behind the main array. 

I fixed this problem for the default (Shepherd) elevation angle calculation, and also for the `-old_elev` option. For consistency I corrected the function call to `elev_goose()`, but that radar has a front inteferometer so it doesn't change the behaviour. 

To test (with and without `-old_elev`):
```
make_fit [-old_elev] 20100305.1401.00.inv.rawacf > inv.fitacf      # front inteferometer 
make_fit [-old_elev] 20100305.1401.00.rkn.rawacf > rkn.fitacf      # rear interferometer

# Display the phase error, elevation, elv_low and elv_high (see note below)
dmapdump -d rkn.fitacf | grep -A 7 phi0_e | head -8
```

- Front interferometer case: the output files should be the same on this branch and `develop`, with `elv_high` > `elv_low` as expected. 
- Rear interferometer case: `elv_high` > `elv_low` on this branch, and `elv_high` < `elv_low` on `develop`

**Note:** This PR does not account for phase flipping due to the 2pi ambiguity. If a 2pi jump occurs when calculating the elevation angle error bounds, it's possible to get `elv_high` < `elv_low`. You can see this problem quite well for the `inv` example I provided above. I don't want to change this behaviour because it would be misrepresenting the data.