### PR TITLE
removed option to download from github

### DIFF
--- a/docs/user_guide/linux_install.md
+++ b/docs/user_guide/linux_install.md
@@ -220,7 +220,6 @@ Error: curses.h not found
 
 1. Obtaining RST software:
     - Download the official release with a citable DOI from [Zenodo](https://doi.org/10.5281/zenodo.801458) (**recommended for most users**)
-    - Download the official release from [Github](https://github.com/SuperDARN/rst/releases)
     - Clone from Github (for developers): ```git clone https://github.com/superdarn/rst/```
 
 2. Check RST environment variables:


### PR DESCRIPTION
This PR is a documentation change where I moved the option to install the release from Github. 

Probably best to just encourage Zenodo and not anything else. 