### PR TITLE
Removing an unnecessary fprintf statement from istp_text.c

### DIFF
--- a/codebase/analysis/src.bin/cdf/istp_text.1.24/istp_text.c
+++ b/codebase/analysis/src.bin/cdf/istp_text.1.24/istp_text.c
@@ -205,7 +205,6 @@ int load_ace() {
   if ((pst !=0) || (swe !=0)) {
     fprintf(stderr,"Calling locate files.\n");
     fptr=locate_files(path,"h0_swe",stime,etime);
-    fprintf(stderr,"got here.\n");
     for (i=0;i<fptr->cnt;i++) {
       fprintf(stderr,"%s\n",fptr->fname[i]);
 


### PR DESCRIPTION
This is a trivial change in `istp_text.c` to remove an unnecessary `fprintf` statement that looks like the leftovers from someone's debugging efforts more than 10 years ago. 