### PR TITLE
Consolidating some elevation angle code in FITACF 3.0

### DIFF
--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.c
@@ -18,6 +18,8 @@ modifications:
     2020-03-11 Marina Schmidt (SuperDARN Canada) removed all defined constants 
                               and include rmath.h
     2020-08-12 Marina Schmidt (SuperDARN Canada) removed map function for better decoupling abilities
+    2020-10-29 Marina Schmidt (SuperDARN Canada) & Emma Bland (UNIS) Changed default elevation calculation to elevation_v2()
+    2021-06-01 Emma Bland (UNIS) Consolidated elevation angle calculations into a single function
 */
 
 /*

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.c
@@ -575,7 +575,7 @@ void find_elevation(llist_node range, struct FitData* fit_data, FITPRMS* fit_prm
 
 
 
-void find_elevation_low(llist_node range, struct FitData* fit_data, FITPRMS* fit_prms)
+void find_elevation_error(llist_node range, struct FitData* fit_data, FITPRMS* fit_prms)
 {
     
     double x,y,z;

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.c
@@ -520,7 +520,7 @@ void set_nump(llist_node range, struct FitRange* fit_range_array){
 }
 
 /**
- * @brief      Determines the elevation angle from the fitted XCF phase.
+ * @brief      Determines the elevation angle from (1) lag zero phase and (2) fitted XCF phase.
  *
  * @param[in]  range            A RANGENODE struct.
  * @param      fit_range_array  This struct holds fit results and is used by RST to write out final
@@ -547,6 +547,8 @@ void find_elevation(llist_node range, struct FitData* fit_data, FITPRMS* fit_prm
     fitprm->tdiff = fit_prms->tdiff;
     fitprm->phidiff = fit_prms->phidiff;
 
+    // elevation angle calculated from the lag zero phase is stored in fit_data->elv[range_node->range].normal
+    // elevation angle calculated from the fitted phase is stored in fit_data->elv[range_node->range].high
     // elv_version 2 is the Shepherd [2017] elevation calculation
     // elv_version 1 is original elevation calculation
     // elv_version 0 is specifically for the GBR radar when -old_elev is specified

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.c
@@ -578,7 +578,7 @@ void find_elevation(llist_node range, struct FitData* fit_data, FITPRMS* fit_prm
 }
 
 
-
+// TODO Integrate this calculation into find_elevation() - requires update to elevation library
 void find_elevation_error(llist_node range, struct FitData* fit_data, FITPRMS* fit_prms)
 {
     

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.h
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.h
@@ -118,9 +118,7 @@ void set_gsct(llist_node range, struct FitRange* fit_range_array);
 void set_nump(llist_node range, struct FitRange* fit_range_array);
 
 void find_elevation(llist_node range, struct FitData* fit_data, FITPRMS* fit_prms, int elv_version);
-void find_elevation_high(llist_node range, struct FitData* fit_data, FITPRMS* fit_prms);
 void find_elevation_low(llist_node range, struct FitData* fit_data, FITPRMS* fit_prms);
-
 
 void set_xcf_phi0(llist_node range, struct FitData* fit_data, FITPRMS* fit_prms);
 void set_xcf_phi0_err(llist_node range, struct FitRange* fit_range_array);

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.h
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.h
@@ -18,7 +18,8 @@ modifications:
     2020-03-11 Marina Schmidt (SuperDARN Canada) removed all defined constants 
                               and include rmath.h
     2020-09-01 Marina Schmidt (SuperDARN Canada) removed map function for better decoupling abilities
-
+    2020-10-29 Marina Schmidt (SuperDARN Canada) & Emma Bland (UNIS) Changed default elevation calculation to elevation_v2()
+    2021-06-01 Emma Bland (UNIS) Consolidated elevation angle calculations into a single function
 */
 
 /*

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.h
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.h
@@ -118,7 +118,7 @@ void set_gsct(llist_node range, struct FitRange* fit_range_array);
 void set_nump(llist_node range, struct FitRange* fit_range_array);
 
 void find_elevation(llist_node range, struct FitData* fit_data, FITPRMS* fit_prms, int elv_version);
-void find_elevation_low(llist_node range, struct FitData* fit_data, FITPRMS* fit_prms);
+void find_elevation_error(llist_node range, struct FitData* fit_data, FITPRMS* fit_prms);
 
 void set_xcf_phi0(llist_node range, struct FitData* fit_data, FITPRMS* fit_prms);
 void set_xcf_phi0_err(llist_node range, struct FitRange* fit_range_array);


### PR DESCRIPTION
I found some code in FITACF 3.0 that's no longer needed now that FITACF 3.0 calls the separate `elevation` library. This PR removes that code. 

Key changes are:
- The `find_elevation()` function does both elevation calculations (i.e. from the lag zero phase and the fitted phase).
- Deleted the function `find_elevation_high()`, which previously did the elevation calculation from the fitted phase and was not calling the `elevation` library 
- Renamed the `find_elevation_low()` function to `find_elevation_error()`.
**Note: the least square error estimate is still based on the old elevation algorithm. I did not find a good way to integrate this calculation with the `elevation` library**
- Code comments updated

Please test this for a radar with a simple interferometer offset (Y-component only, e.g. SAS) and also for a radar with a more complicated offset (e.g. ZHO, LYR, HAN). 

```
make_fit -fitacf-version 3.0 [-old_elev] 20150308.1400.03.sas.rawacf > sas.fitacf3
dmapdump -d sas.fitacf3 | grep -A 5 '"elv"' | head -6
```

Comparing this branch with `develop`: 
- [ ] For radars with a simple Y-offset for the interferometer, output files should be identical on both branches
- [ ] For radars with a X or Z offset, there will be some small differences in the `elv_high` parameter (elevation calculated from the fitted phase)
- [ ] If the `-old_elev` option is used, the output files should be the same on both branches for all radars