### PR TITLE
Fixing bug in native IDL OldGridRead function

### DIFF
--- a/codebase/superdarn/src.idl/lib/main.1.25/oldgrd.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/oldgrd.pro
@@ -168,6 +168,7 @@ function OldGridRead,unit,prm,stvec,gvec
       1: BEGIN
         prm.vcnum=npnt
         prm.xtd=1
+        if prm.vcnum eq 0 then break
         gvec=replicate(gvec,prm.vcnum)
         for n=0,npnt-1 do begin
           readf,unit,gmlon,gmlat,kvect,stid,chn,index,vlos,vlos_sd, $
@@ -190,6 +191,7 @@ function OldGridRead,unit,prm,stvec,gvec
       2: BEGIN
         prm.vcnum=npnt
         prm.xtd=0
+        if prm.vcnum eq 0 then break
         gvec=replicate(gvec,prm.vcnum)
         for n=0,npnt-1 do begin
           readf,unit,gmlon,gmlat,kvect,stid,chn,index,vlos,vlos_sd


### PR DESCRIPTION
This pull request fixes a bug when trying to read an old-format (ie not dmap) `grid` file with the native IDL function `OldGridRead` when there are records with no velocity vectors.  On the `develop` branch, one of two errors will be encountered:

```
% OLDGRIDREAD: Array dimensions must be greater than 0.
% Execution halted at: OLDGRIDREAD        171 rst/codebase/superdarn/src.idl/lib/main.1.25/oldgrd.pro
```

```
% OLDGRIDREAD: Array dimensions must be greater than 0.
% Execution halted at: OLDGRIDREAD        193 rst/codebase/superdarn/src.idl/lib/main.1.25/oldgrd.pro
```

depending on whether or not the record is expected to contain the extra power and spectral width information included when setting the `-xtd` flag with `make_grid`.

To test, something like the following can be used:

```
IDL> fname = 'yyyymmdd.awesomeradar.grid'
IDL> inp = OldGridOpen(fname, /read)
IDL> ret = OldGridRead(inp, prm, stvec, gvec)
```

(please make sure that the DLM version of `OldGridRead` is not being used)