### PR TITLE
Modifying make.code to build the idl subdirectory

### DIFF
--- a/build/script/make.code
+++ b/build/script/make.code
@@ -150,24 +150,22 @@ mkdir -p ${LOGPATH}
 makemodule hdr ${BUILD}/script/build.txt
 makemodule lib ${BUILD}/script/build.txt
 makemodule bin ${BUILD}/script/build.txt
-if [ -r ${IDL_IPATH}/idl_export.h ]
-then 
-  makemodule dlm ${BUILD}/script/build.txt
+if [ -r ${IDL_IPATH}/idl_export.h ]; then makemodule dlm ${BUILD}/script/build.txt; fi
 
-  mkdir -p ${RSTPATH}/idl
-  mkdir -p ${RSTPATH}/idl/lib
-  mkdir -p ${RSTPATH}/idl/app
+mkdir -p ${RSTPATH}/idl
+mkdir -p ${RSTPATH}/idl/lib
+mkdir -p ${RSTPATH}/idl/app
 
-  cd ${RSTPATH}/idl/lib
-  if ! [ -L analysis ]; then ln -svf ../../codebase/analysis/src.idl/lib analysis; fi
-  if ! [ -L general ]; then ln -svf ../../codebase/general/src.idl/lib general; fi
-  if ! [ -L superdarn ]; then  ln -svf ../../codebase/superdarn/src.idl/lib superdarn; fi
+cd ${RSTPATH}/idl/lib
+if ! [ -L analysis ]; then ln -svf ../../codebase/analysis/src.idl/lib analysis; fi
+if ! [ -L general ]; then ln -svf ../../codebase/general/src.idl/lib general; fi
+if ! [ -L superdarn ]; then  ln -svf ../../codebase/superdarn/src.idl/lib superdarn; fi
 
-  cd ${RSTPATH}/idl/app
-  if ! [ -L superdarn ]; then ln -svf ../../codebase/superdarn/src.idl/app superdarn; fi
+cd ${RSTPATH}/idl/app
+if ! [ -L superdarn ]; then ln -svf ../../codebase/superdarn/src.idl/app superdarn; fi
 
-  cd ${RSTPATH}/idl
-  if ! [ -L startup.pro ]; then ln -svf ../codebase/superdarn/src.idl/startup/startup.pro startup.pro; fi
-fi
+cd ${RSTPATH}/idl
+if ! [ -L startup.pro ]; then ln -svf ../codebase/superdarn/src.idl/startup/startup.pro startup.pro; fi
+
 exit 0
 


### PR DESCRIPTION
This pull request modifies the behavior of `make.code` such that the `idl` subdirectory is populated at the end of the compilation process even if the `idl_export.h` file cannot be found and the DLMs are skipped over.  This is because the IDL libraries can still be used with open-source alternatives to IDL such as [GNU Data Language (GDL)](https://github.com/gnudatalanguage/gdl) even if the proprietary `idl_export.h` file is not available.  For example, on this branch a user can rename the `IDL_STARTUP` environment variable in the `idl.bash` file to `GDL_STARTUP` and have access to all of the same functionality as in IDL (minus the DLM speed).