### PR TITLE
Revising the noise calculation in FITACF3.0

### DIFF
--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.c
@@ -823,7 +823,7 @@ double ACF_cutoff_pwr(FITPRMS *fit_prms){
     ni = (ni > 0) ? ni :  1;
     cpc = cutoff_power_correction(fit_prms);
     min_pwr = min_pwr/ni * cpc;
-    if (min_pwr < 1.0) min_pwr = fit_prms->noise;
+    /*if (min_pwr < 1.0) min_pwr = fit_prms->noise;*/
 
     free(pwr_levels);
     return min_pwr;

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.c
@@ -21,9 +21,8 @@ Author(s): Keith Kotyk July 2015
 Modifications: 
     2020-03-11 Marina Schmidt (SuperDARN Canada) removed all defined 
                               constants and included rmath.h 
-    2021-05-26 Pasha Ponomarenko (SuperDARN Canada) commented out repacement of the
-                                skynoise by search noise as it caused problems with 
-                                processing BORELAIS data (no search noise)
+    2021-05-26 Pasha Ponomarenko (SuperDARN Canada) check that the search noise
+               is nonzero before using it to replace the skynoise when min_pwr < 1
 
 */
 
@@ -828,13 +827,12 @@ double ACF_cutoff_pwr(FITPRMS *fit_prms){
     min_pwr = min_pwr/ni * cpc;
     
     
-    /*  Commenting the line below out as it causes problems with processing
-            BOREALIS data by setting Inf values to SNR as the search noise is not 
-            estimated. Amending it temporarily with the check
-            for "skynoise" data to be nonzero. This is a quick fix that allows 
-            BOREALIS data to be processed properly but also makes no impact 
-            on the older data. A more elaborate/universal solution to this issue 
-            should be developed for th enext release. */
+    /*  The commented line below causes Inf values of the SNR when the search noise 
+        is zero. Therefore, we introduce an additional condition that the search noise 
+        must be nonzero. This is a temporary fix that allows the affected data to be 
+        processed properly while not affecting the processing of any other data. 
+        A more universal solution to this issue should be developed for the 
+        next release. */
    
     /*if (min_pwr < 1.0) min_pwr = fit_prms->noise;*/
     if ((min_pwr < 1.0) && (fit_prms->noise != 0.0)) min_pwr = fit_prms->noise;
@@ -1492,5 +1490,4 @@ void Fill_Data_Lists_For_Range(llist_node range,llist lags,FITPRMS *fit_prms){
 
 
 }
-
 

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.c
@@ -21,6 +21,9 @@ Author(s): Keith Kotyk July 2015
 Modifications: 
     2020-03-11 Marina Schmidt (SuperDARN Canada) removed all defined 
                               constants and included rmath.h 
+    2021-05-26 Pasha Ponomarenko (SuperDARN Canada) commented out repacement of the
+                                skynoise by search noise as it caused problems with 
+                                processing BORELAIS data (no search noise)
 
 */
 
@@ -823,6 +826,12 @@ double ACF_cutoff_pwr(FITPRMS *fit_prms){
     ni = (ni > 0) ? ni :  1;
     cpc = cutoff_power_correction(fit_prms);
     min_pwr = min_pwr/ni * cpc;
+    
+    
+    /*  Commenting the line below out as it causes problems with processing
+            BOREALIS data by setting Inf values to SNR as the search noise is not 
+            estimated. */
+   
     /*if (min_pwr < 1.0) min_pwr = fit_prms->noise;*/
 
     free(pwr_levels);

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.c
@@ -830,10 +830,15 @@ double ACF_cutoff_pwr(FITPRMS *fit_prms){
     
     /*  Commenting the line below out as it causes problems with processing
             BOREALIS data by setting Inf values to SNR as the search noise is not 
-            estimated. */
+            estimated. Amending it temporarily with the check
+            for "skynoise" data to be nonzero. This is a quick fix that allows 
+            BOREALIS data to be processed properly but also makes no impact 
+            on the older data. A more elaborate/universal solution to this issue 
+            should be developed for th enext release. */
    
     /*if (min_pwr < 1.0) min_pwr = fit_prms->noise;*/
-
+    if ((min_pwr < 1.0) && (fit_prms->noise != 0.0)) min_pwr = fit_prms->noise;
+    
     free(pwr_levels);
     return min_pwr;
 


### PR DESCRIPTION
This pull request deals with the problem described in issue [#419](https://github.com/SuperDARN/rst/issues/419) when very high (Inf) SNR values sporadically occurr across all range gates in BOREALIS data processed with FITACF3 (note that those are absent if you process the same data with FITACF2.5). This effect is regularly observed in CLY data:

![20210203 1600 00 cly a v3](https://user-images.githubusercontent.com/5315016/119925654-19adf400-bf33-11eb-9f1b-413843f7f740.png)

Testing of the bug fix is very simple: run _make_fit_ from this branch on the respective _rawacf_ file and plot it:

          make_fit -fitacf-version 3.0 20210203.1600.00.cly.a.rawacf > 20210203.1600.00.cly.a.v3_m.fitacf
              
          time_plot -png -km -frang 0 -erang 3500 -a -phi -vmax 100 -vmin -100 -b 5 -st 16:00 -ex 02:00 20210203.1600.00.cly.a.v3_m.fitacf > 20210203.1600.00.cly.a.v3_m.png 

The vertical stripes should disappear: 

![20210203 1600 00 cly a v3_m](https://user-images.githubusercontent.com/5315016/119926079-e7e95d00-bf33-11eb-9384-765e1ea6500e.png)
