### PR TITLE
Remove unnecessary fprintf statements from FITACF 3.0

### DIFF
--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.c
@@ -724,10 +724,7 @@ void set_xcf_phi0(llist_node range, struct FitData* fit_data, FITPRMS* fit_prms)
 
     /* Correct phase sign due to cable swapping */
     fit_data->xrng[range_node->range].phi0 = atan2(imag,real)*fit_prms->phidiff;
-    fprintf(stderr, "xcf_phi0 before elv_a: %f\n", range_node->elev_fit->a);
     range_node->elev_fit->a *= fit_prms->phidiff;
-    fprintf(stderr, "xcf_phi0 after elv_a: %f\n", range_node->elev_fit->a);
-    fprintf(stderr, "phidiff: %f\n", fit_prms->phidiff);
 
 }
 


### PR DESCRIPTION
This PR removes some `fprintf()` statements from the function `set_xcf_phi0` in `determinations.c`. I think these are leftover from debugging when we added the Shepherd (2017) elevation angle calculations. 


To Test: 
```
make_fit -fitacf-version 3.0 20100305.1428.05.sas.rawacf > /dev/null
```

On develop, you will see the following printed in the terminal:
```
xcf_phi0 before elv_a: -1.267452
xcf_phi0 after elv_a: -1.267452
phidiff: 1.000000
```

On this branch, you will see nothing. 

This PR is not related to #345 but I'm planning to take a look at that soon. 
