### PR TITLE
Fixing bug in IDL DLM RadarEpochGetSite and RadarYMDHMSGetSite

### DIFF
--- a/codebase/superdarn/src.dlm/rposdlm.1.9/rposdlm.c
+++ b/codebase/superdarn/src.dlm/rposdlm.1.9/rposdlm.c
@@ -456,9 +456,8 @@ static IDL_VPTR IDLRadarEpochGetSite(int argc,IDL_VPTR *argv) {
     return (IDL_GettmpLong(0));
   if ((iradar->ed_time !=-1) && (tval>iradar->ed_time)) 
     return (IDL_GettmpLong(0));
-  for (s=0;(s<iradar->snum) && (iradar->site[s].tval !=-1) && 
-      (iradar->site[s].tval<tval);s++);
-  if (s==iradar->snum) return (IDL_GettmpLong(0));
+  for (s=0;(s<iradar->snum) && (iradar->site[s].tval<=tval);s++);
+  s=s-1;
 
   isite=IDLRadarMakeSite(&vsite);
 
@@ -523,9 +522,8 @@ static IDL_VPTR IDLRadarYMDHMSGetSite(int argc,IDL_VPTR *argv) {
     return (IDL_GettmpLong(0));
   if ((iradar->ed_time !=-1) && (tval>iradar->ed_time)) 
     return (IDL_GettmpLong(0));
-  for (s=0;(s<iradar->snum) && (iradar->site[s].tval !=-1) && 
-      (iradar->site[s].tval<tval);s++);
-  if (s==iradar->snum) return (IDL_GettmpLong(0));
+  for (s=0;(s<iradar->snum) && (iradar->site[s].tval<=tval);s++);
+  s=s-1;
 
   isite=IDLRadarMakeSite(&vsite);
 


### PR DESCRIPTION
This pull request fixes a bug when calling `RadarYMDHMSGetSite` or `RadarEpochGetSite` via the IDL DLMs which prevents loading the new hardware file format information.  The solution was to modify the two appropriate functions in `rposdlm.c` to match the logic in the native C `RadarEpochGetSite` function in `radar.c`, eg

https://github.com/SuperDARN/rst/blob/develop/codebase/superdarn/src.lib/tk/radar.1.22/src/radar.c#L36-L50