### PR TITLE
Remove duplicate copyright notices

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/combine_snd.1.0/combine_snd.c
+++ b/codebase/superdarn/src.bin/tk/tool/combine_snd.1.0/combine_snd.c
@@ -1,7 +1,7 @@
 /* combine_snd.c
    =============
    Author: E.G.Thomas
-Copyright (C) <year>  <name of author>
+
 Copyright (C) <year>  <name of author>
 
 This file is part of the Radar Software Toolkit (RST).

--- a/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitClose/CFitClose.c
+++ b/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitClose/CFitClose.c
@@ -1,8 +1,8 @@
 /* CFitClose.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+   
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitFwrite/CFitFwrite.c
+++ b/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitFwrite/CFitFwrite.c
@@ -1,8 +1,8 @@
 /* CFitFwrite.c
    ============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitOpen/CFitOpen.c
+++ b/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitOpen/CFitOpen.c
@@ -1,8 +1,8 @@
 /* CFitOpen.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitRead/CFitRead.c
+++ b/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitRead/CFitRead.c
@@ -1,8 +1,8 @@
 /* CFitRead.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitReadRadarScan/CFitReadRadarScan.c
+++ b/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitReadRadarScan/CFitReadRadarScan.c
@@ -1,8 +1,8 @@
 /* CFitReadRadarScan.c
    ===================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitSeek/CFitSeek.c
+++ b/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitSeek/CFitSeek.c
@@ -1,8 +1,8 @@
 /* CFitSeek.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitToRadarScan/CFitToRadarScan.c
+++ b/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitToRadarScan/CFitToRadarScan.c
@@ -1,8 +1,8 @@
 /* CFitToRadarScan.c
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitWrite/CFitWrite.c
+++ b/codebase/superdarn/src.lib/tk/cfit.1.19/doc/src/CFitWrite/CFitWrite.c
@@ -1,8 +1,8 @@
 /* CFitWrite.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapFread/CnvMapFread.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapFread/CnvMapFread.c
@@ -1,8 +1,8 @@
 /* CnvMapFread.c
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapFseek/CnvMapFseek.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapFseek/CnvMapFseek.c
@@ -1,8 +1,8 @@
 /* CnvMapFseek.c
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapFwrite/CnvMapFwrite.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapFwrite/CnvMapFwrite.c
@@ -1,8 +1,8 @@
 /* CnvMapFwrite.c
    ==============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapIndexFload/CnvMapIndexFload.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapIndexFload/CnvMapIndexFload.c
@@ -1,8 +1,8 @@
 /* CnvMapIndexFload.c
    ==================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapIndexFree/CnvMapIndexFree.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapIndexFree/CnvMapIndexFree.c
@@ -1,8 +1,8 @@
 /* CnvMapIndexFree.c
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapIndexLoad/CnvMapIndexLoad.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapIndexLoad/CnvMapIndexLoad.c
@@ -1,8 +1,8 @@
 /* CnvMapIndexLoad.c
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapRead/CnvMapRead.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapRead/CnvMapRead.c
@@ -1,8 +1,8 @@
 /* CnvMapRead.c
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapSeek/CnvMapSeek.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapSeek/CnvMapSeek.c
@@ -1,8 +1,8 @@
 /* CnvMapSeek.c
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapWrite/CnvMapWrite.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/doc/src/CnvMapWrite/CnvMapWrite.c
@@ -1,8 +1,8 @@
 /* CnvMapWrite.c
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/filter.1.8/doc/src/FilterBound/FilterBound.c
+++ b/codebase/superdarn/src.lib/tk/filter.1.8/doc/src/FilterBound/FilterBound.c
@@ -1,8 +1,8 @@
 /* FilterBound.c
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/filter.1.8/doc/src/FilterBoundType/FilterBoundType.c
+++ b/codebase/superdarn/src.lib/tk/filter.1.8/doc/src/FilterBoundType/FilterBoundType.c
@@ -1,8 +1,8 @@
 /* FilterBoundType.c
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/filter.1.8/doc/src/FilterCheckOps/FilterCheckOps.c
+++ b/codebase/superdarn/src.lib/tk/filter.1.8/doc/src/FilterCheckOps/FilterCheckOps.c
@@ -1,8 +1,8 @@
 /* FilterCheckOps.c
    ================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/filter.1.8/doc/src/FilterRadarScan/FilterRadarScan.c
+++ b/codebase/superdarn/src.lib/tk/filter.1.8/doc/src/FilterRadarScan/FilterRadarScan.c
@@ -1,8 +1,8 @@
 /* FilterRadarScan.c
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitDecode/FitDecode.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitDecode/FitDecode.c
@@ -1,8 +1,8 @@
 /* FitDecode.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitFread/FitFread.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitFread/FitFread.c
@@ -1,8 +1,8 @@
 /* FitFread.c
    ==========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitFreadRadarScan/FitFreadRadarScan.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitFreadRadarScan/FitFreadRadarScan.c
@@ -1,8 +1,8 @@
 /* FitFreadRadarScan.c
    ===================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitFseek/FitFseek.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitFseek/FitFseek.c
@@ -1,8 +1,8 @@
 /* FitFseek.c
    ==========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitFwrite/FitFwrite.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitFwrite/FitFwrite.c
@@ -1,8 +1,8 @@
 /* FitFwrite.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitIndexFload/FitIndexFload.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitIndexFload/FitIndexFload.c
@@ -1,8 +1,8 @@
 /* FitIndexFload.c
    ===============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitIndexFree/FitIndexFree.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitIndexFree/FitIndexFree.c
@@ -1,8 +1,8 @@
 /* FitIndexFree.c
    ==============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitIndexLoad/FitIndexLoad.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitIndexLoad/FitIndexLoad.c
@@ -1,8 +1,8 @@
 /* FitIndexLoad.c
    ==============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitRead/FitRead.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitRead/FitRead.c
@@ -1,8 +1,8 @@
 /* FitRead.c
    =========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitReadRadarScan/FitReadRadarScan.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitReadRadarScan/FitReadRadarScan.c
@@ -1,8 +1,8 @@
 /* FitReadRadarScan.c
    ===================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitSeek/FitSeek.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitSeek/FitSeek.c
@@ -1,8 +1,8 @@
 /* FitSeek.c
    =========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitToCFit/FitToCFit.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitToCFit/FitToCFit.c
@@ -1,8 +1,8 @@
 /* FitToCFit.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitToRadarScan/FitToRadarScan.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitToRadarScan/FitToRadarScan.c
@@ -1,8 +1,8 @@
 /* FitToRadarScan.c
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitWrite/FitWrite.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/src/FitWrite/FitWrite.c
@@ -1,8 +1,8 @@
 /* FitWrite.c
    ==========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACF/FitACF.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACF/FitACF.c
@@ -1,8 +1,8 @@
 /* FitACF.c
    ========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACFBadLags/FitACFBadLags.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACFBadLags/FitACFBadLags.c
@@ -1,8 +1,8 @@
 /* FitACFBadlags.c
    ===============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACFBadLagsStereo/FitACFBadLagsStereo.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACFBadLagsStereo/FitACFBadLagsStereo.c
@@ -1,8 +1,8 @@
 /* FitACFBadlagsStereo.c
    =====================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACFCkRng/FitACFCkRng.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACFCkRng/FitACFCkRng.c
@@ -1,8 +1,8 @@
 /* FitACFBadlags.c
    ===============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACFEnd/FitACFEnd.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACFEnd/FitACFEnd.c
@@ -1,8 +1,8 @@
 /* FitACFEnd.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACFStart/FitACFStart.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACFStart/FitACFStart.c
@@ -1,8 +1,8 @@
 /* FitACFStart.c
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/fitcnx.1.16/doc/src/FitCnxRead/FitCnxRead.c
+++ b/codebase/superdarn/src.lib/tk/fitcnx.1.16/doc/src/FitCnxRead/FitCnxRead.c
@@ -1,8 +1,8 @@
 /* FitCnxRead
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridAdd/GridAdd.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridAdd/GridAdd.c
@@ -1,8 +1,8 @@
 /* GridAdd.c
    ===============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridAverage/GridAverage.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridAverage/GridAverage.c
@@ -1,8 +1,8 @@
 /* GridAverage.c
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridCopy/GridCopy.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridCopy/GridCopy.c
@@ -1,8 +1,8 @@
 /* GridCopy.c
    ==========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridFread/GridFread.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridFread/GridFread.c
@@ -1,8 +1,8 @@
 /* GridFread.c
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridFseek/GridFseek.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridFseek/GridFseek.c
@@ -1,8 +1,8 @@
 /* GridFseek.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridFwrite/GridFwrite.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridFwrite/GridFwrite.c
@@ -1,8 +1,8 @@
 /* GridFwrite.c
    ============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridIndexFload/GridIndexFload.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridIndexFload/GridIndexFload.c
@@ -1,8 +1,8 @@
 /* GridIndexFload.c
    ================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridIndexFree/GridIndexFree.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridIndexFree/GridIndexFree.c
@@ -1,8 +1,8 @@
 /* GridIndexFree.c
    ===============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridIndexLoad/GridIndexLoad.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridIndexLoad/GridIndexLoad.c
@@ -1,8 +1,8 @@
 /* GridIndexLoad.c
    ===============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridIntegrate/GridIntegrate.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridIntegrate/GridIntegrate.c
@@ -1,8 +1,8 @@
 /* GridIntegrate.c
    ===============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridLocateCell/GridLocateCell.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridLocateCell/GridLocateCell.c
@@ -1,8 +1,8 @@
 /* GridLocateCell.c
    ================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridMerge/GridMerge.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridMerge/GridMerge.c
@@ -1,8 +1,8 @@
 /* GridMerge.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridRead/GridRead.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridRead/GridRead.c
@@ -1,8 +1,8 @@
 /* GridRead.c
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridSeek/GridSeek.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridSeek/GridSeek.c
@@ -1,8 +1,8 @@
 /* GridSeek.c
    ==========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridSort/GridSort.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridSort/GridSort.c
@@ -1,8 +1,8 @@
 /* GridSort.c
    ==========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridWrite/GridWrite.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/doc/src/GridWrite/GridWrite.c
@@ -1,8 +1,8 @@
 /* GridWrite.c
    ============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/gtable.2.0/doc/src/GridTableMap/GridTableMap.c
+++ b/codebase/superdarn/src.lib/tk/gtable.2.0/doc/src/GridTableMap/GridTableMap.c
@@ -1,8 +1,8 @@
 /* GridTableMap.c
    ==============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/gtable.2.0/doc/src/GridTableTest/GridTableTest.c
+++ b/codebase/superdarn/src.lib/tk/gtable.2.0/doc/src/GridTableTest/GridTableTest.c
@@ -1,8 +1,8 @@
 /* GridTableTest.c
    ===============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/gtablewrite.1.9/doc/src/GridTableFwrite/GridTableFwrite.c
+++ b/codebase/superdarn/src.lib/tk/gtablewrite.1.9/doc/src/GridTableFwrite/GridTableFwrite.c
@@ -1,8 +1,8 @@
 /* GridTableFwrite.c
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/gtablewrite.1.9/doc/src/GridTableWrite/GridTableWrite.c
+++ b/codebase/superdarn/src.lib/tk/gtablewrite.1.9/doc/src/GridTableWrite/GridTableWrite.c
@@ -1,8 +1,8 @@
 /* GridTableWrite.c
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldcnvmap.1.2/doc/src/OldCnvMapFread/OldCnvMapFread.c
+++ b/codebase/superdarn/src.lib/tk/oldcnvmap.1.2/doc/src/OldCnvMapFread/OldCnvMapFread.c
@@ -1,8 +1,8 @@
 /* OldCnvMapFread.c
    ================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldcnvmap.1.2/doc/src/OldCnvMapFseek/OldCnvMapFseek.c
+++ b/codebase/superdarn/src.lib/tk/oldcnvmap.1.2/doc/src/OldCnvMapFseek/OldCnvMapFseek.c
@@ -1,8 +1,8 @@
 /* OldCnvMapFseek.c
    ================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldcnvmap.1.2/doc/src/OldCnvMapFwrite/OldCnvMapFwrite.c
+++ b/codebase/superdarn/src.lib/tk/oldcnvmap.1.2/doc/src/OldCnvMapFwrite/OldCnvMapFwrite.c
@@ -1,8 +1,8 @@
 /* OldCnvMapFwrite.c
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitClose/OldFitClose.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitClose/OldFitClose.c
@@ -2,8 +2,7 @@
    =============
    Author: R.J.Barnes 
 
-
-    Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitFwrite/OldFitFwrite.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitFwrite/OldFitFwrite.c
@@ -1,8 +1,8 @@
 /* OldFitFwrite.c
    ==============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitHeaderFwrite/OldFitHeaderFwrite.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitHeaderFwrite/OldFitHeaderFwrite.c
@@ -1,8 +1,8 @@
 /* OldFitHeaderFwrite.c
    ====================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitHeaderWrite/OldFitHeaderWrite.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitHeaderWrite/OldFitHeaderWrite.c
@@ -1,8 +1,8 @@
 /* OldFitHeaderWrite.c
    ===================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitInxClose/OldFitInxClose.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitInxClose/OldFitInxClose.c
@@ -1,8 +1,8 @@
 /* OldFitInxClose.c
    ================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitInxFclose/OldFitInxFclose.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitInxFclose/OldFitInxFclose.c
@@ -1,8 +1,8 @@
 /* OldFitInxFclose.c
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitInxFwrite/OldFitInxFwrite.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitInxFwrite/OldFitInxFwrite.c
@@ -1,8 +1,8 @@
 /* OldFitInxFclose.c
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitInxHeaderFwrite/OldFitInxHeaderFwrite.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitInxHeaderFwrite/OldFitInxHeaderFwrite.c
@@ -1,8 +1,8 @@
 /* OldFitInxFclose.c
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitInxHeaderWrite/OldFitInxHeaderWrite.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitInxHeaderWrite/OldFitInxHeaderWrite.c
@@ -1,8 +1,8 @@
 /* OldFitInxHeaderWrite.c
    ======================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitInxWrite/OldFitInxWrite.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitInxWrite/OldFitInxWrite.c
@@ -1,8 +1,8 @@
 /* OldFitInxWrite.c
    ================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitOpen/OldFitOpen.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitOpen/OldFitOpen.c
@@ -1,8 +1,8 @@
 /* OldFitOpen.c
    ============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitRead/OldFitRead.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitRead/OldFitRead.c
@@ -1,8 +1,8 @@
 /* OldFitRead.c
    ============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitReadRadarScan/OldFitReadRadarScan.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitReadRadarScan/OldFitReadRadarScan.c
@@ -1,8 +1,8 @@
 /* OldFitOpen.c
    ============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitSeek/OldFitSeek.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitSeek/OldFitSeek.c
@@ -1,8 +1,8 @@
 /* OldFitSeek.c
    ============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitWrite/OldFitWrite.c
+++ b/codebase/superdarn/src.lib/tk/oldfit.1.25/doc/src/OldFitWrite/OldFitWrite.c
@@ -1,8 +1,8 @@
 /* OldFitWrite.c
    ==============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldfitcnx.1.10/doc/src/OldFitCnxRead/OldFitCnxRead.c
+++ b/codebase/superdarn/src.lib/tk/oldfitcnx.1.10/doc/src/OldFitCnxRead/OldFitCnxRead.c
@@ -1,8 +1,8 @@
 /* OldFitCnxRead
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldgrid.1.3/doc/src/OldGridFread/OldGridFread.c
+++ b/codebase/superdarn/src.lib/tk/oldgrid.1.3/doc/src/OldGridFread/OldGridFread.c
@@ -1,8 +1,8 @@
 /* OldGridFread.c
    ==============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldgrid.1.3/doc/src/OldGridFseek/OldGridFseek.c
+++ b/codebase/superdarn/src.lib/tk/oldgrid.1.3/doc/src/OldGridFseek/OldGridFseek.c
@@ -1,8 +1,8 @@
 /* OldGridFseek.c
    ==============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldgrid.1.3/doc/src/OldGridFwrite/OldGridFwrite.c
+++ b/codebase/superdarn/src.lib/tk/oldgrid.1.3/doc/src/OldGridFwrite/OldGridFwrite.c
@@ -1,8 +1,8 @@
 /* OldGridFwrite.c
    ===============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldgtablewrite.1.4/doc/src/OldGridTableFwrite/OldGridTableFwrite.c
+++ b/codebase/superdarn/src.lib/tk/oldgtablewrite.1.4/doc/src/OldGridTableFwrite/OldGridTableFwrite.c
@@ -1,8 +1,8 @@
 /* OldGridTableFwrite.c
    ====================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldgtablewrite.1.4/doc/src/OldGridTableWrite/OldGridTableWrite.c
+++ b/codebase/superdarn/src.lib/tk/oldgtablewrite.1.4/doc/src/OldGridTableWrite/OldGridTableWrite.c
@@ -1,8 +1,8 @@
 /* OldGridTableWrite.c
    ===================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawClose/OldRawClose.c
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawClose/OldRawClose.c
@@ -1,8 +1,8 @@
 /* OldRawClose.c
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawFwrite/OldRawFwrite.c
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawFwrite/OldRawFwrite.c
@@ -1,8 +1,8 @@
 /* OldRawFwrite.c
    ==============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawHeaderFwrite/OldRawHeaderFwrite.c
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawHeaderFwrite/OldRawHeaderFwrite.c
@@ -1,8 +1,8 @@
 /* OldHeaderRawFwrite.c
    ====================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawHeaderWrite/OldRawHeaderWrite.c
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawHeaderWrite/OldRawHeaderWrite.c
@@ -1,8 +1,8 @@
 /* OldRawHeaderWrite.c
    ===================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawOpen/OldRawOpen.c
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawOpen/OldRawOpen.c
@@ -1,8 +1,8 @@
 /* OldRawOpen.c
    ============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawRead/OldRawRead.c
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawRead/OldRawRead.c
@@ -1,8 +1,8 @@
 /* OldRawRead.c
    ============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawSeek/OldRawSeek.c
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawSeek/OldRawSeek.c
@@ -1,8 +1,8 @@
 /* OldRawSeek.c
    ============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawWrite/OldRawWrite.c
+++ b/codebase/superdarn/src.lib/tk/oldraw.1.16/doc/src/OldRawWrite/OldRawWrite.c
@@ -1,8 +1,8 @@
 /* OldRawWrite.c
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarEpochGetSite/RadarEpochGetSite.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarEpochGetSite/RadarEpochGetSite.c
@@ -1,8 +1,8 @@
 /* RadarEpochGetSite
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarFree/RadarFree.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarFree/RadarFree.c
@@ -1,8 +1,8 @@
 /* RadarFree
    =========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetCode/RadarGetCode.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetCode/RadarGetCode.c
@@ -1,8 +1,8 @@
 /* RadarGetCode
    ============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetCodeNum/RadarGetCodeNum.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetCodeNum/RadarGetCodeNum.c
@@ -1,8 +1,8 @@
 /* RadarGetCodeNum
    ===============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetID/RadarGetID.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetID/RadarGetID.c
@@ -1,8 +1,8 @@
 /* RadarGetID
    ==========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetName/RadarGetName.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetName/RadarGetName.c
@@ -1,8 +1,8 @@
 /* RadarGetName
    ============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetOperator/RadarGetOperator.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetOperator/RadarGetOperator.c
@@ -1,8 +1,8 @@
 /* RadarGetOperator
    =========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetRadar/RadarGetRadar.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetRadar/RadarGetRadar.c
@@ -1,8 +1,8 @@
 /* RadarGetRadar
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetStatus/RadarGetStatus.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarGetStatus/RadarGetStatus.c
@@ -1,8 +1,8 @@
 /* RadarGetStatus
    ==============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarLoad/RadarLoad.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarLoad/RadarLoad.c
@@ -1,8 +1,8 @@
 /* RadarLoad
    =========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarLoadHardware/RadarLoadHardware.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarLoadHardware/RadarLoadHardware.c
@@ -1,8 +1,8 @@
 /* RadarLoadHardware
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarYMDHMSGetSite/RadarYMDHMSGetSite.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/doc/src/RadarYMDHMSGetSite/RadarYMDHMSGetSite.c
@@ -1,8 +1,8 @@
 /* RadarYMDHMSGetSite
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawFread/RawFread.c
+++ b/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawFread/RawFread.c
@@ -1,8 +1,8 @@
 /* RawFread.c
    ==========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawFseek/RawFseek.c
+++ b/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawFseek/RawFseek.c
@@ -1,8 +1,8 @@
 /* RawFseek.c
    ==========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawFwrite/RawFwrite.c
+++ b/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawFwrite/RawFwrite.c
@@ -1,8 +1,8 @@
 /* RawFwrite.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawIndexFload/RawIndexFload.c
+++ b/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawIndexFload/RawIndexFload.c
@@ -1,8 +1,8 @@
 /* RawIndexFload.c
    ===============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawIndexFree/RawIndexFree.c
+++ b/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawIndexFree/RawIndexFree.c
@@ -1,8 +1,8 @@
 /* RawIndexFree.c
    ==============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawIndexLoad/RawIndexLoad.c
+++ b/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawIndexLoad/RawIndexLoad.c
@@ -1,8 +1,8 @@
 /* RawIndexLoad.c
    ==============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawRead/RawRead.c
+++ b/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawRead/RawRead.c
@@ -1,8 +1,8 @@
 /* RawRead.c
    =========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawSeek/RawSeek.c
+++ b/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawSeek/RawSeek.c
@@ -1,8 +1,8 @@
 /* RawSeek.c
    =========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawWrite/RawWrite.c
+++ b/codebase/superdarn/src.lib/tk/raw.1.22/doc/src/RawWrite/RawWrite.c
@@ -1,8 +1,8 @@
 /* RawWrite.c
    ==========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosCalcVector/RPosCalcVector.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosCalcVector/RPosCalcVector.c
@@ -1,8 +1,8 @@
 /* RPosCalcVector
    ==============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosCubic/RPosCubic.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosCubic/RPosCubic.c
@@ -1,8 +1,8 @@
 /* RPosCubic.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosCubicGS/RPosCubicGS.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosCubicGS/RPosCubicGS.c
@@ -1,8 +1,8 @@
 /* RPosCubicGS.c
    =============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosGeo/RPosGeo.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosGeo/RPosGeo.c
@@ -1,8 +1,8 @@
 /* RPosGeo
    =======
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosGeoGS/RPosGeoGS.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosGeoGS/RPosGeoGS.c
@@ -1,8 +1,8 @@
 /* RPosGeoGS
    =========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosInvMag/RPosInvMag.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosInvMag/RPosInvMag.c
@@ -1,8 +1,8 @@
 /* RPosInvMag
    ==========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosMag/RPosMag.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosMag/RPosMag.c
@@ -1,8 +1,8 @@
 /* RPosMag
    =======
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosMagGS/RPosMagGS.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosMagGS/RPosMagGS.c
@@ -1,8 +1,8 @@
 /* RPosMagGS
    =========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosRngBmAzmElv/RPosRngBmAzmElv.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/doc/src/RPosRngBmAzmElv/RPosRngBmAzmElv.c
@@ -1,8 +1,8 @@
 /* RPosRngBmAzmElv
    ===============
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/scan.1.7/doc/src/RadarScanReset/RadarScanReset.c
+++ b/codebase/superdarn/src.lib/tk/scan.1.7/doc/src/RadarScanReset/RadarScanReset.c
@@ -1,8 +1,8 @@
 /* RadarScanReset.c
    ================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/scan.1.7/doc/src/RadarScanResetBeam/RadarScanResetBeam.c
+++ b/codebase/superdarn/src.lib/tk/scan.1.7/doc/src/RadarScanResetBeam/RadarScanResetBeam.c
@@ -1,8 +1,8 @@
 /* RadarScanResetBeam.c
    ====================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/smr.1.7/doc/src/SmrFread/SmrFread.c
+++ b/codebase/superdarn/src.lib/tk/smr.1.7/doc/src/SmrFread/SmrFread.c
@@ -1,8 +1,8 @@
 /* SmrFread.c
    ==========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/smr.1.7/doc/src/SmrFwrite/SmrFwrite.c
+++ b/codebase/superdarn/src.lib/tk/smr.1.7/doc/src/SmrFwrite/SmrFwrite.c
@@ -1,8 +1,8 @@
 /* SmrFwrite.c
    ===========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/smr.1.7/doc/src/SmrHeaderFwrite/SmrHeaderFwrite.c
+++ b/codebase/superdarn/src.lib/tk/smr.1.7/doc/src/SmrHeaderFwrite/SmrHeaderFwrite.c
@@ -1,8 +1,8 @@
 /* SmrHeaderFwrite.c
    =================
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/smr.1.7/doc/src/SmrRadarScan/SmrRadarScan.c
+++ b/codebase/superdarn/src.lib/tk/smr.1.7/doc/src/SmrRadarScan/SmrRadarScan.c
@@ -1,8 +1,8 @@
 /* SmrRadarScan.c
    ==========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 

--- a/codebase/superdarn/src.lib/tk/smr.1.7/doc/src/SmrSeek/SmrSeek.c
+++ b/codebase/superdarn/src.lib/tk/smr.1.7/doc/src/SmrSeek/SmrSeek.c
@@ -1,8 +1,8 @@
 /* SmrSeek.c
    =========
    Author: R.J.Barnes
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
- Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
+
+Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
 


### PR DESCRIPTION
@egthomas noted in #447 that there were about 300 files with duplicate copyright information that was introduced while cleaning up the license notices. This PR removes those duplicate lines.

I only found 132 files with duplicate copyright info. There were more files in `$RSTPATH/doc/`, but that documentation is built from the files I have modified in this PR. 