### PR TITLE
[Ehn]Add rst version to origin command

### DIFF
--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -81,10 +81,37 @@ int RadarParmSetOriginTime(struct RadarParm *ptr,char *str) {
 
 }
 
+char* GetRSTVersion() {
 
+  char *rst_path=NULL;
+  char *rst_version = malloc(120 * sizeof(char));
+  char vname[256];
+  char buff[100];
+  FILE *vfp=NULL;
+
+  rst_path=getenv("RSTPATH");
+  strcpy(vname, rst_path);
+  strcat(vname, "/.rst.version");
+
+  vfp=fopen(vname, "r");
+
+  if (vfp != NULL) {
+    while (fscanf(vfp,"%s",buff)==1); 
+    strcat(rst_version, " RST Version: ");
+    strcat(rst_version, buff);
+    fclose(vfp);
+  } else {
+    fprintf(stderr, "RST version file %s not found\n", vname);
+    return NULL;
+  }
+
+  return rst_version;
+
+}
 
 int RadarParmSetOriginCommand(struct RadarParm *ptr,char *str) {
   char *tmp=NULL;
+  char *rst_version;
   if (ptr==NULL) return -1;
 
   if (str==NULL) {
@@ -93,11 +120,17 @@ int RadarParmSetOriginCommand(struct RadarParm *ptr,char *str) {
     return 0;
   }
 
-  if (ptr->origin.command==NULL) tmp=malloc(strlen(str)+1);
-  else tmp=realloc(ptr->origin.command,strlen(str)+1);
+  rst_version = GetRSTVersion();
+  if (ptr->origin.command==NULL) 
+      tmp=malloc(strlen(str)+strlen(rst_version));
+  else 
+      tmp=realloc(ptr->origin.command,strlen(str)+strlen(rst_version));
 
-  if (tmp==NULL) return -1;
+  // TODO: add error code or message?
+  if (tmp==NULL) 
+      return -1;
   strcpy(tmp,str);
+  strcat(tmp, rst_version);
   ptr->origin.command=tmp;
   return 0;
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -140,7 +140,6 @@ int RadarParmSetOriginCommand(struct RadarParm *ptr,char *str) {
   if (ptr->origin.command==NULL) {
       //fprintf(stderr, "before malloc\n");
       tmp=malloc(strlen(str)+strlen(rst_version));
-      //fprintf(stderr, "tmp extended\n");
   }
   else 
       tmp=realloc(ptr->origin.command,strlen(str)+strlen(rst_version));

--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -94,7 +94,8 @@ int RadarParmSetOriginTime(struct RadarParm *ptr,char *str) {
 char* GetRSTVersion() {
 
   char *rst_path=NULL;
-  char *rst_version = malloc(120 * sizeof(char));
+  //fprintf(stderr, "rst_version\n");
+  char *rst_version = malloc(80);
   char vname[256];
   char buff[100];
   // used the save the .rst_version file
@@ -127,15 +128,20 @@ int RadarParmSetOriginCommand(struct RadarParm *ptr,char *str) {
   char *rst_version;
   if (ptr==NULL) return -1;
 
+  // is this a sensible check? 
   if (str==NULL) {
-    if (ptr->origin.command !=NULL) free(ptr->origin.command);
+    if (ptr->origin.command !=NULL) 
+        free(ptr->origin.command);
     ptr->origin.command=NULL;
     return 0;
   }
 
   rst_version = GetRSTVersion();
-  if (ptr->origin.command==NULL) 
+  if (ptr->origin.command==NULL) {
+      //fprintf(stderr, "before malloc\n");
       tmp=malloc(strlen(str)+strlen(rst_version));
+      //fprintf(stderr, "tmp extended\n");
+  }
   else 
       tmp=realloc(ptr->origin.command,strlen(str)+strlen(rst_version));
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -82,12 +82,22 @@ int RadarParmSetOriginTime(struct RadarParm *ptr,char *str) {
 
 }
 
+/*
+ * GetRSTVersion 
+ * Get the rst version from the .rst_version file 
+ * 
+ * return:
+ *  rst_version char * of the version number of RST 
+ *  if the version is not found then NULL is returned 
+ *  and error message appears. 
+ */
 char* GetRSTVersion() {
 
   char *rst_path=NULL;
   char *rst_version = malloc(120 * sizeof(char));
   char vname[256];
   char buff[100];
+  // used the save the .rst_version file
   FILE *vfp=NULL;
 
   rst_path=getenv("RSTPATH");
@@ -97,11 +107,13 @@ char* GetRSTVersion() {
   vfp=fopen(vname, "r");
 
   if (vfp != NULL) {
+    // read the .rst_version file 
     while (fscanf(vfp,"%s",buff)==1); 
     strcat(rst_version, " RST Version: ");
     strcat(rst_version, buff);
     fclose(vfp);
   } else {
+    // could not find the .rst_version file! 
     fprintf(stderr, "RST version file %s not found\n", vname);
     return NULL;
   }

--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -110,7 +110,7 @@ char* GetRSTVersion() {
   if (vfp != NULL) {
     // read the .rst_version file 
     while (fscanf(vfp,"%s",buff)==1); 
-    strcat(rst_version, " RST Version: ");
+    strcat(rst_version, " -- RST Version: ");
     strcat(rst_version, buff);
     fclose(vfp);
   } else {
@@ -559,4 +559,3 @@ int RadarParmExpand(struct RadarParm *ptr,void *buffer) {
 
   return 0;
 }
-

--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -21,6 +21,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 Modifications:
+2020-06-10 Marina Schmidt (SuperDARN Canada) Added GetRSTVersion function to append RST version to origin.command
 */
 
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -138,7 +138,6 @@ int RadarParmSetOriginCommand(struct RadarParm *ptr,char *str) {
 
   rst_version = GetRSTVersion();
   if (ptr->origin.command==NULL) {
-      //fprintf(stderr, "before malloc\n");
       tmp=malloc(strlen(str)+strlen(rst_version));
   }
   else 


### PR DESCRIPTION
# Scope 

When using `make_fit` and `dattorawacf` it adds the RST version into the `origin.command` at the end. 

**issue**: #422 

## Approval: 1 - simple fix 

## Test

``` bash
make_fit 20180404.0200.12.lyr.rawacf > test.fitacf
dmapdump test.fitacf | grep origin.command | head -n 1
	string	"origin.command" = "make_fit 20180404.0200.12.lyr.rawacf RST Version: 4.5"
```

``` bash
dattorawacf 2005050520d.dat > test.rawacf
dmapdump test.rawacf | grep origin.command | head -n 1
	string	"origin.command" = "dattorawacf 2005050520d.dat RST Version: 4.5"
```
