### PR TITLE
Fixing bug in dattodmap.c causing usr_resL1 to be stored in usr_resL2 (and vice versa)

### DIFF
--- a/codebase/general/src.lib/dat/src/dattodmap.c
+++ b/codebase/general/src.lib/dat/src/dattodmap.c
@@ -87,8 +87,8 @@ int DatToDmap(struct DataMap *ptr, struct DatData *dat) {
     DataMapAddScalar(ptr,"rxrise",DATASHORT,&dat->PARMS.RXRISE);
     DataMapAddScalar(ptr,"bmnum",DATASHORT,&dat->PARMS.BMNUM);
 
-    DataMapAddScalar(ptr,"usr_resL2",DATAINT,&dat->PARMS.usr_resL1); 
-    DataMapAddScalar(ptr,"usr_resL1",DATAINT,&dat->PARMS.usr_resL2);
+    DataMapAddScalar(ptr,"usr_resL1",DATAINT,&dat->PARMS.usr_resL1);
+    DataMapAddScalar(ptr,"usr_resL2",DATAINT,&dat->PARMS.usr_resL2);
     DataMapAddScalar(ptr,"intt",DATASHORT,&dat->PARMS.INTT);
 
     DataMapAddScalar(ptr,"usr_resS1",DATASHORT,&dat->PARMS.usr_resS1);


### PR DESCRIPTION
As indicated by the title, this pull request fixes a bug in `datdump` where the value of `usr_resL1` was being stored in `usr_resL2`, and vice versa.

Note that sometime in the early 2000's, `usr_resL1` became the field in which `offset` information for Stereo radars was stored, eg

https://github.com/SuperDARN/rst/blob/main/codebase/superdarn/src.lib/tk/oldraw.1.16/src/rawreadcurrent.c#L221

Unfortunately the `channel` information for the very earliest Stereo data (eg `2001091721fa.dat`) does not appear to be properly captured by either `datdump` or `dattorawacf`, but I'm not sure how widespread that issue is and it can probably be left for another pull request.