### PR TITLE
Print despecking statistics in the terminal

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/doc/fit_speck_removal.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/doc/fit_speck_removal.doc.xml
@@ -5,13 +5,15 @@
 <location>src.bin/tk/tool/fit_speck_removal</location>
 
 <syntax>fit_speck_removal --help</syntax>
-<syntax>fit_speck_removal [-vb] <ar>fitacfname</ar></syntax>
+<syntax>fit_speck_removal [-vb] [-quiet] <ar>fitacfname</ar></syntax>
 
 <option><on>--help</on><od>print the help message and exit.</od>
 </option>
 <option><on>--version</on><od>print the RST version number and exit.</od>
 </option>
-<option><on>-vb</on><od>verbose. Log information to the console.</od>
+<option><on>-vb</on><od>print extra information in the terminal.</od>
+</option>
+<option><on>-quiet</on><od>prevent statistics from being printed in the terminal.</od>
 </option>
 <option><on><ar>fitacfname</ar></on><od>filename of the input <code>fitacf</code>-format file.</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/fit_speck_removal.c
+++ b/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/fit_speck_removal.c
@@ -25,9 +25,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
        
 Modifications:
-	E.C.Bland, University Centre in Svalbard, 2021-09-17: fix handling of qflg>1 data from fitacf2.5, 
+    2021-09-17 E.C.Bland, University Centre in Svalbard (UNIS): fix handling of qflg>1 data from fitacf2.5, 
 	           which in rare cases might include values other than qflg=0 for rejected ACFs.
-
+    2022-02-23 E.C.Bland, (UNIS): add statistics on number of rejected ACFs
 */
 
 
@@ -253,6 +253,8 @@ int main (int argc,char *argv[]) {
     free_parameters(prm, fit, fp, qflgs);
     exit(-1);
   }
+  int echoes_total=0;
+  int echoes_removed=0;
   do {
   
     if (vb) {
@@ -319,7 +321,11 @@ int main (int argc,char *argv[]) {
         
         // Remove record if median=0 (sum of qflgs < 5)
         if (sum < 5) 
+        {
             fit->rng[range].qflg=0;
+            echoes_removed+=1;
+        }
+        echoes_total+=1;
       }
     }
     irec[beam][channel]++;
@@ -359,6 +365,9 @@ int main (int argc,char *argv[]) {
   } while (FitFread(fp,prm,fit) !=-1);
 
   fclose(fp);
+  
+  // Print statistics
+  fprintf(stderr,"Number of echoes removed: %d of %d (%4.1f%%)\n",echoes_removed,echoes_total,100*(float)(echoes_removed)/(float)(echoes_total));
 
   // Free memory
   free_parameters(prm, fit, NULL, qflgs);

--- a/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/fit_speck_removal.c
+++ b/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/fit_speck_removal.c
@@ -103,6 +103,7 @@ void free_parameters(struct RadarParm *prm, struct FitData *fit, FILE *fp, qflgD
 int main (int argc,char *argv[]) {
   
   unsigned char vb=0;
+  unsigned char quiet=0;
   unsigned char help=0;
   unsigned char option=0;
   unsigned char version=0;
@@ -111,6 +112,7 @@ int main (int argc,char *argv[]) {
   OptionAdd(&opt,"-option",'x',&option);
   OptionAdd(&opt,"-version",'x',&version);
   OptionAdd(&opt,"vb",'x',&vb);
+  OptionAdd(&opt,"quiet",'x',&quiet);
 
   int arg;
   arg=OptionProcess(1,argc,argv,&opt,rst_opterr);
@@ -367,7 +369,8 @@ int main (int argc,char *argv[]) {
   fclose(fp);
   
   // Print statistics
-  fprintf(stderr,"Number of echoes removed: %d of %d (%4.1f%%)\n",echoes_removed,echoes_total,100*(float)(echoes_removed)/(float)(echoes_total));
+  if (quiet==0) 
+     fprintf(stderr,"Number of echoes removed: %d of %d (%4.1f%%)\n",echoes_removed,echoes_total,100*(float)(echoes_removed)/(float)(echoes_total));
 
   // Free memory
   free_parameters(prm, fit, NULL, qflgs);


### PR DESCRIPTION
@alexchartier suggested that we update `fit_speck_removal` to print some basic statistics in the terminal about how much scatter was removed. 

Here's an example of the new output: 
```
$ fit_speck_removal 20180308.0201.00.cly.fitacf3 > /dev/null

Number of echoes removed: 3999 of 33074 (12.1%)
```

I also added a new command line option `-quiet` which allows the user can suppress this output if they want to. By default, the statistics will be printed in the terminal.

------------

**Note:** The percentage of scatter removed can seem alarmingly high when the amount of ground/ionospheric scatter is low. In the following example, we see that the time periods with almost no ionospheric/ground scatter have a high percentage of echoes removed (mostly meteor scatter in this example). There is no problem here of course...and we leave it to the user to interpret the results. 

```
$ for file in 20180308*cly.fitacf3; do echo $file ; fit_speck_removal $file > /dev/null ; done

20180308.0001.00.cly.fitacf3
Number of echoes removed: 3002 of 53806 ( 5.6%)
20180308.0201.00.cly.fitacf3
Number of echoes removed: 3999 of 33074 (12.1%)
20180308.0401.00.cly.fitacf3
Number of echoes removed: 1761 of 3576 (49.2%)
20180308.0601.00.cly.fitacf3
Number of echoes removed: 2180 of 7612 (28.6%)
20180308.0801.00.cly.fitacf3
Number of echoes removed: 2285 of 6632 (34.5%)
20180308.1001.00.cly.fitacf3
Number of echoes removed: 3280 of 7232 (45.4%)
20180308.1201.00.cly.fitacf3
Number of echoes removed: 5658 of 37055 (15.3%)
20180308.1401.00.cly.fitacf3
Number of echoes removed: 5379 of 41404 (13.0%)
20180308.1601.00.cly.fitacf3
Number of echoes removed: 5565 of 36754 (15.1%)
20180308.1801.00.cly.fitacf3
Number of echoes removed: 5765 of 46067 (12.5%)
20180308.2001.00.cly.fitacf3
Number of echoes removed: 4548 of 46838 ( 9.7%)
20180308.2201.00.cly.fitacf3
Number of echoes removed: 3917 of 52648 ( 7.4%)
```

![20180308 cly fitacf3](https://user-images.githubusercontent.com/22493623/155374840-163c09fd-4a6d-4860-ac53-8aad30b064e7.png)
![20180308 cly despeck fitacf3](https://user-images.githubusercontent.com/22493623/155374834-9ae841c4-6ce5-4a7b-b0a0-51d1f80ca515.png)

