### PR TITLE
Fixing error when using fov_plot

### DIFF
--- a/codebase/superdarn/src.lib/tk/binplotlib.1.0/include/make_fov.h
+++ b/codebase/superdarn/src.lib/tk/binplotlib.1.0/include/make_fov.h
@@ -24,10 +24,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 Modifications:
 */
 
+struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
+                             float alt,int chisham);
+
 struct PolygonData *make_field_fov(double tval,struct RadarNetwork *network,
                                    int id,int chisham);
 
 struct PolygonData *make_grid_fov(double tval,struct RadarNetwork *network,
                                   int chisham,int old_aacgm);
+
 struct PolygonData *make_grid_fov_data(struct GridData *ptr,struct RadarNetwork *network,
                                        int chisham,int old_aacgm);


### PR DESCRIPTION
This pull request corrects a segmentation fault when trying to execute the `fov_plot` binary.  For example, using the command

```
fov_plot -x -fov -ffov -stereo -coast -grd -st gbr
```

on the `develop` branch will result in a segmentation fault when trying to generate the radar FOVs (ie no output figure), while on this branch it will correctly generate an output FOV figure.  For more usage details, see the `fov_plot` documentation here:

https://superdarn.github.io/rst/superdarn/src.bin/tk/plot/fov_plot/index.html