### PR TITLE
[New] make system for RST

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,37 @@
+# (C) Copyright 2021 SuperDARN Canada, University of Saskatchewan
+# Author(s): Marina Schmidt
+# 
+#
+lib_analysis = $(wildcard ./codebase/analysis/src.lib/*/*/src/)
+lib_base = $(wildcard ./codebase/base/src.lib/*/*/src/)
+lib_general = $(wildcard ./codebase/general/src.lib/*/src/)
+lib_imagery = $(wildcard ./codebase/imagery/src.lib/*/src/)
+lib_superdarn = $(wildcard ./codebase/superdarn/src.lib/tk/*/src/)
+
+libraries := $(lib_base) $(lib_general) $(lib_analysis) $(lib_imagery) $(lib_superdarn)
+
+bin_analysis = $(wildcard ./codebase/analysis/src.bin/*/*/)
+bin_base = $(wildcard ./codebase/base/src.bin/*/*/)
+bin_general = $(wildcard ./codebase/general/src.bin/*/*/)
+bin_superdarn_tool = $(wildcard ./codebase/superdarn/src.bin/tk/tool/*/)
+bin_superdarn_testing_cmp = $(wildcard ./codebase/superdarn/src.bin/tk/testing/cmp*/)
+bin_superdarn_testing = $(wildcard ./codebase/superdarn/src.bin/tk/testing/test*/)
+bin_superdarn_tcpip = $(wildcard ./codebase/superdarn/src.bin/tk/tcpip/*/)
+bin_superdarn_reformat = $(wildcard ./codebase/superdarn/src.bin/tk/reformat/*/)
+bin_superdarn_plot = $(wildcard ./codebase/superdarn/src.bin/tk/plot/*/)
+
+
+
+bin_superdarn := $(bin_superdarn_tool) $(bin_superdarn_testing_cmp) $(bin_superdarn_testing) $(bin_superdarn_tcpip) $(bin_superdarn_reformat) $(bin_superdarn_plot)
+rst := $(bin_base) $(bin_analysis) $(bin_general) $(bin_superdarn) 
+
+.PHONY: all $(rst) $(libraries)
+all: $(rst)
+
+$(rst) $(libraries):
+	$(MAKE) --directory=$@
+
+$(rst): $(libraries)
+$(lib_analysis): $(lib_general)
+$(lib_superdarn): $(lib_base) $(lib_analysis) $(lib_general) $(lib_imagery)
+

--- a/makefile
+++ b/makefile
@@ -3,12 +3,13 @@
 # 
 #
 lib_analysis = $(wildcard ./codebase/analysis/src.lib/*/*/src/)
+lib_base_rmxl = $(wildcard ./codebase/base/src.lib/*rxml*/*/src/)
 lib_base = $(wildcard ./codebase/base/src.lib/*/*/src/)
 lib_general = $(wildcard ./codebase/general/src.lib/*/src/)
 lib_imagery = $(wildcard ./codebase/imagery/src.lib/*/src/)
 lib_superdarn = $(wildcard ./codebase/superdarn/src.lib/tk/*/src/)
 
-libraries := $(lib_base) $(lib_general) $(lib_analysis) $(lib_imagery) $(lib_superdarn)
+libraries := $(lib_base) $(lib_base_rxml) $(lib_general) $(lib_analysis) $(lib_imagery) $(lib_superdarn)
 
 bin_analysis = $(wildcard ./codebase/analysis/src.bin/*/*/)
 bin_base = $(wildcard ./codebase/base/src.bin/*/*/)
@@ -32,6 +33,9 @@ $(rst) $(libraries):
 	$(MAKE) --directory=$@
 
 $(rst): $(libraries)
+
+$(lib_base): $(lib_base_rxml)
+$(lib_general): $(lib_base)
 $(lib_analysis): $(lib_general)
 $(lib_superdarn): $(lib_base) $(lib_analysis) $(lib_general) $(lib_imagery)
 

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@
 # 
 #
 lib_analysis = $(wildcard ./codebase/analysis/src.lib/*/*/src/)
-lib_base_rmxl = $(wildcard ./codebase/base/src.lib/*rxml*/*/src/)
+lib_base_rmxl = $(wildcard ./codebase/base/src.lib/xml/xml.1.8/src/)
 lib_base = $(wildcard ./codebase/base/src.lib/*/*/src/)
 lib_general = $(wildcard ./codebase/general/src.lib/*/src/)
 lib_imagery = $(wildcard ./codebase/imagery/src.lib/*/src/)


### PR DESCRIPTION
# Scope 

So this is less refactoring right now as I just made a makefile in the root directory to essentially do what `make.build` and `make.code` does. In the future, we can deprecate those two scripts and use the `makefile` as it allows more flexibility and is the built-in make system than what RST has built into it. Also, the hope is more flexibility and less maintenance. 

**issue** #451 

I will be building off of this branch with other branches for more in-depth refactoring to fix ongoing users and including myself problems with install RST on remote servers. 

## Approvals: 3 
- [ ] Mac OS user @billetd or @mtwalach ?
- [ ] Debian user (Ubuntu) @ksterne ? @ecbland ? 
- [ ] Fedora/RPM user 
- [ ] IDL test @ecbland ?

## Test

``` bash 
git checkout ehn/refactor_make
cd rst 
make
```
Should compile RST and you should be able to use `make_fit` and other binaries with no issues. 

```bash 
make TARGET=clean
```
is a nother option to run make clean on all of RST files. 

It does not compile the documentation. 