### PR TITLE
Fixing segmentation fault in fov_plot when using -dot with invalid date

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
@@ -953,6 +953,7 @@ int main(int argc,char *argv[]) {
        if (network->radar[i].id==stid) continue;
        if (network->radar[i].status !=0) continue;
        site=RadarYMDHMSGetSite(&(network->radar[i]),yr,mo,dy,hr,mt,sc);
+       if (site == NULL) continue;
        if (magflg) {
          if (old_aacgm) {
            s=AACGMConvert(site->geolat,site->geolon,300,&mlat,&mlon,&r,0);
@@ -979,6 +980,7 @@ int main(int argc,char *argv[]) {
        if (network->radar[i].id==stid) continue;
        if (network->radar[i].status !=1) continue;
        site=RadarYMDHMSGetSite(&(network->radar[i]),yr,mo,dy,hr,mt,sc);
+       if (site == NULL) continue;
        if (magflg) {
          if (old_aacgm) {
            s=AACGMConvert(site->geolat,site->geolon,300,&mlat,&mlon,&r,0);
@@ -1004,24 +1006,26 @@ int main(int argc,char *argv[]) {
    if (fovflg) {
      
      site=RadarYMDHMSGetSite(&(network->radar[stnum]),yr,mo,dy,hr,mt,sc);
-     if (magflg) {
-       if (old_aacgm) {
-         s=AACGMConvert(site->geolat,site->geolon,300,&mlat,&mlon,&r,0);
-         pnt[0]=mlat;
-         pnt[1]=mlon;
+     if (site !=NULL) {
+       if (magflg) {
+         if (old_aacgm) {
+           s=AACGMConvert(site->geolat,site->geolon,300,&mlat,&mlon,&r,0);
+           pnt[0]=mlat;
+           pnt[1]=mlon;
+         } else {
+           s=AACGM_v2_Convert(site->geolat,site->geolon,300,&mlat,&mlon,&r,0);
+           pnt[0]=mlat;
+           pnt[1]=mlon;
+         }
        } else {
-         s=AACGM_v2_Convert(site->geolat,site->geolon,300,&mlat,&mlon,&r,0);
-         pnt[0]=mlat;
-         pnt[1]=mlon;
+         pnt[0]=site->geolat;
+         pnt[1]=site->geolon;
        }
-     } else {
-       pnt[0]=site->geolat;
-       pnt[1]=site->geolon;
+       s=(*tfunc)(sizeof(float)*2,pnt,2*sizeof(float),pnt,marg);
+       if (s==0) PlotEllipse(plot,NULL,pad+pnt[0]*(wdt-2*pad),
+                      pad+pnt[1]*(hgt-2*pad),dotr,dotr,
+                      1,ffovcol,0x0f,0,NULL);
      }
-     s=(*tfunc)(sizeof(float)*2,pnt,2*sizeof(float),pnt,marg);
-     if (s==0) PlotEllipse(plot,NULL,pad+pnt[0]*(wdt-2*pad),
-                    pad+pnt[1]*(hgt-2*pad),dotr,dotr,
-                    1,ffovcol,0x0f,0,NULL);
    }
 
 


### PR DESCRIPTION
This pull request fixes a bug in `fov_plot` causing a segmentation fault when using the `-dot` command line option and the radar site information cannot be found.  For example, on the develop branch the following command will generate a valid figure (note the date is before the SCH radar end date):

```
fov_plot -x -st sch -d 19950101 -fov -ffov -coast -stereo -latmin 30 -fcoast -grd -grdontop -dot
```

![sch_dot](https://user-images.githubusercontent.com/1869073/122148332-53826400-ce28-11eb-82c7-2f9a8510f69a.png)

while this second command will cause a segmentation fault (note the date is after the SCH radar end date):

```
fov_plot -x -st sch -d 19960101 -fov -ffov -coast -stereo -latmin 30 -fcoast -grd -grdontop -dot
```

The same behavior (ie segmentation fault) occurs on the `develop` branch for dates before a radar's official start date as well.  On this branch however, the latter statement will generate a valid figure (without a radar FOV or dot) as expected.

![sch_empty](https://user-images.githubusercontent.com/1869073/122148342-5715eb00-ce28-11eb-92f8-591eaed575d5.png)