### PR TITLE
Multi-radar FOV plots with fov_plot

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/doc/fov_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/doc/fov_plot.doc.xml
@@ -129,7 +129,7 @@
 </option>
 <option><on>-t <ar>hr:mn</ar></on><od>plot for the time <ar>hr:mn</ar>.</od>
 </option>
-<option><on>-st <ar>stid</ar></on><od>plot the field of view for the radar with the station identifier <ar>stid</ar>.</od>
+<option><on>-st <ar>stid...</ar></on><od>plot the fields of view for the radars listed in <ar>stid</ar> which is a comma separated list of station identifier codes.</od>
 </option>
 <option><on>-png</on><od>produce a Portable Network Graphics (PNG) image as the output.</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
@@ -403,8 +403,10 @@ int main(int argc,char *argv[]) {
   float dotr=2; 
  
   int stid=-1;
+  int st_cnt=0;
   char *ststr=NULL;
-  int stnum=0;
+  int stnum[64];
+  int *rad=NULL;
 
   char tsfx[16];
 
@@ -677,16 +679,29 @@ int main(int argc,char *argv[]) {
  
   if (tmkflg) tmk=make_grid(30*tmtick,10,cylind);
 
-  if (ststr !=NULL) stid=RadarGetID(network,ststr);
-  for (stnum=0;stnum<network->rnum;stnum++) {
-    if (network->radar[stnum].id==stid) {
-      if ((lat<0) != (network->radar[stnum].site[0].geolat<0)) {
-        lat=-lat;
+  rad=calloc(network->rnum,sizeof(int));
+
+  if (ststr !=NULL) {
+    char *tmp;
+    tmp=strtok(ststr,",");
+    do {
+      stid=RadarGetID(network,tmp);
+      if (stid !=-1) {
+        for (i=0;i<network->rnum;i++) {
+          if (network->radar[i].id==stid) {
+            if ((lat<0) != (network->radar[i].site[0].geolat<0)) {
+              lat=-lat;
+            }
+            rad[i]=1;
+            stnum[st_cnt]=i;
+            break;
+          }
+        }
+        if (i==network->rnum) stnum[st_cnt]=0;
+        st_cnt++;
       }
-      break;
-    }
+    } while ((tmp=strtok(NULL,",")) !=NULL);
   }
-  if (stnum==network->rnum) stnum=0;
 
   if ((lat<0) && (latmin>0)) latmin=-latmin;
   if ((lat>0) && (latmin<0)) latmin=-latmin;
@@ -892,7 +907,7 @@ int main(int argc,char *argv[]) {
   
   if (fofovflg) {
     for (i=0;i<network->rnum;i++) {
-      if (network->radar[i].id==stid) continue;
+      if (rad[i]==1) continue;
       if (network->radar[i].status !=1) continue;
       MapPlotPolygon(plot,NULL,pad,pad,
                    wdt-2*pad,hgt-2*pad,1,fofovcol,0x0f,0,NULL,pfov,i); 
@@ -901,7 +916,7 @@ int main(int argc,char *argv[]) {
 
   if (fcfovflg) {
     for (i=0;i<network->rnum;i++) {
-      if (network->radar[i].id==stid) continue;
+      if (rad[i]==1) continue;
       if (network->radar[i].status!=0) continue;
       MapPlotPolygon(plot,NULL,pad,pad,wdt-2*pad,hgt-2*pad,1,
                        fcfovcol,0x0f,0,NULL,pfov,i); 
@@ -910,8 +925,10 @@ int main(int argc,char *argv[]) {
 
 
    if (ffovflg) {
-    MapPlotPolygon(plot,NULL,pad,pad,
-                 wdt-2*pad,hgt-2*pad,1,ffovcol,0x0f,0,NULL,pfov,stnum); 
+     for (i=0;i<st_cnt;i++) {
+       MapPlotPolygon(plot,NULL,pad,pad,
+                      wdt-2*pad,hgt-2*pad,1,ffovcol,0x0f,0,NULL,pfov,stnum[i]);
+     }
    }
   
 
@@ -931,7 +948,7 @@ int main(int argc,char *argv[]) {
 
   if (ofovflg)  {
     for (i=0;i<network->rnum;i++) {
-      if (network->radar[i].id==stid) continue;
+      if (rad[i]==1) continue;
       if (network->radar[i].status !=1) continue;
       MapPlotPolygon(plot,NULL,pad,pad,wdt-2*pad,hgt-2*pad,0,
                     ofovcol,0x0f,width,NULL,
@@ -942,7 +959,7 @@ int main(int argc,char *argv[]) {
  if (cfovflg)  {
    
     for (i=0;i<network->rnum;i++) {
-      if (network->radar[i].id==stid) continue;
+      if (rad[i]==1) continue;
       if (network->radar[i].status !=0) continue;
       MapPlotPolygon(plot,NULL,pad,pad,wdt-2*pad,hgt-2*pad,0,
                     cfovcol,0x0f,width,NULL,
@@ -956,7 +973,7 @@ int main(int argc,char *argv[]) {
    double mlat,mlon,r;
    if (cfovflg | fcfovflg)  {
      for (i=0;i<network->rnum;i++) {
-       if (network->radar[i].id==stid) continue;
+       if (rad[i]==1) continue;
        if (network->radar[i].status !=0) continue;
        site=RadarYMDHMSGetSite(&(network->radar[i]),yr,mo,dy,hr,mt,sc);
        if (site == NULL) continue;
@@ -983,7 +1000,7 @@ int main(int argc,char *argv[]) {
    }
    if (ofovflg | fofovflg)  {
      for (i=0;i<network->rnum;i++) {
-       if (network->radar[i].id==stid) continue;
+       if (rad[i]==1) continue;
        if (network->radar[i].status !=1) continue;
        site=RadarYMDHMSGetSite(&(network->radar[i]),yr,mo,dy,hr,mt,sc);
        if (site == NULL) continue;
@@ -1010,36 +1027,41 @@ int main(int argc,char *argv[]) {
    }
 
    if (fovflg) {
-     
-     site=RadarYMDHMSGetSite(&(network->radar[stnum]),yr,mo,dy,hr,mt,sc);
-     if (site !=NULL) {
-       if (magflg) {
-         if (old_aacgm) {
-           s=AACGMConvert(site->geolat,site->geolon,300,&mlat,&mlon,&r,0);
-           pnt[0]=mlat;
-           pnt[1]=mlon;
+     for (i=0;i<st_cnt;i++) {
+       site=RadarYMDHMSGetSite(&(network->radar[stnum[i]]),yr,mo,dy,hr,mt,sc);
+       if (site !=NULL) {
+         if (magflg) {
+           if (old_aacgm) {
+             s=AACGMConvert(site->geolat,site->geolon,300,&mlat,&mlon,&r,0);
+             pnt[0]=mlat;
+             pnt[1]=mlon;
+           } else {
+             s=AACGM_v2_Convert(site->geolat,site->geolon,300,&mlat,&mlon,&r,0);
+             pnt[0]=mlat;
+             pnt[1]=mlon;
+           }
          } else {
-           s=AACGM_v2_Convert(site->geolat,site->geolon,300,&mlat,&mlon,&r,0);
-           pnt[0]=mlat;
-           pnt[1]=mlon;
+           pnt[0]=site->geolat;
+           pnt[1]=site->geolon;
          }
-       } else {
-         pnt[0]=site->geolat;
-         pnt[1]=site->geolon;
+         s=(*tfunc)(sizeof(float)*2,pnt,2*sizeof(float),pnt,marg);
+         if (s==0) PlotEllipse(plot,NULL,pad+pnt[0]*(wdt-2*pad),
+                        pad+pnt[1]*(hgt-2*pad),dotr,dotr,
+                        1,ffovcol,0x0f,0,NULL);
        }
-       s=(*tfunc)(sizeof(float)*2,pnt,2*sizeof(float),pnt,marg);
-       if (s==0) PlotEllipse(plot,NULL,pad+pnt[0]*(wdt-2*pad),
-                      pad+pnt[1]*(hgt-2*pad),dotr,dotr,
-                      1,ffovcol,0x0f,0,NULL);
      }
    }
 
 
  }
 
-  if (fovflg) MapPlotPolygon(plot,NULL,pad,pad,wdt-2*pad,hgt-2*pad,0,
-                    fovcol,0x0f,width,NULL,
-                    pfov,stnum);
+  if (fovflg) {
+    for (i=0;i<st_cnt;i++) {
+      MapPlotPolygon(plot,NULL,pad,pad,wdt-2*pad,hgt-2*pad,0,
+                     fovcol,0x0f,width,NULL,
+                     pfov,stnum[i]);
+    }
+  }
 
   if (bndflg) MapPlotOpenPolygon(plot,NULL,pad,pad,wdt-2*pad,hgt-2*pad,
                                 bndcol,0x0f,width,NULL,

--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
@@ -23,6 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 Modifications:
+  2021-06 E.G.Thomas (Dartmouth College), bug fixes, multi-radar FOVs, etc
 */
 
 


### PR DESCRIPTION
This pull request adds support for selected multi-radar plotting with `fov_plot` by allowing a comma-separated list of 3-letter station IDs to be passed via the `-st` option (similar to `trim_grid` and its `-exc` option).  For example,

```
fov_plot -x -grd -grdontop -coast -fcoast -fov -ffov -stereo -latmin 30 -time -dot -d 20170101 -st lyr,han,bks,cvw,han,hok
```

![multi_rads](https://user-images.githubusercontent.com/1869073/122610190-367aaa80-d04d-11eb-9125-bf67aacbb65e.png)

The other radar FOVs which have not been selected can still be drawn with the `-ofov` and `-fofov` options, eg

```
fov_plot -x -grd -grdontop -coast -fcoast -fov -ffov -stereo -latmin 30 -time -dot -d 20170101 -st lyr,han,bks,cvw,han,hok -ofov -fofov
```

![multi_rads2](https://user-images.githubusercontent.com/1869073/122610298-61fd9500-d04d-11eb-9304-3386797edcae.png)

One small issue is that the automatic hemisphere determination will no longer always work, since more than radar is now supported.  If radars from more than one hemisphere are provided via the `-st` option then the hemisphere of the final radar in the list will be used to determine the output, eg

```
fov_plot -x -grd -grdontop -coast -fcoast -fov -ffov -stereo -latmin 30 -time -dot -d 20170101 -st lyr,han,bks,cvw,han,hok,fir
```

![multi_rads3](https://user-images.githubusercontent.com/1869073/122610435-a25d1300-d04d-11eb-9ef5-bea80be0dcaa.png)

Finally, my apologies to @ecbland - this is the last modification to `fov_plot`, I promise!