### PR TITLE
Fixing bug in time_plot causing farthest range cell to be filled

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -1385,7 +1385,7 @@ int main(int argc,char *argv[]) {
         eprng=erng;
       }
 
-      for (rng=sprng;rng<=eprng;rng++) {
+      for (rng=sprng;rng<eprng;rng++) {
         if ((expr !=NULL) && (eval_expr(expr,&tplot,rng)==0)) continue;
         if ((tplot.qflg[rng]==0) && (n !=7)) continue;
         if ((tplot.gsct[rng]==1) && (gmflg)) continue;


### PR DESCRIPTION
This pull request fixes a small bug in `time_plot` which often causes the farthest range cell to be filled, even when the `qflag` associated with that range is not equal to one.  For example, on the `develop` branch using

```
time_plot -png -a -c a -st 00:00 -et 24:00 -erng 110 20220330.hkw.fitacf
```

![20220330 hkw all 00_24](https://user-images.githubusercontent.com/1869073/161394653-6fadf31b-881c-439f-958b-c630cffbed6b.png)

You might notice a blue strip at range gate 69 during the first ~10 hours in each panel.  The number of ranges at HKW changed over the course of this day (from 70 to 75 to 110 to 75), so let's zoom into a smaller region to better see that erroneous band:

```
time_plot -png -a -c a -st 09:00 -et 12:00 -srng 65 -erng 110 20220330.hkw.fitacf
```

![20220330 hkw lim 09_12](https://user-images.githubusercontent.com/1869073/161394676-f02d389f-9015-4faf-84c8-730b76ba3bd7.png)

Looking at the `slist` contents of the `fitacf` output for this day, there are almost never any actual measurements with `qflg = 1` at the furthest range.   On this branch, the plotting bug in `time_plot` is fixed such that this no longer occurs, eg

![20220330 hkw all 00_24_fix](https://user-images.githubusercontent.com/1869073/161394768-cbd1d8f6-8560-47ff-ab7f-b7481d1c5124.png)

![20220330 hkw lim 09_12_fix](https://user-images.githubusercontent.com/1869073/161394775-a8a1682f-1b2c-448b-81e6-844444f264f4.png)

Note this fix doesn't necessarily need to be included in the 4.7 release, I just wanted to include all of the other most recent commits from that branch for compilation purposes.