### PR TITLE
Modifying fitacf 2.5, fitex2, and lmfit libraries to correctly handle multi-channel tdiff values

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit.1.19/make_fit.c
@@ -402,9 +402,9 @@ int main(int argc,char *argv[]) {
       }
   }
   else if (fitacf_version == 25) {
-    fblk = FitACFMake(site,prm->time.yr,prm->channel,prm->offset);
+    fblk = FitACFMake(site,prm->time.yr);
     fblk->prm.old_elev = old_elev;        /* passing in old_elev flag */
-    FitACF(prm,raw,fblk,fit);
+    FitACF(prm,raw,fblk,fit,site);
   }
 
   if (old) {
@@ -500,7 +500,7 @@ int main(int argc,char *argv[]) {
         }
       }
       else if (fitacf_version == 25) {
-        FitACF(prm,raw,fblk,fit);
+        FitACF(prm,raw,fblk,fit,site);
       }
       else {
             fprintf(stderr, "The requested fitacf version does not exist\n");

--- a/codebase/superdarn/src.bin/tk/tool/make_fitex2.1.0/make_fitex2.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fitex2.1.0/make_fitex2.c
@@ -233,9 +233,9 @@ int main(int argc,char *argv[])
 	     prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
 
 
-  fblk=FitACFMake(site,prm->time.yr,prm->channel,prm->offset);
+  fblk=FitACFMake(site,prm->time.yr);
 
-  fitacfex2(prm,raw,fit,fblk,0);
+  fitacfex2(prm,raw,fit,fblk,site,0);
 
   if (old)
   {
@@ -279,7 +279,7 @@ int main(int argc,char *argv[])
 
 
     if (status==0)
-			fitacfex2(prm,raw,fit,fblk,0);
+			fitacfex2(prm,raw,fit,fblk,site,0);
 
   } while (status==0);
 

--- a/codebase/superdarn/src.bin/tk/tool/make_lmfit.1.0/make_lmfit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_lmfit.1.0/make_lmfit.c
@@ -232,9 +232,9 @@ int main(int argc,char *argv[])
       fprintf(stderr,"%d-%d-%d %d:%d:%d beam=%d\n",prm->time.yr,prm->time.mo,
 	     prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
 
-  fblk=FitACFMake(site,prm->time.yr,prm->channel,prm->offset);
+  fblk=FitACFMake(site,prm->time.yr);
 
-	lmfit(prm,raw,fit,fblk,0);
+  lmfit(prm,raw,fit,fblk,site,0);
 
   if (old)
   {
@@ -284,7 +284,7 @@ int main(int argc,char *argv[])
 
 
     if (status==0)
-			lmfit(prm,raw,fit,fblk,0);
+			lmfit(prm,raw,fit,fblk,site,0);
 
   } while (status==0);
 

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/include/fitacf.h
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/include/fitacf.h
@@ -26,8 +26,8 @@ Modifications:
 #define _FITACF_H
 
 void FitACFFree(struct FitBlock *fptr); 
-struct FitBlock *FitACFMake(struct RadarSite *hd,int year,int channel,int offset);
+struct FitBlock *FitACFMake(struct RadarSite *hd,int year);
 void FitACF(struct RadarParm *prm,struct RawData *ptr,struct FitBlock *input,
-	    struct FitData *fit);
+	    struct FitData *fit,struct RadarSite *hd);
 
 #endif

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fitacf.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fitacf.c
@@ -54,7 +54,7 @@ void FitACFFree(struct FitBlock *fptr) {
 }
 
 
-struct FitBlock *FitACFMake(struct RadarSite *hd, int year, int channel, int offset) {
+struct FitBlock *FitACFMake(struct RadarSite *hd, int year) {
     int i;
     struct FitBlock *fptr;
 
@@ -66,11 +66,6 @@ struct FitBlock *FitACFMake(struct RadarSite *hd, int year, int channel, int off
     fptr->prm.bmoff=hd->bmoff;
     fptr->prm.bmsep=hd->bmsep;
     fptr->prm.phidiff=hd->phidiff;
-    if ((offset == 0) || (channel < 2)) {
-      fptr->prm.tdiff=hd->tdiff[0];
-    } else {
-      fptr->prm.tdiff=hd->tdiff[1];
-    }
     fptr->prm.vdir=hd->vdir;
     fptr->prm.maxbeam=hd->maxbeam;
     fptr->prm.pulse=NULL;
@@ -83,7 +78,8 @@ struct FitBlock *FitACFMake(struct RadarSite *hd, int year, int channel, int off
 }
 
 int fill_fit_block(struct RadarParm *prm, struct RawData *raw,
-                   struct FitBlock *input, struct FitData *fit){
+                   struct FitBlock *input, struct FitData *fit,
+                   struct RadarSite *hd){
 
     int i, j, n;
     void *tmp=NULL;
@@ -103,6 +99,11 @@ int fill_fit_block(struct RadarParm *prm, struct RawData *raw,
     input->prm.cp=prm->cp;
     input->prm.channel=prm->channel;
     input->prm.offset=prm->offset;  /* stereo offset */
+    if ((input->prm.offset == 0) || (input->prm.channel < 2)) {
+      input->prm.tdiff=hd->tdiff[0];
+    } else {
+      input->prm.tdiff=hd->tdiff[1];
+    }
 
     /* need to incorporate Sessai's code for setting the offset
          for legacy data here.
@@ -167,7 +168,7 @@ int fill_fit_block(struct RadarParm *prm, struct RawData *raw,
     return 0;
 }
 int FitACF(struct RadarParm *prm, struct RawData *raw,struct FitBlock *input,
-           struct FitData *fit) {
+           struct FitData *fit, struct RadarSite *hd) {
 
     int fnum, goose, s;
 
@@ -179,7 +180,7 @@ int FitACF(struct RadarParm *prm, struct RawData *raw,struct FitBlock *input,
     fit->revision.minor=FITACF_MINOR_REVISION;
 
     /*initialize the fitblock with prm*/
-    s = fill_fit_block(prm, raw, input, fit);
+    s = fill_fit_block(prm, raw, input, fit, hd);
     if (s == -1){
         return -1;
     }

--- a/codebase/superdarn/src.lib/tk/fitacfex2.1.0/include/fitacfex2.h
+++ b/codebase/superdarn/src.lib/tk/fitacfex2.1.0/include/fitacfex2.h
@@ -36,6 +36,7 @@ Modifications:
 #define _fitacfex2_H
 
 void fitacfex2(struct RadarParm *prm,struct RawData *raw,
-                struct FitData *fit,struct FitBlock *fblk, int print);
+               struct FitData *fit,struct FitBlock *fblk,
+               struct RadarSite *hd,int print);
 
 #endif

--- a/codebase/superdarn/src.lib/tk/fitacfex2.1.0/src/fitacfex2.c
+++ b/codebase/superdarn/src.lib/tk/fitacfex2.1.0/src/fitacfex2.c
@@ -48,6 +48,7 @@ Modifications:
 #include "nrfit.h"
 #include "dmap.h"
 #include "rprm.h"
+#include "radar.h"
 #include "rawdata.h"
 #include "fitdata.h"
 #include "fitblk.h"
@@ -144,8 +145,9 @@ maxiter = 100;
   }
 }
 
-void fitacfex2(struct RadarParm *prm,struct RawData *raw,
-              struct FitData *fit, struct FitBlock *fblk, int print)
+void fitacfex2(struct RadarParm *prm, struct RawData *raw,
+               struct FitData *fit, struct FitBlock *fblk,
+               struct RadarSite *hd, int print)
 {
   float minpwr  = 3.0;
   double skynoise = 0.;
@@ -224,7 +226,7 @@ void fitacfex2(struct RadarParm *prm,struct RawData *raw,
   }
 
   /*setup fitblock parameter*/
-  setup_fblk(prm, raw, fblk);
+  setup_fblk(prm, raw, fblk, hd);
  
   FitSetRng(fit,fblk->prm.nrang);
   FitSetXrng(fit,fblk->prm.nrang);

--- a/codebase/superdarn/src.lib/tk/lmfit.1.0/include/lmfit.h
+++ b/codebase/superdarn/src.lib/tk/lmfit.1.0/include/lmfit.h
@@ -57,14 +57,16 @@ struct exdatapoints
 };
 
 void lmfit(struct RadarParm *prm,struct RawData *ptr,
-                struct FitData *fit,struct FitBlock *fblk, int print);
+           struct FitData *fit,struct FitBlock *fblk,
+           struct RadarSite *hd,int print);
 double getguessex(struct RadarParm *prm,struct RawData *raw,
               struct FitData *fit, struct FitBlock *fblk, int rang, double skynoise);
 int singlefit(int m, int n, double *p, double *deviates,
                         double **derivs, void *private);
 void lm_noise_stat(struct RadarParm *prm, struct RawData * raw,
                 double * skynoise);
-void setup_fblk(struct RadarParm *prm, struct RawData *raw,struct FitBlock *input);
+void setup_fblk(struct RadarParm *prm, struct RawData *raw,
+                struct FitBlock *input, struct RadarSite *hd);
 double calc_phi0(float *x,float *y, float m, int n);
 void ls_fit(float *x,float *y, int n, float *a, float *b);
 double calc_err(double w_guess, struct RawData *raw, float *good_lags, int goodcnt,

--- a/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
+++ b/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
@@ -38,6 +38,7 @@ Modifications:
 #include "nrfit.h" 
 #include "dmap.h"
 #include "rprm.h"
+#include "radar.h"
 #include "rawdata.h" 
 #include "fitdata.h"
 #include "fitblk.h"
@@ -62,7 +63,7 @@ int lm_dbl_cmp(const void *x,const void *y)
 }
 
 
-void setup_fblk(struct RadarParm *prm, struct RawData *raw,struct FitBlock *input)
+void setup_fblk(struct RadarParm *prm, struct RawData *raw,struct FitBlock *input,struct RadarSite *hd)
 {
   int i,j,n;
   void *tmp=NULL;
@@ -84,6 +85,11 @@ void setup_fblk(struct RadarParm *prm, struct RawData *raw,struct FitBlock *inpu
   input->prm.cp=prm->cp;
   input->prm.channel=prm->channel;
   input->prm.offset=prm->offset; /* stereo offset */
+  if ((input->prm.offset == 0) || (input->prm.channel < 2)) {
+    input->prm.tdiff=hd->tdiff[0];
+  } else {
+    input->prm.tdiff=hd->tdiff[1];
+  }
 
 
   /* need to incorporate Sessai's code for setting the offset
@@ -643,7 +649,8 @@ double getguessex(struct RadarParm *prm,struct RawData *raw,
 }
 
 void lmfit(struct RadarParm *prm,struct RawData *raw,
-              struct FitData *fit, struct FitBlock *fblk, int print)
+           struct FitData *fit, struct FitBlock *fblk,
+           struct RadarSite *hd, int print)
 {
   float minpwr  = 3.0;
   double skynoise = 0.;
@@ -700,7 +707,7 @@ void lmfit(struct RadarParm *prm,struct RawData *raw,
 
 
   /*setup fitblock parameter*/
-  setup_fblk(prm, raw, fblk);
+  setup_fblk(prm, raw, fblk, hd);
 
   FitSetRng(fit,fblk->prm.nrang);
   if(fblk->prm.xcf)


### PR DESCRIPTION
This pull request addresses the issue identified by @pasha-ponomarenko in #493 where channel B `tdiff` values were not being correctly assigned when using `make_fit` with FITACF 2.5.  I had to move the channel-dependent `tdiff` assignment from `FitACFMake` (which is only called once by `make_fit`) to `fill_fit_block` (which is called for every record).  I've also modified the `fitex2` and `lmfit` code to assign the channel-dependent `tdiff` values correctly, even though those fitting algorithms do not calculate elevation angles.

One potential issue I've identified is that if a radar's other hardware information (eg `bmsep`, `bmoff`, etc) change partway through a `rawacf` file (or input file stream) then that may not be accurately captured in the output `fitacf`-format file.  I don't know if that ever happens, since a new `rawacf` file is typically created whenever a radar stops and then starts again, but it may be worth investigating in the future.