### PR TITLE
Update github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,20 +1,19 @@
----
-name: Bug
-about: Reporting the bug
+----
+name: Bug report
+about: Report a problem or issue
+----
 
----
-
-# BUG 
+# BUG
 
 *description of the bug*
 
 ## Priority
 
-- [ ] Minor - typo, incorrect naming, fails on specific uncommon situation
-- [ ] Major - misrepresentation of data, failure in a common situation 
-- [ ] Urgent - failure in usage, large misrepresentation
+- [ ] Minor - typo, incorrect naming, fails in a specific uncommon situation
+- [ ] Major - misrepresentation of data, failure in a common situation
+- [ ] Urgent - failure in usage, large misrepresentation of data
 
-## Example of the bug 
+## Example of the bug
 
 *please provide **code** and **output** of the bug*
 
@@ -22,27 +21,25 @@ about: Reporting the bug
 
 *What have you tried already to fix it?*
 
-*What have you tried to get around it?*
+*What have you tried to work around it?*
 
-### Data Location
+### Data Access
 
-*Please indicate where (and how) to get the data file that was used to obtain the bug.*
+*Please describe how to obtain the data needed to reproduce the bug* (e.g. specific file, use `make_fit` on any rawacf file).
 
-## Potential Bug Location 
+## Potential Bug Location
 
-*Please note this is not required.*
-
-*If you can link to some code in RST where you think the bug is coming from this will help the developer fix it sooner* 
+*If possible, provide a link to the RST source code where you think the bug is coming from*
 
 ## Potential Solution(s)
 
-*Please note this is not required.*
+*If possible, provide suggestions on how to fix the bug*
 
-*If you have some idea of how to fix/improve on the bug then please describe here for possible solution(s)*
 
 ## Extra Notes
 
 *Please provide any other details about this bug*
+
 - *Operating System*
 - *Compiler version* `gcc --version`
 - *Examples of what the visual should look like*

--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -13,6 +13,13 @@ about: Report a problem or issue
 - [ ] Major - misrepresentation of data, failure in a common situation
 - [ ] Urgent - failure in usage, large misrepresentation of data
 
+## RST version
+
+*Does the bug occur in an official RST release?*
+
+- [ ] Yes. RST version: ______
+- [ ] No. Branch containing the bug (e.g. develop): ______
+
 ## Example of the bug
 
 *please provide **code** and **output** of the bug*

--- a/.github/ISSUE_TEMPLATE/deprecation_template.md
+++ b/.github/ISSUE_TEMPLATE/deprecation_template.md
@@ -1,29 +1,41 @@
 ---
-name: Deprecation 
-about: to suggest removing an option or a feature
+name: Deprecation
+about: Suggest removing an option or a feature
 ---
 
-# DEPRECATION 
+# DEPRECATION
 
 **Feature:**
 
 **function:**  *filename.c*
- 
+
 **bin/lib:** */directory*
 
 ## Reason
 
-*Why should this feature be deprecated?  Possible reasons include being outside of RST's current scope or being a legacy function that is no longer used.*
+*Why should this feature be deprecated?  Possible reasons include being outside of RST's current scope, or being a legacy function that is no longer used.*
 
 ## Replacement
 
 *Would anything replace this feature?*
-## Potential Issues 
 
-- [ ] Backwards compatibility - *Does this potentially influence any old file formats or old code? Does it change backward compatibility?*
-- [ ] reproducibility  - *Does this affect reproducibility between various RST versions?*
+## Potential Issues
 
-*If this affects one or both of the possible issues how would you inform or ensure people are aware and why this is needed.*
+- [ ] Backwards compatibility - *Could this affect any old-format files or other RST code? Does it affect backward compatibility?*
+- [ ] Reproducibility  - *Could this affect the reproducibility of analysis results between different RST versions?*
+
+### Communication with the SuperDARN community
+
+*How should users be informed about this deprecation?*
+
+## Approval from PI Executive Council and/or Data Standards Working Group
+
+*Deprecation of a feature or library may require approval from the PI Executive Council and/or the Data Standards Working Group (DSWG).*
+
+- [ ] Approval from PI Executive Council - *changes that could affect the scientific interpretation of SuperDARN data*
+- [ ] Approval from DSWG - *deprecations related to file formats, data file I/O, integration of hardware files*
+- [ ] Approval not necessary - *simple deprecations such as command line options or removing duplicated code*
+
 ## Details
 
 *Please provide any other details about the deprecation process and the future.*

--- a/.github/ISSUE_TEMPLATE/discussion_template.md
+++ b/.github/ISSUE_TEMPLATE/discussion_template.md
@@ -1,10 +1,10 @@
 ---
-name: Discussion  
+name: Discussion
 about: initiate an open discussion with other developers
 
 ---
 
-# Discussion 
+# Discussion
 
 **Topic:**
 
@@ -14,26 +14,26 @@ about: initiate an open discussion with other developers
 
 ## Category
 
-- [ ] User-friendly  
+- [ ] User-friendly
 - [ ] Software Design
 - [ ] Data related
 - [ ] Capabilities
-- [ ] Clarity 
+- [ ] Clarity
 - [ ] Workflow
 
 ## Details
 
-*Please provide any other details or desription around your question.*
+*Please provide any other details or description around your question.*
 
-## Example  
+## Example
 
 *If applicable, fill in one of the following.*
 
 ### Code
 
-*Please provide **code** and **output** that the discussion is around.*
+*Please provide the **code** and **output** that you would like to discuss.*
 
-### Installation Process 
+### Installation Process
 
 *Please provide the steps you took to install RST.*
 

--- a/.github/ISSUE_TEMPLATE/documentation_template.md
+++ b/.github/ISSUE_TEMPLATE/documentation_template.md
@@ -4,19 +4,19 @@ about: propose updates to documentation
 
 ---
 
-# Documentation 
+# Documentation
 
 *title or suggestion of documentation*
 
 ## Purpose
 
 - [ ] update
-- [ ] new 
+- [ ] new
 - [ ] remove
 - [ ] typo/grammar change
 - [ ] formatting improvement
 
-## Category 
+## Category
 
 - [ ] code documentation
 - [ ] wiki
@@ -24,14 +24,14 @@ about: propose updates to documentation
 - [ ] installation guide
     - [ ] OS specifics
     - [ ] dependency
-- [ ] Data products information 
+- [ ] data products information
 - [ ] tutorials
     - [ ] plotting
     - [ ] io
     - [ ] data products
 - [ ] examples
 - [ ] citing/licensing
-- [ ] trouble shooting
+- [ ] troubleshooting
     - [ ] installation
     - [ ] tutorials
 - [ ] history

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -1,6 +1,6 @@
 ---
 name: New Feature
-about: Notify that a new feature is being planned
+about: Notify other developers that you intend to add a new feature to the RST
 
 ---
 
@@ -8,50 +8,50 @@ about: Notify that a new feature is being planned
 
 **Name**: *Feature name*
 
-**function**:  *filename.c* 
+**function**:  *filename.c*
 
 **bin/lib**: */directory*
 
-## Scope
+## Description & User Interface
 
-*Create a check list using markdowns [checklist syntax](https://help.github.com/en/github/managing-your-work-on-github/about-task-lists) on the scope of the feature.*
+*Please provide a description of the new feature. What will the feature do/not do?*
 
-*What will the feature do?*
+*Please provide **pseudocode** to demonstrate the new feature's user interface*
 
-*What will the feature not do?* 
+## RST Checklist
 
-## Description
+- [ ] Does the feature fit within RST's scope?
+- Is this a major or minor change?
+    - [ ] Major (e.g. includes large amounts of new code, existing code significantly restructured, or impacts on other RST libraries/binaries)
+    - [ ] Minor (e.g. addition of a new self-contained library)
+-  [ ] Do you need help developing it?
+-  [ ] Have you created a (github project)[https://github.com/SuperDARN/rst/projects] to reflect the process of developing it? (optional)
+-  [ ] Can the code be released under the GPL v3.0 license?
+-  [ ] Does the source code include copyright and authorship information? (can be added later at the pull request stage)
 
-*Please provide a description of the new feature, and whether it will improve/solve a problem.*
+## Development help
 
-### RST Checklist 
-
--  [ ] Does this fit within RST's scope? 
--  [ ] Is this a minor change?
--  [ ] Is this a major change?
--  [ ] Do you need help developing it? 
--  [ ] Have you created a RST project (github project) to reflect the process of developing it? 
--  [ ] Does it follow GPL 3.0v License and has been copyrighted/authored to you? 
-
-### Developement help
-
-*RST does not have a dedicated development team for full feature development. 
-However, if you are able to provide some time and help, the community will try to aid you the best way they can in making your feature possible.*
+*RST does not have a dedicated team for full feature development. However, the community may be able to assist you with development.*
 
 *If you need help please indicate what expertise you are looking for:*
+
 - [ ] developer help with design and integration of code
-- [ ] scientific help with ensuring what you develop is scientifically correct/accurate
-- [ ] project management to help organize what steps need to be taken to make this possible 
+- [ ] scientific help to ensure that the new feature is scientifically sound
+- [ ] project management to help organize the steps involved in adding the new feature to RST
+- [ ] other______
 
-*Please also provide any other information you may need help with (not including testing/reviewers of code)*
+*Note: all code will be tested/reviewed before being merged into the RST codebase.*
 
-## User Interface 
+## Timeline
 
-*Please provide **pseudocode** on how you see your new feature interacting with the code or user-interface*
+*When do you expect the code will be ready for testing?*
+
+*If you need help with development, when do you expect to need help?*
 
 ## Extra Notes
 
 *Please provide any other details about this feature*
-- *publications*
-- *GitHub link of code in another language*
-- *potential solutions to current/future problems*
+
+- *Publications*
+- *GitHub link to code in another language*
+- *Potential solutions to current/future problems*

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -36,7 +36,7 @@ about: Notify other developers that you intend to add a new feature to the RST
 *If you need help please indicate what expertise you are looking for:*
 
 - [ ] developer help with design and integration of code
-- [ ] scientific help to ensure that the new feature is scientifically sound
+- [ ] scientific help to ensure that the new feature produces the expected results
 - [ ] project management to help organize the steps involved in adding the new feature to RST
 - [ ] other______
 

--- a/.github/ISSUE_TEMPLATE/question_template.md
+++ b/.github/ISSUE_TEMPLATE/question_template.md
@@ -6,35 +6,35 @@ about: Ask for help or advice on using RST
 
 # Question
 
-**Question:**
+*What is your question?*
 
 ## Category
 
-- [ ] Usage 
+- [ ] Usage
 - [ ] Troubleshooting
 - [ ] Software Design
 - [ ] Data related
 - [ ] Capabilities
-- [ ] Clarity 
+- [ ] Clarity
 - [ ] Workflow
 
 ## Details
 
-*Please provide any other details or desription around your question.*
+*Please provide any other details relating to your question.*
 
-## Example  
+## Example
 
-*If applicable fill in one of the following.*
+*If applicable, fill in one of the following.*
 
 ### Code
 
-*please provide **pseudocode/code** and **output** that the question is around.*
+*please provide any **pseudocode/code** and **output** that relates to the question.*
 
-### Installation Process 
+### Installation Process
 
 *Please provide the steps you took to install RST.*
 
-*Include your Operating System.* 
+*Include your Operating System.*
 
 ### Documentation
 

--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -1,6 +1,6 @@
 ---
 name: RST Release
-about: 
+about: Checklist for finalizing and testing new RST releases
 
 ---
 
@@ -11,42 +11,44 @@ about:
 - [ ] MAJOR
 
 ## Deadline: *set date*
-If you need more time after the deadline is set, please comment in the Pull Request conversation.
+Please comment in the Pull Request conversation if you need additional time to test the release.
 
 ## Testing
 
 - [ ] Mac OSx
-- [ ] Linux deb - Debian, Ubuntu, Mint 
+- [ ] Linux deb - Debian, Ubuntu, Mint
 - [ ] Linux rpm - OpenSuse, Fedora, CentOS
 
-*highlight  what binaries/libraries that should be focused in test*
+*Do any binaries/libraries require special attention during testing?*
 
 - [ ] `make_fit`
 - [ ] `make_grid`
 - [ ] map potential
-- [ ] read over documentation 
+- [ ] Documentation
+- [ ] Other: ______
+
+*If yes, please provide information about what testers should look for*
 
 ## Checklist
 
-- [ ] update radar.dat (if required)
-- [ ] update hardware files (if required)
-- [ ] `.rst.version` updated
-- [ ] `.zendo.json` update with approved author list
+- [ ] Update `radar.dat` (if required)
+- [ ] Update hardware files (if required)
+- [ ] Update `.rst.version`
+- [ ] Update author list in `.zenodo.json`
 
-## Approvals
-Please *approve* and comment on what Operating System you are using and 
-what you tested
+## Extra Notes
 
-To approve a PR:
-
-1. click on `files changed` top right
-2. click on `start review` green top right  button
-3. Comment in the comment section on Operating System and version 
-with what you have also tested. 
-4. Then select `approve` and `submit review`
-
-## Extra Notes 
-
-*Example info:* 
-- *Are hdw files getting changed?*
+*Example info:*
+- *Do any hardware files need updating?*
 - *Are there new dependencies needed?*
+
+## Approving the release
+
+After testing, please state which operating system you used and what you tested.
+
+If you found no bugs during testing, please *approve* the PR:
+
+1. Click on `files changed` top right
+2. Click on `start review` green top right  button
+3. In the comment box, state which operating system you used for testing, and any other helpful information
+4. Select `approve` and `submit review`


### PR DESCRIPTION
So I really like the new ISSUE and PULL_REQUEST templates that @mts299 created in January :100:

Now that we've been using these for a while, I made some minor updates that I thought might be helpful. Most of this is re-ordering/consolidating sections and rephrasing some text. I also added some new sections to the "new feature" and "deprecation" templates. 

*Note: the base branch is set to `master` for this PR*