### PR TITLE
Add Shepherd elevation angle calculation to `fitex2`

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_fit/make_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit/make_fit.c
@@ -423,6 +423,7 @@ int main(int argc,char *argv[]) {
   }
   else if (strcmp(fitting_algorithm, "fitex2") == 0) {
     fblk=FitACFMake(site,prm->time.yr);
+    fblk->prm.old_elev = old_elev;
     fitacfex2(prm,raw,fit,fblk,site,0);
   }
   else if (strcmp(fitting_algorithm, "fitex1") == 0) {

--- a/codebase/superdarn/src.lib/tk/fitacfex2.1.0/src/fitacfex2.c
+++ b/codebase/superdarn/src.lib/tk/fitacfex2.1.0/src/fitacfex2.c
@@ -2,7 +2,7 @@
 /* fitacfex2.c
 ==========
 TODO: Add copyright statment 
-Algorithm: R.A.Greenwald, K.Oskavik
+Algorithm: R.A.Greenwald, K.Oksavik
 Implementation: R.J.Barnes, R.A.Greenwald
 
 Copyright (C) <year>  <name of author>

--- a/codebase/superdarn/src.lib/tk/fitacfex2.1.0/src/fitacfex2.c
+++ b/codebase/superdarn/src.lib/tk/fitacfex2.1.0/src/fitacfex2.c
@@ -611,11 +611,8 @@ void fitacfex2(struct RadarParm *prm, struct RawData *raw,
           /* use old elevation angle routines 
              NB: elev_goose() has never been used in fitacfex2 */
              fit->elv[R].normal = elevation(&fblk->prm,phi0);
-           
-          /* TODO This is just calculating the elevation angle again. 
-             Need to determine phi0_error.*/
-             fit->elv[R].high = elevation(&fblk->prm,phi0);
-             fit->elv[R].low = elevation(&fblk->prm,phi0);
+             fit->elv[R].high = 0.; // no error calculation since we don't have phi0_error
+             fit->elv[R].low = 0.;  // no error calculation since we don't have phi0_error
           }
           else {
             /* use the Shepherd elevation angle routine */

--- a/codebase/superdarn/src.lib/tk/fitacfex2.1.0/src/fitacfex2.c
+++ b/codebase/superdarn/src.lib/tk/fitacfex2.1.0/src/fitacfex2.c
@@ -1,11 +1,11 @@
 
 /* fitacfex2.c
-   ==========
-   TODO: Add copyright statment 
-   Algorithm: R.A.Greenwald, K.Oskavik
-   Implementation: R.J.Barnes, R.A.Greenwald
+==========
+TODO: Add copyright statment 
+Algorithm: R.A.Greenwald, K.Oskavik
+Implementation: R.J.Barnes, R.A.Greenwald
 
-   Copyright (C) <year>  <name of author>
+Copyright (C) <year>  <name of author>
 
 This file is part of the Radar Software Toolkit (RST).
 
@@ -23,17 +23,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 Modifications:
-
-   RST is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-   
-   This program is distributed in the hope that it will be useful,
-   GNU General Public License for more details.
-   
-   You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    Emma Bland 22-05-2022 (University Centre in Svalbard) Added Shepherd elevation angle algorithm
 
 */
 
@@ -614,10 +604,25 @@ void fitacfex2(struct RadarParm *prm, struct RawData *raw,
 
           }
           phi0 = calc_phi0(good_lags,xcf_phases, w_guess, goodcnt)*PI/180.;
+          //TODO calculate phi0_error
           fit->xrng[R].phi0 = phi0;
-          fit->elv[R].normal = elevation(&fblk->prm,phi0);
-          fit->elv[R].high = elevation(&fblk->prm,phi0);
-          fit->elv[R].low = elevation(&fblk->prm,phi0);
+          
+          if (fblk->prm.old_elev) {
+          /* use old elevation angle routines 
+             NB: elev_goose() has never been used in fitacfex2 */
+             fit->elv[R].normal = elevation(&fblk->prm,phi0);
+           
+          /* TODO This is just calculating the elevation angle again. 
+             Need to determine phi0_error.*/
+             fit->elv[R].high = elevation(&fblk->prm,phi0);
+             fit->elv[R].low = elevation(&fblk->prm,phi0);
+          }
+          else {
+            /* use the Shepherd elevation angle routine */
+            fit->elv[R].normal = elevation_v2(&fblk->prm,phi0);
+            fit->elv[R].high = 0.; // no error calculation since we don't have phi0_error
+            fit->elv[R].low = 0.;  // no error calculation since we don't have phi0_error
+          }
         }
         else
           {


### PR DESCRIPTION
While working on #504 I noticed that `fitex2` uses the old elevation angle calculations. This was also identified by @egthomas back in #150 and was easy to update thanks to #217 and #504 :100: 


The default elevation angle algorithm is now `elevation_v2()`. The command line option `-old_elev` can be used to access the old version.
 ```
# Use Shepherd elevation angle algorithm, elevation_v2()
make_fit -fitting-algorithm fitex2 20180323.0801.00.lyr.rawacf > 20180323.0801.00.lyr.fitex2

# Use original elevation angle algorithm, elevation()
make_fit -fitting-algorithm fitex2 -old_elev 20180323.0801.00.lyr.rawacf > 20180323.0801.00.lyr.fitex2
```

Notice that `fitex2` does not calculate the phase error (`phi0_err`), so the upper and lower bounds on the elevation cannot be determined. I added some comments to reflect this, but I'm not intending to fix it. 

Note: The target branch for this PR is `feature/make_fit` due to the changes I proposed in #504