### PR TITLE
SndWrite fixes to bring in line with original control program code

### DIFF
--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
@@ -116,44 +116,45 @@ int SndWrite(int fid, struct SndData *snd) {
   if (snd->xcf !=0) xnum=snum;
   else xnum=0;
 
-  if (snum==0) return 0;
+  if (snum !=0) {
 
-  slist=DataMapStoreArray(ptr,"slist",DATASHORT,1,&snum,NULL);
+    slist=DataMapStoreArray(ptr,"slist",DATASHORT,1,&snum,NULL);
 
-  qflg=DataMapStoreArray(ptr,"qflg",DATACHAR,1,&snum,NULL);
-  gflg=DataMapStoreArray(ptr,"gflg",DATACHAR,1,&snum,NULL);
+    qflg=DataMapStoreArray(ptr,"qflg",DATACHAR,1,&snum,NULL);
+    gflg=DataMapStoreArray(ptr,"gflg",DATACHAR,1,&snum,NULL);
 
-  v=DataMapStoreArray(ptr,"v",DATAFLOAT,1,&snum,NULL);
-  v_e=DataMapStoreArray(ptr,"v_e",DATAFLOAT,1,&snum,NULL);
-  p_l=DataMapStoreArray(ptr,"p_l",DATAFLOAT,1,&snum,NULL);
-  w_l=DataMapStoreArray(ptr,"w_l",DATAFLOAT,1,&snum,NULL);
+    v=DataMapStoreArray(ptr,"v",DATAFLOAT,1,&snum,NULL);
+    v_e=DataMapStoreArray(ptr,"v_e",DATAFLOAT,1,&snum,NULL);
+    p_l=DataMapStoreArray(ptr,"p_l",DATAFLOAT,1,&snum,NULL);
+    w_l=DataMapStoreArray(ptr,"w_l",DATAFLOAT,1,&snum,NULL);
 
-  x_qflg=DataMapStoreArray(ptr,"x_qflg",DATACHAR,1,&xnum,NULL);
+    x_qflg=DataMapStoreArray(ptr,"x_qflg",DATACHAR,1,&xnum,NULL);
 
-  phi0=DataMapStoreArray(ptr,"phi0",DATAFLOAT,1,&xnum,NULL);
-  phi0_e=DataMapStoreArray(ptr,"phi0_e",DATAFLOAT,1,&xnum,NULL);
+    phi0=DataMapStoreArray(ptr,"phi0",DATAFLOAT,1,&xnum,NULL);
+    phi0_e=DataMapStoreArray(ptr,"phi0_e",DATAFLOAT,1,&xnum,NULL);
 
-  x=0;
+    x=0;
 
-  for (c=0;c<snd->nrang;c++) {
-    if ( (snd->rng[c].qflg==1) || (snd->rng[c].x_qflg==1)) {
-      slist[x]=c;
+    for (c=0;c<snd->nrang;c++) {
+      if ( (snd->rng[c].qflg==1) || (snd->rng[c].x_qflg==1)) {
+        slist[x]=c;
 
-      qflg[x]=snd->rng[c].qflg;
-      gflg[x]=snd->rng[c].gsct;
+        qflg[x]=snd->rng[c].qflg;
+        gflg[x]=snd->rng[c].gsct;
 
-      p_l[x]=snd->rng[c].p_l;
-      v[x]=snd->rng[c].v;
-      v_e[x]=snd->rng[c].v_err;
-      w_l[x]=snd->rng[c].w_l;
+        p_l[x]=snd->rng[c].p_l;
+        v[x]=snd->rng[c].v;
+        v_e[x]=snd->rng[c].v_err;
+        w_l[x]=snd->rng[c].w_l;
 
-      if (xnum !=0) {
-        x_qflg[x]=snd->rng[c].x_qflg;
+        if (xnum !=0) {
+          x_qflg[x]=snd->rng[c].x_qflg;
 
-        phi0[x]=snd->rng[c].phi0;
-        phi0_e[x]=snd->rng[c].phi0_err;
+          phi0[x]=snd->rng[c].phi0;
+          phi0_e[x]=snd->rng[c].phi0_err;
+        }
+        x++;
       }
-      x++;
     }
   }
 

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
@@ -128,10 +128,12 @@ int SndWrite(int fid, struct SndData *snd) {
     p_l=DataMapStoreArray(ptr,"p_l",DATAFLOAT,1,&snum,NULL);
     w_l=DataMapStoreArray(ptr,"w_l",DATAFLOAT,1,&snum,NULL);
 
-    x_qflg=DataMapStoreArray(ptr,"x_qflg",DATACHAR,1,&xnum,NULL);
+    if (snd->xcf !=0) {
+      x_qflg=DataMapStoreArray(ptr,"x_qflg",DATACHAR,1,&xnum,NULL);
 
-    phi0=DataMapStoreArray(ptr,"phi0",DATAFLOAT,1,&xnum,NULL);
-    phi0_e=DataMapStoreArray(ptr,"phi0_e",DATAFLOAT,1,&xnum,NULL);
+      phi0=DataMapStoreArray(ptr,"phi0",DATAFLOAT,1,&xnum,NULL);
+      phi0_e=DataMapStoreArray(ptr,"phi0_e",DATAFLOAT,1,&xnum,NULL);
+    }
 
     x=0;
 


### PR DESCRIPTION
This pull request makes a few small changes to `SndWrite` in `sndwrite.c` to bring the behavior in line with the original control program code (eg found [here](https://github.com/SuperDARN/control_programs/blob/master/qnx6/interleavesound.1.0/sndwrite.c) for interleavesound).

Previously, if there were no ranges with valid ACF or XCF fits then `SndWrite` would skip writing the entire record, when the intended behavior is for the radar operations info usually stored in the header / parameter block to still be written and to only skip over writing the (missing) fitted parameters.  This issue was noticed when looking at either Borealis or Mabel data which were processed using `make_snd`, although I can't remember the specific radar or file.

There was one other small inconsistency fixed to prevent storing XCF-related information if the XCF flag was not originally set.  I haven't actually encountered an issue with this, but the check was in the original sounding code I wrote and is in line with other similar RST functions.