### PR TITLE
Checking the value of qflg in fit_speck_removal

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/doc/fit_speck_removal.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/doc/fit_speck_removal.doc.xml
@@ -17,12 +17,13 @@
 </option>
 
 <synopsis><p>Removes salt and pepper noise from a <code>fitacf</code> file.</p></synopsis>
-<description><p>Removes salt and pepper noise from a fitacf file by applying a 3x3 median filter in range-time space. The quality flag in the center cell of a 3x3 range-time grid is set to zero if the median 
-of the quality flags in the 3x3 grid is zero. Filtering is performed separately for each beam and channel.</p></description>
+<description><p>Removes salt and pepper noise from a fitacf. The quality flag in the center cell of a 3x3 range-time grid is set to zero if the median 
+of the quality flags in the 3x3 grid is zero. This procedure is performed separately for each beam and channel. 
+The output is a fitacf file with the salt and pepper noise removed, but otherwise identical to the input file.</p></description>
 
 <example>
-<command>fit_speck_removal 20170825.gbr.fitacf &gt 20170825.gbr.filtered.fitacf</command>
-<description>Perform the speck removal procedure on the <code>fitacf</code>-format file named "<code>20170825.gbr.fitacf</code>". The output file is called "<code>20170825.gbr.filtered.fitacf</code>".</description>
+<command>fit_speck_removal 20170825.gbr.fitacf &gt 20170825.gbr.despeck.fitacf</command>
+<description>Perform the speck removal procedure on the <code>fitacf</code>-format file named "<code>20170825.gbr.fitacf</code>". The output file is called "<code>20170825.gbr.despeck.fitacf</code>".</description>
 </example>
 
 </binary>

--- a/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/fit_speck_removal.c
+++ b/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/fit_speck_removal.c
@@ -213,7 +213,7 @@ int main (int argc,char *argv[]) {
       }
       
       // Populate the qflg array using the values from the input file
-      // if qflg>1 (ref: fitacf2.5), we set qflg=0
+      // if fit->rng[range].qflg>1 (ref: fitacf2.5), we set qflg=0
       if (fit->rng[range].qflg==1) {
         qflgs->value[index] = 1;
       } else {      

--- a/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/fit_speck_removal.c
+++ b/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/fit_speck_removal.c
@@ -1,10 +1,10 @@
 /* fit_speck_removal.c
    ==========
    
-Removes salt & pepper noise from a fitacf file using a median filtering procedure in range-time space.
+Removes salt & pepper noise from a fitacf file. 
 The quality flag (fit->qflg) in the center cell of a 3x3 range-time grid is set to zero if the median 
-of the quality flags in the 3x3 grid is zero. Filtering is performed separately for each beam and channel. 
-Output is a fitacf file.
+of the quality flags in the 3x3 grid is zero. This procedure is performed separately for each beam and channel. 
+The output is a fitacf file with the salt & pepper noise removed, but otherwise identical to the input file.
 
 (C) Copyright 2021 E.C.Bland
 author: E.C.Bland
@@ -25,8 +25,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
        
 Modifications:
+	E.C.Bland, University Centre in Svalbard, 2021-09-17: fix handling of qflg>1 data from fitacf2.5, 
+	           which in rare cases might include values other than qflg=0 for rejected ACFs.
 
-   
 */
 
 
@@ -53,9 +54,9 @@ Modifications:
 #include "hlpstr.h"
 
 // Define maximum number of time records, beams, channels and range gates (used for memory allocation)
-#define tmax 2000     // initial number of time records
-#define maxbeam 30    // max number of beams
-#define maxchannel 3  // max number of channels (0, 1, or 2)
+#define tmax 2000       // initial number of time records
+#define maxbeam 30      // max number of beams
+#define maxchannel 3    // max number of channels (0, 1, or 2)
 #define maxrange 250    // max number of range gates
 
 int fnum=0;
@@ -210,7 +211,14 @@ int main (int argc,char *argv[]) {
           exit(-1);
         }
       }
-      qflgs->value[index] = fit->rng[range].qflg;
+      
+      // Populate the qflg array using the values from the input file
+      // if qflg>1 (ref: fitacf2.5), we set qflg=0
+      if (fit->rng[range].qflg==1) {
+        qflgs->value[index] = 1;
+      } else {      
+        qflgs->value[index] = 0;
+      }
       qflgs->used = maxindex;
       
     }

--- a/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/fit_speck_removal.c
+++ b/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/fit_speck_removal.c
@@ -227,9 +227,9 @@ int main (int argc,char *argv[]) {
   } while (FitFread(fp,prm,fit) !=-1);
   
   
-  // Do the median filtering
-  //   Since qflg can only be 0 or 1, the median qflg of the 3x3 grid can be 
-  //     calculated using the test ( sum_of_qflgs >= 5 ).
+  // Identify isolated points by calculating the median of the quality flags
+  //   in a 3x3 grid. Since qflg can only be 0 or 1, the median qflg of the 
+  //   3x3 grid can be calculated using the test ( sum_of_qflgs >= 5 ).
   //   Replicate padding is used to handle corner/edge cases
   int sum;
   int index_list[9];  
@@ -241,7 +241,7 @@ int main (int argc,char *argv[]) {
   }
   
   
-  //** Read the file again, apply the median filter, and write a new file
+  //** Read the file again, remove the isolated points, and write a new file
   rewind(fp); // rewind the file pointer
   if (FitFread(fp,prm,fit)==-1) {
     fprintf(stderr,"Error reading file\n");


### PR DESCRIPTION
This PR adds a check in `fit_speck_removal` to ensure that `qflg` can only have the value 0 or 1. This will always be the case for data processed with `fitacf3.0`, but @egthomas pointed out to me that `fitacf2.5` uses other integer values of `qflg` to mark rejected ACFs. I believe that only the records with `qflg=1` are written to file, but we cannot find which part of the code would reject the data assigned `qflg=8` here:

https://github.com/SuperDARN/rst/blob/c9345ca78fe88c0279dc09fbb9eaf91da512d684/codebase/superdarn/src.lib/tk/fitacf.2.5/src/do_fit.c#L268-L271

I searched 4 months of `fitacf2.5` data from 11 radars and did not find a single record with `qflg=8`. But it's straightforward to check the `qflg` value so that's what I did.

**Testing:** Since I can't find a specific test case where this modification would matter, please just check that `fit_speck_removal` produces identical output on this branch and `develop` for a fitacf file of your choice. 

*I also updated the description and comments in this routine to avoid using the word "filter". There is some potential for confusion with traditional median filtering procedures that modify the fitted values in the neighbouring cells. In contrast, `fit_speck_removal` just removes isolated points without modifying any of the remaining fitted data.*
