### PR TITLE
Update make_grid tutorial on readthedocs

### DIFF
--- a/docs/user_guide/make_grid.md
+++ b/docs/user_guide/make_grid.md
@@ -3,7 +3,7 @@
 author: Emma Bland, UNIS
 -->
 # FITACF to GRD
-Grid files contain combined data from multiple SuperDARN radars which have been organized into a latitude/longitude grid. Grid files are created in a two-step process:
+Grid files contain combined data that have been organized into a latitude/longitude grid. They may contain data from a single radar or from multiple radars. Multi-radar grid files are created in a two-step process:
 
 1. Create separate grid files for each radar
 2. Combine the separate grid files into a single file
@@ -17,13 +17,14 @@ combine_grid -vb *.grd > [outputfile].grd
 
 The `make_grid` routine provides a lot of options for customizing the gridding process, such as the altitude at which the mapping is performed, or whether to exclude ground/ionospheric scatter. The optional `-xtd` ("extended") flag will include the power and spectral width parameters in the output file, in addition to the velocity. Type `make_grid --help` for more information. 
 	
-## Full-day grid files
-The standard practice is to generate 24-hour grid files. If you have already made a concatenated 24-hour fitacf file, then use that file in the manner shown above. Otherwise, you can use the `-c` flag to get RST to concatenate the input fitacf files on-the-fly. This works only when the input files are all from the same radar; the method for combining data from multiple radars into a single grid file is shown in the next section.
+	
+### Full-day grid files
+The standard practice is to generate 24-hour grid files. If you have already made a concatenated 24-hour fitacf file, then use that file in the manner shown above. Alternatively, you can provide several fitacf files as input to `make_grid`, and the routine will automatically concatenate the files for you. This works only when the input files are all from the same radar; the method for combining data from multiple radars into a single grid file is shown in the next section.
 ```
 make_grid -vb -tl 60 -xtd 20181001.*.lyr.fitacf > 20181001.lyr.grd
 ```
 
-## Multi-Channel Data 
+### Multi-Channel Data 
 
 Some SuperDARN radars provide multi-channel data, either through stereo capability (e.g. Hankasalmi) or as a convenient way to separate data from different frequencies (e.g. the  *twofsound* mode). In both cases, the data are assigned to either channel 1 or channel 2. When only a single channel is used, the channel number is 0. 
 
@@ -56,26 +57,14 @@ make_grid -cn b 20180101.C0.cly.fitacf > 20180101.cly.2.grid
 First, generate grid files for each `fitacf` file you want to include. For example,
 
 ```
-# Make grid files for specific radars
-#
-for radar in lyr cly inv rkn
-do 
-  make_grid -new -tl 60 -xtd -vb -c \
-  20181001*.$radar.fitacf > 20181001.$radar.grd
-done
-```
+# Make grid files for specific radars. The 2-hour fitacf files from each radar are
+# automatically concatenated by make_grid
 
-*The `-f 4` option extracts the 3-letter radar code `rad` from the filename `YYYYMMDD.hhmm.ss.rad.fitacf`.*
-
-```
-# Make grid files for all 2-hour fitacf files in the current
-# directory. The fitacf files are concatenated using the -c flag
-
-radarlist="$(ls | cut -d "." -f 4 | sort -u)"
+radarlist=lyr cly inv rkn
 
 for radar in $radarlist
 do
-  make_grid -tl 60 -xtd -vb 20181001*.$radar.fitacf > 20181001.$radar.grd
+  make_grid -tl 60 -xtd -vb 20181001.*.$radar.fitacf > 20181001.$radar.grd
 done
 ```
 


### PR DESCRIPTION
This PR updates the readthedocs tutorial for making grid files. 

The documentation was written before we removed the `-new` and `-c` (concatenate) command line options from `make_grid`, so that's the motivation for the update.