### PR TITLE
Modifying IDL RadarSlantRange function in radar.pro to correctly handle large slant ranges

### DIFF
--- a/codebase/superdarn/src.idl/lib/main.1.25/radar.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/radar.pro
@@ -412,8 +412,8 @@ end
 
 
 function RadarSlantRange,frang,rsep,rxrise,range_edge,range_gate
-   lagfr=frang*20/3
-   smsep=rsep*20/3
+   lagfr=frang*20/3.D
+   smsep=rsep*20/3.D
    return, (lagfr-rxrise+(range_gate-1)*smsep+range_edge)*0.15D
 end
 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/src/cnvtcoord.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/src/cnvtcoord.c
@@ -22,7 +22,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 Modifications:
     Comments: E.G.Thomas (2016)
     2020-03-11 Marina Schmidt removed earth's radius defined constant 
-along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 */
 


### PR DESCRIPTION
This pull request fixes a bug in the IDL version of `RadarSlantRange` when calculating the slant range for extreme range gates, eg (on `develop`):

```
IDL> inp = FitOpen('yyyymmdd.rad.fitacf', /read)
% Loaded DLM: FITDLM.
IDL> ret = FitRead(inp, prm, fit)
IDL> print, RadarSlantRange(prm.frang, prm.rsep, prm.rxrise, 0, 106)
       4890.0000
IDL> print, RadarSlantRange(prm.frang, prm.rsep, prm.rxrise, 0, 107)
      -4895.4000
```

This is because `prm.frang`, `prm.rsep`, and `prm.rxrise` are all integers, and will cause an overflow for very far range gates in `RadarSlantRange` because it works in units of microseconds rather than km.  On this branch, the bug is fixed by ensuring `lagfr` and `smsep` are both cast as doubles (which is what `RadarSlantRange` outputs anyway):

```
IDL> inp = FitOpen('yyyymmdd.rad.fitacf', /read)          
% Loaded DLM: FITDLM.
IDL> ret = FitRead(inp, prm, fit)                               
IDL> print, RadarSlantRange(prm.frang, prm.rsep, prm.rxrise, 0, 106)
       4890.0000
IDL> print, RadarSlantRange(prm.frang, prm.rsep, prm.rxrise, 0, 107)
       4935.0000
```