### PR TITLE
[Ehn] Remove partial records

### DIFF
--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fitwrite.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fitwrite.c
@@ -18,6 +18,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 Modifications:
+2921-06-10 Marina Schmidt (SuperDARN Canada) removed the qflg check that
+causes partial records to be written
 */
 
 #include <stdio.h>
@@ -114,8 +116,9 @@ int FitEncode(struct DataMap *ptr,struct RadarParm *prm, struct FitData *fit) {
 
   snum=0;
   for (c=0;c<prm->nrang;c++) {
-    if ( (fit->rng[c].qflg==1) ||
-         ((fit->xrng !=NULL) && (fit->xrng[c].qflg==1))) snum++;
+    if (((fit->xrng !=NULL)) 
+            snum++;
+            break;
   }
 
   if (prm->xcf !=0) xnum=snum;

--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fitwrite.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fitwrite.c
@@ -119,7 +119,6 @@ int FitEncode(struct DataMap *ptr,struct RadarParm *prm, struct FitData *fit) {
     if (fit->xrng !=NULL)
     {
             snum++;
-            break;
     }
   }
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fitwrite.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fitwrite.c
@@ -116,9 +116,11 @@ int FitEncode(struct DataMap *ptr,struct RadarParm *prm, struct FitData *fit) {
 
   snum=0;
   for (c=0;c<prm->nrang;c++) {
-    if (((fit->xrng !=NULL)) 
+    if (fit->xrng !=NULL)
+    {
             snum++;
             break;
+    }
   }
 
   if (prm->xcf !=0) xnum=snum;


### PR DESCRIPTION
# Scope 

Removing partial records from FITACF files which may remove partial records for GRID and MAP files (still need to double-check but will make a PR for the others if its something else)

# TEST

On `develop`
```bash
make_fit 20180404.0200.12.lyr.rawacf > test.fitacf 
dmapdump test.fitacf | less
```
I search `/ptab`
```
        float   "noise.sky" = 508.299988
        float   "noise.lag0" = 0.000000
        float   "noise.vel" = 0.000000
arrays:
        short   "ptab" [7]
        short   "ltab" [19][2]
        float   "pwr0" [70]
scalars:
        char    "radar.revision.major" = 1
        char    "radar.revision.minor" = 1
        char    "origin.code" = 1
        string  "origin.time" = "Thu Jun 10 23:14:58 2021"
        string  "origin.command" = "make_fit 20180404.0200.12.lyr.rawacf"
        short   "cp" = 153
```
On `ehn/remove_partial_record`

```bash
make_fit 20180404.0200.12.lyr.rawacf > test.fitacf 
dmapdump test.fitacf | less
```
I search `/ptab`
```bash
      short   "ptab" [7]
        short   "ltab" [19][2]
        float   "pwr0" [70]
        short   "slist" [70]
        short   "nlag" [70]
        char    "qflg" [70]
        char    "gflg" [70]
        float   "p_l" [70]
        float   "p_l_e" [70]
        float   "p_s" [70]
```
you will notice there are now variables where they were missing before 