### PR TITLE
Fix undeclared variable in FITACF2.5

### DIFF
--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/do_fit.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/do_fit.c
@@ -370,7 +370,7 @@ int do_fit(struct FitBlock *iptr, int lag_lim, int goose,
 
       /* Y_offset_sign indicates whether interferometer array is in front (+) or behind (-) main array
          used for elv_low and elv_high calculation */
-      int interfer_sign;
+      int Y_offset_sign;
       if (iptr->prm.interfer[1] > 0.0)
         Y_offset_sign= 1.0;
       else


### PR DESCRIPTION
I just realised that compilation on `develop` fails now that #411 has been merged. This bug was introduced when I changed a variable name but forgot update the variable declaration.

To test, just run `make.build && make.code` on this branch and check that the package compiles correctly