### PR TITLE
Adding new fitacfclientgui binary for alternative display of real-time fit data

### DIFF
--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/doc/fitacfclientgui.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/doc/fitacfclientgui.doc.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<binary>
+<project>superdarn</project>
+<name>fitacfclientgui</name>
+<location>src.bin/tk/tcpip/fitacfclientgui</location>
+
+<syntax>fitacfclientgui --help</syntax>
+<syntax>fitacfclientgui <ar>host</ar> <ar>port</ar></syntax>
+
+<option><on>--help</on><od>print the help message and exit.</od>
+</option>
+<option><on>--version</on><od>print the RST version number and exit.</od>
+</option>
+<option><on>-nrange <ar>nrng</ar></on><od>set the maximum number of range gates to display to <ar>nrng</ar> (default is 75).</od>
+</option>
+<option><on>-color</on><od>display the data stream in color according to the selected parameter (default is power).</od>
+</option>
+<option><on>-p</on><od>plot power.</od>
+</option>
+<option><on>-v</on><od>plot velocity.</od>
+</option>
+<option><on>-w</on><od>plot spectral width.</od>
+</option>
+<option><on>-pmin <ar>pmin</ar></on><od>set the minimum value of the power scale to <ar>pmin</ar>.</od>
+</option>
+<option><on>-pmax <ar>pmax</ar></on><od>set the maximum value of the power scale to <ar>pmax</ar>.</od>
+</option>
+<option><on>-vmin <ar>vmin</ar></on><od>set the minimum value of the velocity scale to <ar>vmin</ar>.</od>
+</option>
+<option><on>-vmax <ar>vmax</ar></on><od>set the maximum value of the velocity scale to <ar>vmax</ar>.</od>
+</option>
+<option><on>-wmin <ar>wmin</ar></on><od>set the minimum value of the spectral width scale to <ar>wmin</ar>.</od>
+</option>
+<option><on>-wmax <ar>wmax</ar></on><od>set the maximum value of the spectral width scale to <ar>wmax</ar>.</od>
+</option>
+<option><on><ar>host</ar></on><od>hostname or IP address of the system to connect to.</od>
+</option>
+<option><on><ar>port</ar></on><od>port number to connect to on the system.</od></option>
+<synopsis><p>Graphical client program for <code>fitacf</code> TCP/IP data streams.</p></synopsis>
+<description><p>Graphical client program for <code>fitacf</code> TCP/IP data streams.</p>
+<p>The program dumps an ASCII representation of the <code>fitacf</code> data stream to standard output.</p>
+</description>
+
+<example>
+<command>fitacfclientgui peanut.jhuapl.edu 1024</command>
+<description>Connect to the host <code>peanut.jhuapl.edu</code> at port 1024 and display the data stream.</description>
+</example>
+
+</binary>

--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/fitacfclientgui.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/fitacfclientgui.c
@@ -1,0 +1,291 @@
+/* fitacfclientgui.c
+   =================
+   Author: E.G.Thomas
+ 
+Copyright (C) 2022  Evan G. Thomas
+
+This file is part of the Radar Software Toolkit (RST).
+
+RST is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+Modifications:
+
+*/
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <time.h>
+#include <unistd.h>
+#include <zlib.h>
+#include <ncurses.h>
+#include <signal.h>
+#include "rtypes.h"
+#include "option.h"
+#include "dmap.h"
+#include "rprm.h"
+#include "fitdata.h"
+#include "connex.h"
+#include "fitcnx.h"
+
+#include "errstr.h"
+#include "hlpstr.h"
+
+
+
+struct OptionData opt;
+
+int rst_opterr(char *txt) {
+  fprintf(stderr,"Option not recognized: %s\n",txt);
+  fprintf(stderr,"Please try: fitacfclientgui --help\n");
+  return(-1);
+}
+
+int main(int argc,char *argv[]) {
+  int i,j,arg;
+  int nrng=75;
+  unsigned char help=0;
+  unsigned char option=0;
+  unsigned char version=0;
+
+  unsigned char colorflg=0;
+  double nlevels=5;
+  double smin=0;
+  double smax=0;
+  int val=0;
+  int start=0;
+
+  unsigned char pwrflg=0;
+  double pmin=0;
+  double pmax=40;
+
+  unsigned char velflg=0;
+  double vmin=-500;
+  double vmax=500;
+
+  unsigned char widflg=0;
+  double wmin=0;
+  double wmax=250;
+
+  int sock;
+  int remote_port=0;
+  char host[256];
+  int flag,status;
+  struct RadarParm *prm;
+  struct FitData *fit;
+ 
+  prm=RadarParmMake();
+  fit=FitMake();
+
+  OptionAdd(&opt,"-help",'x',&help);
+  OptionAdd(&opt,"-option",'x',&option);
+  OptionAdd(&opt,"-version",'x',&version);
+  OptionAdd(&opt,"nrange",'i',&nrng);
+
+  OptionAdd(&opt,"color",'x',&colorflg);
+  OptionAdd(&opt,"p",'x',&pwrflg);
+  OptionAdd(&opt,"pmin",'d',&pmin);
+  OptionAdd(&opt,"pmax",'d',&pmax);
+  OptionAdd(&opt,"v",'x',&velflg);
+  OptionAdd(&opt,"vmin",'d',&vmin);
+  OptionAdd(&opt,"vmax",'d',&vmax);
+  OptionAdd(&opt,"w",'x',&widflg);
+  OptionAdd(&opt,"wmin",'d',&wmin);
+  OptionAdd(&opt,"wmax",'d',&wmax);
+
+  arg=OptionProcess(1,argc,argv,&opt,rst_opterr);
+
+  if (arg==-1) {
+    exit(-1);
+  }
+
+  if (help==1) {
+    OptionPrintInfo(stdout,hlpstr);
+    exit(0);
+  }
+
+  if (option==1) {
+    OptionDump(stdout,&opt);
+    exit(0);
+  }
+
+  if (version==1) {
+    OptionVersion(stdout);
+    exit(0);
+  }
+
+  if (argc-arg<2) {
+    OptionPrintInfo(stdout,errstr);
+    exit(-1);
+  }
+
+  strcpy(host,argv[argc-2]);
+  remote_port=atoi(argv[argc-1]);
+
+  sock=ConnexOpen(host,remote_port,NULL); 
+
+  if (sock<0) {
+    fprintf(stderr,"Could not connect to host.\n");
+    exit(-1);
+  }
+
+  /* Initialize new screen */
+  initscr();
+
+  signal(SIGWINCH, NULL);
+
+  /* Hide the cursor */
+  curs_set(0);
+
+  /* Initialize colors */
+  if (colorflg) {
+    if (has_colors() == FALSE) {
+      endwin();
+      fprintf(stderr,"No color support!\n");
+      exit(1);
+    }
+
+    start_color();
+    init_pair(1, COLOR_MAGENTA, COLOR_BLACK);
+    init_pair(2, COLOR_BLUE, COLOR_BLACK);
+    init_pair(3, COLOR_GREEN, COLOR_BLACK);
+    init_pair(4, COLOR_CYAN, COLOR_BLACK);
+    init_pair(5, COLOR_YELLOW, COLOR_BLACK);
+    init_pair(6, COLOR_RED, COLOR_BLACK);
+
+    init_pair(7, COLOR_MAGENTA, COLOR_MAGENTA);
+    init_pair(8, COLOR_BLUE, COLOR_BLUE);
+    init_pair(9, COLOR_GREEN, COLOR_GREEN);
+    init_pair(10, COLOR_CYAN, COLOR_CYAN);
+    init_pair(11, COLOR_YELLOW, COLOR_YELLOW);
+    init_pair(12, COLOR_RED, COLOR_RED);
+
+    if ((!pwrflg) && (!velflg) && (!widflg)) pwrflg=1;
+
+    if (pwrflg) {
+      smin=pmin;
+      smax=pmax;
+    } else if (velflg) {
+      smin=vmin;
+      smax=vmax;
+    } else if (widflg) {
+      smin=wmin;
+      smax=wmax;
+    }
+  }
+
+  do {
+
+    status=FitCnxRead(1,&sock,prm,fit,&flag,NULL);
+
+    if (status==-1) break;
+
+    if (flag !=-1) {
+      /* Print date/time and radar operating parameters */
+      move(0, 0);
+      clrtoeol();
+      printw("%04d-%02d-%02d %02d:%02d:%02d\n",
+             prm->time.yr,prm->time.mo,prm->time.dy,
+             prm->time.hr,prm->time.mt,prm->time.sc);
+      clrtoeol();
+      printw("stid  = %3d  cpid = %d  channel = %2d\n", prm->stid,prm->cp,prm->channel);
+      clrtoeol();
+      printw("bmnum = %3d  bmazm = %.2f  intt = %3.1f\n",
+             prm->bmnum,prm->bmazm,prm->intt.sc+prm->intt.us/1.0e6);
+      clrtoeol();
+      printw("frang = %3d  nrang = %3d  tfreq = %d\n", prm->frang,prm->nrang,prm->tfreq);
+      clrtoeol();
+      printw("rsep  = %3d  noise.search = %g\n", prm->rsep,prm->noise.search);
+      clrtoeol();
+      printw("scan  = %3d  noise.mean   = %g\n", prm->scan,prm->noise.mean);
+      clrtoeol();
+      printw("mppul = %3d  mpinc = %d\n", prm->mppul,prm->mpinc);
+      clrtoeol();
+      printw("origin.code = %d\n", prm->origin.code);
+
+      if (prm->origin.time != NULL) {
+        clrtoeol();
+        printw("origin.time = %s\n",prm->origin.time);
+      }
+      if (prm->origin.command !=NULL) {
+        clrtoeol();
+        printw("origin.command = %s\n\n",prm->origin.command);
+      }
+
+      /* Draw beam and gate labels */
+      move(11, 0);
+      printw("B\\G 0         10        20        30        40        50        60        70\n");
+
+      /* Draw each range gate for beam */
+      move(prm->bmnum+12, 0);
+      clrtoeol();
+      printw("%02d: ",prm->bmnum);
+      for (i=0;i<nrng; i++) {
+        if (fit->rng[i].qflg == 1) {
+          if (colorflg) {
+            if (pwrflg)      val = (int)((fit->rng[i].p_l-smin)/(smax-smin)*nlevels)+1;
+            else if (velflg) val = (int)((fit->rng[i].v-smin)/(smax-smin)*nlevels)+1;
+            else if (widflg) val = (int)((fit->rng[i].w_l-smin)/(smax-smin)*nlevels)+1;
+
+            if (val < 1) val=1;
+            if (val > nlevels+1) val=nlevels+1;
+            attron(COLOR_PAIR(val));
+          }
+          
+          if (fit->rng[i].gsct != 0) printw("g");
+          else                       printw("i");
+
+          if (colorflg) attroff(COLOR_PAIR(val));
+        } else {
+          printw("-");
+        }
+      }
+      printw("\n");
+
+      /* Draw a color bar */
+      if (colorflg) {
+        move(10, nrng+4);
+        if (pwrflg)      printw("Pow [dB]");
+        else if (velflg) printw("Vel [m/s]");
+        else if (widflg) printw("Wid [m/s]");
+        start=12;
+        for (j=12;j>6;j--) {
+          attron(COLOR_PAIR(j));
+          for (i=start;i<start+2;i++) {
+            move(i, nrng+5);
+            printw(" ");
+          }
+          attroff(COLOR_PAIR(j));
+          move(i-1, nrng+7);
+          printw("%d",(int)((j-7)*(smax-smin)/nlevels+smin));
+          start=start+2;
+        }
+      }
+
+      refresh();
+
+    }
+
+  } while(1);
+
+  endwin();
+
+  return 0;
+}

--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/makefile
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/makefile
@@ -1,0 +1,17 @@
+# Makefile for fitacfclientgui
+# ============================
+# Author: E.G.Thomas
+# by E.G.Thomas
+#
+#
+include $(MAKECFG).$(SYSTEM)
+INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn
+OBJS = fitacfclientgui.o
+SRC=hlpstr.h errstr.h fitacfclientgui.c
+
+LIBS=-lfitcnx.1 -lfit.1 -lcfit.1 -lrscan.1 -lradar.1 -lcnx.1 -ldmap.1 -lopt.1 -lrtime.1 -lrcnv.1 -lncurses -ltinfo
+SLIB=-lz
+DSTPATH = $(BINPATH)
+OUTPUT = fitacfclientgui
+
+include $(MAKEBIN).$(SYSTEM)


### PR DESCRIPTION
This pull request adds a new `fitacfclientgui` binary that I worked on a year or so ago and thought might be of general interest.  As opposed to `fitacfclient` where the real-time fit data keep scrolling down the terminal window, this routine refreshes a single window which displays `i`, `g`, and `-` symbols for ionospheric, ground, or no scatter, respectively, at each gate along each beam of a scan.  The `-color` option can be used to color-code these symbols according to power (`-p`, default), velocity (`-v`), or spectral width (`-w`), eg

![fitacfclientgui_example](https://user-images.githubusercontent.com/1869073/169390334-9c6d3ca6-2bd8-498b-9103-f34d5082dfb5.png)

For testing, if you don't have access to a real-time data stream you could probably spoof one using `fitacfserver` (eg #273).