### PR TITLE
More fixes to fov_plot

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/doc/fov_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/doc/fov_plot.doc.xml
@@ -152,6 +152,8 @@
 </option>
 <option><on>-yoff <ar>yoff</ar></on><od>open the window <ar>ypad</ar> pixels from the top edge of the screen.</od>
 </option>
+<option><on>-time</on><od>plot the date and time of the plotted field of view.</od>
+</option>
 <option><on>-chisham</on><od>use the Chisham virtual height model.</od>
 </option>
 <synopsis><p>Plot the radar fields of view.</p></synopsis>

--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
@@ -75,6 +75,8 @@ Modifications:
 #include "sza.h"
 #include "szamap.h"
 #include "clip.h"
+#include "plot_time.h"
+#include "plot_logo.h"
 
 
 #include "hlpstr.h"
@@ -335,6 +337,7 @@ int main(int argc,char *argv[]) {
   unsigned char grdontop=0;
 
   unsigned char dotflg=0;
+  unsigned char tmeflg=0;
 
   int tmtick=3;
 
@@ -520,8 +523,7 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"grd",'x',&grdflg);
   OptionAdd(&opt,"tmk",'x',&tmkflg);
 
- OptionAdd(&opt,"grdontop",'x',&grdontop);
-
+  OptionAdd(&opt,"grdontop",'x',&grdontop);
 
   OptionAdd(&opt,"fov",'x',&fovflg);
   OptionAdd(&opt,"ffov",'x',&ffovflg);
@@ -567,6 +569,8 @@ int main(int argc,char *argv[]) {
 
   OptionAdd(&opt,"dotr",'f',&dotr);
   OptionAdd(&opt,"dot",'x',&dotflg);
+
+  OptionAdd(&opt,"time",'x',&tmeflg);
 
   OptionAdd(&opt,"old_aacgm",'x',&old_aacgm);
 
@@ -1072,6 +1076,12 @@ int main(int argc,char *argv[]) {
                            (wdt/2)-pad,6,
                            txtcol,0x0f,fontname,fontsize,fontdb);
   }
+
+  if (tmeflg) plot_time(plot,5,5,wdt-10,hgt-10,tval,
+                        txtcol,0x0f,"Helvetica",12.0,fontdb);
+
+  if (magflg) plot_aacgm(plot,4,4,wdt-8,wdt-8,txtcol,0x0f,"Helvetica",
+                         7.0,fontdb,old_aacgm);
 
   PlotPlotEnd(plot);  
   PlotDocumentEnd(plot);

--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
@@ -269,7 +269,7 @@ int main(int argc,char *argv[]) {
   char *cfname=NULL;
   FILE *fp;
 
-
+  struct RadarSite *site;
 
   float wdt=540,hgt=540;
   float pad=0;
@@ -425,7 +425,7 @@ int main(int argc,char *argv[]) {
   bnd=MapBndFread(mapfp);
   fclose(mapfp);
 
- envstr=getenv("SD_RADAR");
+  envstr=getenv("SD_RADAR");
   if (envstr==NULL) {
     fprintf(stderr,"Environment variable 'SD_RADAR' must be defined.\n");
     exit(-1);
@@ -677,6 +677,17 @@ int main(int argc,char *argv[]) {
  
   if (tmkflg) tmk=make_grid(30*tmtick,10,cylind);
 
+  if (ststr !=NULL) stid=RadarGetID(network,ststr);
+  for (stnum=0;stnum<network->rnum;stnum++) {
+    if (network->radar[stnum].id==stid) {
+      if ((lat<0) != (network->radar[stnum].site[0].geolat<0)) {
+        lat=-lat;
+      }
+      break;
+    }
+  }
+  if (stnum==network->rnum) stnum=0;
+
   if ((lat<0) && (latmin>0)) latmin=-latmin;
   if ((lat>0) && (latmin<0)) latmin=-latmin;
 
@@ -814,14 +825,6 @@ int main(int argc,char *argv[]) {
    exit(-1);
   }
 
-
-  if (ststr !=NULL) stid=RadarGetID(network,ststr);
-  for (stnum=0;stnum<network->rnum;stnum++) 
-     if (stid==network->radar[stnum].id) break;  
-  if (stnum==network->rnum) stnum=0;
-
-
-
   /* now determine our output type */
 
   if (psflg) pflg=1;
@@ -949,7 +952,6 @@ int main(int argc,char *argv[]) {
 
  if (dotflg) {
    int s=0;
-   struct RadarSite *site;
    float pnt[2];
    double mlat,mlon,r;
    if (cfovflg | fcfovflg)  {

--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
@@ -1052,7 +1052,7 @@ int main(int argc,char *argv[]) {
                                 ptmk,1);
 
   if ((grdflg) && (grdontop)) {
-    MapPlotPolygon(plot,NULL,0,0,wdt-2*pad,hgt-2*pad,0,
+    MapPlotPolygon(plot,NULL,pad,pad,wdt-2*pad,hgt-2*pad,0,
                                 grdcol,0x0f,width,NULL,
                                 pgrd,1);
   }

--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/makefile
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/makefile
@@ -6,9 +6,9 @@ include $(MAKECFG).$(SYSTEM)
 INCLUDE = -I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/analysis \
           -I$(IPATH)/imagery -I$(IPATH)/superdarn 
  
-SRC = hlpstr.h fov_plot.c errstr.h clip.c clip.h
+SRC = hlpstr.h fov_plot.c errstr.h clip.c clip.h plot_time.c plot_time.h
  
-OBJS = clip.o fov_plot.o  
+OBJS = clip.o plot_time.o fov_plot.o  
 DSTPATH = $(BINPATH)
 OUTPUT = fov_plot
 LIBS = -lbinplot.1 -lrpos.1 -lradar.1 -lsza.1 -lszamap.1 -laacgm.1 -lmlt.1 -lastalg.1 \

--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/plot_time.c
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/plot_time.c
@@ -1,0 +1,92 @@
+/* plot_time.c
+   =========== 
+   Author: R.J.Barnes
+*/
+
+
+/*
+ Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+This file is part of the Radar Software Toolkit (RST).
+
+RST is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+Modifications:
+*/
+
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <ctype.h>
+
+#include "rfbuffer.h"
+#include "iplot.h"
+#include "rtime.h"
+#include "text_box.h"
+
+
+
+void plot_time(struct Plot *plot,
+               float xoff,float yoff,float wdt,float hgt,
+               double time,
+               unsigned int color,unsigned char mask,
+               char *fontname,float fontsize,
+               void *txtdata) {
+  int i;
+  char txt[256];
+  float txbox[3];
+  char *month[]={"Jan","Feb","Mar","Apr","May","Jun",
+               "Jul","Aug","Sep","Oct","Nov","Dec",0};
+  char *tmeA="00:00:00 UT";
+  char *tmeC="0";
+  float cwdt;
+  float x,y;
+  int yr,mo,dy,hr,mt;
+  double sec;
+
+  txtbox(fontname,fontsize,strlen(tmeC),tmeC,txbox,txtdata);
+  cwdt=txbox[0];
+
+  TimeEpochToYMDHMS(time,&yr,&mo,&dy,&hr,&mt,&sec);
+
+  sprintf(txt,"%.2d %s %d",dy,month[mo-1],yr);
+  txtbox(fontname,fontsize,strlen(txt),txt,txbox,txtdata);
+  x=xoff;
+  y=yoff+txbox[2];
+  for (i=0;txt[i] !=0;i++) {
+    txtbox(fontname,fontsize,1,txt+i,txbox,txtdata);
+    PlotText(plot,NULL,fontname,fontsize,x,
+              y,1,txt+i,color,mask,1);
+    if (isdigit(txt[i])) x+=cwdt;
+    else x+=txbox[0];
+  }
+
+  sprintf(txt,"%.2d:%.2d UT",hr,mt);
+
+  txtbox(fontname,fontsize,strlen(tmeA),tmeA,txbox,txtdata);
+
+  x=xoff+wdt-txbox[0];
+  y=yoff+txbox[2];
+  for (i=0;txt[i] !=0;i++) {
+    txtbox(fontname,fontsize,1,txt+i,txbox,txtdata);
+    PlotText(plot,NULL,fontname,fontsize,x,
+              y,1,txt+i,color,mask,1);
+    if (isdigit(txt[i])) x+=cwdt;
+    else x+=txbox[0];
+  }
+}
+

--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/plot_time.h
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/plot_time.h
@@ -1,0 +1,34 @@
+/* plot_time.h
+   ===========
+   Author: R.J.Barnes
+*/
+
+/*
+  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+ 
+This file is part of the Radar Software Toolkit (RST).
+
+RST is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+Modifications:
+*/ 
+
+
+
+void plot_time(struct Plot *plot,
+               float xoff,float yoff,float wdt,float hgt,
+               double time,
+               unsigned int color,unsigned char mask,
+               char *fontname,float fontsize,
+               void *txtdata);


### PR DESCRIPTION
This pull request makes a few more fixes to `fov_plot` (apologies for not including these all in one pull request).

First, this pull request adds date and time labels via the new `-time` flag (similar to `grid_plot` and `map_plot`), eg

```
fov_plot -x -fov -ffov -coast -stereo -fcoast -grd -grdontop -dot -d 19950101 -t 06:30 -st sch -time
```

![time_label](https://user-images.githubusercontent.com/1869073/122273377-61c79300-ceaf-11eb-9110-4d6ccb26b0cb.png)

Next, this pull request adds an `AACGM_v2` label to the bottom-right corner of the plot when using the `-mag` flag, or an `AACGM` label with the `-mag` and `-old_aacgm` flags (again similar to `grid_plot` and `map_plot`), eg

```
fov_plot -x -fov -ffov -coast -stereo -fcoast -grd -grdontop -dot -d 19950101 -t 06:30 -st sch -mag
```

![aacgm_v2_label](https://user-images.githubusercontent.com/1869073/122273542-891e6000-ceaf-11eb-950b-4c768b1470e2.png)

```
fov_plot -x -fov -ffov -coast -stereo -fcoast -grd -grdontop -dot -d 19950101 -t 06:30 -st sch -mag -old_aacgm
```

![aacgm_label](https://user-images.githubusercontent.com/1869073/122273547-8c195080-ceaf-11eb-998d-b30f02cef38c.png)

Finally, this pull request fixes a bug when using both the `-grdontop` and `tmlbl` flags together causing the plotted grids to be misaligned.  For example, the following command on the `develop` branch will cause the grids to be misaligned, eg

```
fov_plot -fov -ffov -coast -fcoast -stereo -grd -grdontop -dot -d 19950101 -t 06:30 -time -st sch -tmlbl
```

![tmlbl_old](https://user-images.githubusercontent.com/1869073/122273840-e5817f80-ceaf-11eb-8ff1-623922e96373.png)

while on this branch the bug will be fixed, eg

![tmlbl_new](https://user-images.githubusercontent.com/1869073/122273852-e9ad9d00-ceaf-11eb-933a-562b9c87325f.png)

(note - keeping this as a draft for now in case any other unexpected bugs appear)