### PR TITLE
Initializing unused model vector fields in map files to zero

### DIFF
--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/readmap.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/readmap.c
@@ -426,6 +426,14 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
       map->model[n].mlon=adata[35]->data.fptr[n];
       map->model[n].azm=adata[36]->data.fptr[n];
       map->model[n].vel.median=adata[37]->data.fptr[n];
+      map->model[n].vel.sd=0;
+      map->model[n].pwr.median=0;
+      map->model[n].pwr.sd=0;
+      map->model[n].wdt.median=0;
+      map->model[n].wdt.sd=0;
+      map->model[n].st_id=0;
+      map->model[n].chn=0;
+      map->model[n].index=0;
     }
   }
 

--- a/codebase/superdarn/src.lib/tk/oldcnvmap.1.2/src/readmap.c
+++ b/codebase/superdarn/src.lib/tk/oldcnvmap.1.2/src/readmap.c
@@ -82,6 +82,14 @@ int OldCnvMapDecodeOne(char *name,char *unit,char *type,
     mp->model[pnt].mlon=data[0].data.fval;
     mp->model[pnt].azm=data[2].data.fval;
     mp->model[pnt].vel.median=data[3].data.fval;
+    mp->model[pnt].vel.sd=0;
+    mp->model[pnt].pwr.median=0;
+    mp->model[pnt].pwr.sd=0;
+    mp->model[pnt].wdt.median=0;
+    mp->model[pnt].wdt.sd=0;
+    mp->model[pnt].st_id=0;
+    mp->model[pnt].chn=0;
+    mp->model[pnt].index=0;
   }
   return 1;
 }


### PR DESCRIPTION
This pull request sets the unused model vector parameters in the `GridGVec` structure to zero when reading a `cnvmap` or `map`-format file to prevent garbage values from being stored and passed to IDL via the DLMs.  For example, reading a `dmap` `cnvmap`-format file in IDL (note the values returned in the `st_id`, `chn`, and `index` fields):

```
IDL> fname = 'YYYYMMDD.hemi.cnvmap'
IDL> inp = CnvMapOpen(fname, /read)                                        
% Loaded DLM: CNVMAPDLM.
IDL> ret = CnvMapRead(inp,prm,stvec,gvec,mvec,coef,bvec)                   
IDL> help, /str, mvec[0]
** Structure GRIDGVEC, 9 tags, length=44, data length=44:
   MLAT            FLOAT          -82.5000
   MLON            FLOAT           71.4837
   AZM             FLOAT           1.56553
   VEL             STRUCT    -> GRIDVALUE Array[1]
   PWR             STRUCT    -> GRIDVALUE Array[1]
   WDT             STRUCT    -> GRIDVALUE Array[1]
   ST_ID           INT          29811
   CHN             INT          11892
   INDEX           LONG        1702131054
```

while on this branch the unused fields (`pwr`, `wdt`, `st_id`, `chn`, `index`) will all be set to zero (same as if one uses the native IDL `GridMakeGVec` function to create an empty `mvec` structure):

```             
IDL> help, /str, mvec[0]
** Structure GRIDGVEC, 9 tags, length=44, data length=44:
   MLAT            FLOAT          -82.5000
   MLON            FLOAT           71.4837
   AZM             FLOAT           1.56553
   VEL             STRUCT    -> GRIDVALUE Array[1]
   PWR             STRUCT    -> GRIDVALUE Array[1]
   WDT             STRUCT    -> GRIDVALUE Array[1]
   ST_ID           INT              0
   CHN             INT              0
   INDEX           LONG                 0
```

Similarly, `OldCnvMapDecodeOne` of the `oldcnvmap` library is modified for reading the old-format plain-text `map` files to initialize these unused fields to zero.  On the `develop` branch you will see something like this:

```
IDL> fname = 'YYYYMMDD.hemi.map'
IDL> inp = OldCnvMapOpen(fname, /read)                                  
% Loaded DLM: OLDCNVMAPDLM.
IDL> ret = OldCnvMapRead(inp,prm,stvec,gvec,mvec,coef,bvec)             
IDL> help, /str, mvec[0]
** Structure GRIDGVEC, 9 tags, length=44, data length=44:
   MLAT            FLOAT          -82.5000
   MLON            FLOAT           71.5182
   AZM             FLOAT          -55.2069
   VEL             STRUCT    -> GRIDVALUE Array[1]
   PWR             STRUCT    -> GRIDVALUE Array[1]
   WDT             STRUCT    -> GRIDVALUE Array[1]
   ST_ID           INT              0
   CHN             INT           7251
   INDEX           LONG                 0
IDL> print,mvec.st_id
       0       0       0       0       0     258     258     258      10       0       0       0       0       0       0       0       0       0       0
       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0
       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0
       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0
       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0
       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0
       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0
       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0
       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0
       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0   17495   12832    3360
    2573    3377       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0
       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0       0
       0

```

while on this branch all of the unused fields will be correctly initialized to zero.