### PR TITLE
Tdiff for twof channels

### DIFF
--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fitacf.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fitacf.c
@@ -99,7 +99,7 @@ int fill_fit_block(struct RadarParm *prm, struct RawData *raw,
     input->prm.cp=prm->cp;
     input->prm.channel=prm->channel;
     input->prm.offset=prm->offset;  /* stereo offset */
-    if ((input->prm.offset == 0) || (input->prm.channel < 2)) {
+    if (input->prm.channel < 2) {
       input->prm.tdiff=hd->tdiff[0];
     } else {
       input->prm.tdiff=hd->tdiff[1];

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/fitacftoplevel.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/fitacftoplevel.c
@@ -171,7 +171,7 @@ void Copy_Fitting_Prms(struct RadarSite *radar_site, struct RadarParm *radar_prm
   fit_prms->bmoff=radar_site->bmoff;
   fit_prms->bmsep=radar_site->bmsep;
   fit_prms->phidiff=radar_site->phidiff;
-  if ((radar_prms->offset == 0) || (radar_prms->channel < 2)) {
+  if (radar_prms->channel < 2) {
     fit_prms->tdiff=radar_site->tdiff[0];
   } else {
     fit_prms->tdiff=radar_site->tdiff[1];


### PR DESCRIPTION
This pull request implements changes discussed in https://github.com/SuperDARN/rst/issues/490.

Testing consists of making sure that different tdiffs are applied to different channels in both stereo and USask twofrequency mode data (CLY, SAS, PGR, INV, RKN starting from late 2016, cp_id=3501 or similar). The most straightforward way to test is to compare elevation data for four combinations of tdiff values:
- both tdiff[0] and tdiff[1] are zero -- reference set
- tdiff[0] is non-zero and tdiff[1] is zero -- ch1 changes, ch2  does not change
- tdiff[0] is zero and tdiff[1] is non-zero -- ch1 does not change, ch2  changes
- both tdiff[0] and tdiff[1] are non-zero -- both ch1 and ch2 change

I recommend to do this testing for both FITACF2.5 and FITACF3.0.

Please remember that in the new hardware format the date is given for the first occurrence of the respective set of parameters, while in the old format it is provided for the last occurrence, so one needs to make sure that the correct record in the HDW file is modified.

I used following commands to process and plot data from `20170319.1601.00.cly.rawacf`:
- Processing rawacf files:
FITACF2.5
`make_fit -fitacf-version 2.5 20170319.1601.00.cly.rawacf  > probe_v25_cly_11.fitacf`
FITACF3.0
`make_fit -fitacf-version 3.0 20170319.1601.00.cly.rawacf  > probe_v30_cly_11.fitacf`
- Plotting elevation data (beam 8):
channel 1;
`time_plot -png -e -b 8 -c A -st 16:00 -ex 02:00 -emax 45 probe_v30_cly_11.fitacf > probe_v30_cly_11_ch1.png`
channel 2:
`time_plot -png -e -b 8 -c B -st 16:00 -ex 02:00 -emax 45 probe_v30_cly_11.fitacf > probe_v30_cly_11_ch1.png`


For example, the reference elevation data (tdiff[0]=0, tdiff[1]=0) for FITACF2.5 in the above data looks like this:

- channel 1

![probe_v25_cly_00_ch1](https://user-images.githubusercontent.com/5315016/161155646-c2f48d1b-1c34-496f-a284-cc57da9c553c.png)

- channel 2

![probe_v25_cly_00_ch2](https://user-images.githubusercontent.com/5315016/161156593-7f63958e-60ba-4177-a3bc-da1b5534d6e9.png)


Then I used tdiff[0]=-0.014 and tdiff[1]=0 and obtained the following graphs:

- channel 1 (changed as compared to the reference set above)

![probe_v25_cly_10_ch1](https://user-images.githubusercontent.com/5315016/161155982-38b30b0b-753d-497c-b6b7-89a99e74105b.png)

- channel 2 (unchanged)

![probe_v25_cly_10_ch2](https://user-images.githubusercontent.com/5315016/161156819-8b29a3ac-1322-4b08-b17f-46f0524998d0.png)


 