### PR TITLE
Update linux_install.md

### DIFF
--- a/docs/user_guide/linux_install.md
+++ b/docs/user_guide/linux_install.md
@@ -85,20 +85,20 @@ Now install the [CDF library](#cdf-library)
 
 ### Mint 
 
-Mint 18.1 	|
+Mint 20.2 	|
 --------- 	|
 libc6-dev 	|
 libncurses5-dev |
 libnetcdf-dev 	|
-libpng16-dev 	|
+libpng-dev 	|
 libx11-dev 	|
 libxext-dev 	|
 netcdf 		|
 netcdf-devel 	|
 
-**Mint 18.1**
+**Mint 20.2**
     
-    sudo apt-get install libc6-dev libncurses5-dev libnetcdf-dev libpng16-dev libx11-dev libxext-dev
+    apt install libc6-dev libncurses5-dev libnetcdf-dev libpng-dev libx11-dev libxext-dev
 
 
 


### PR DESCRIPTION
This PR updates the installation guide for Linux Mint. The previous instructions give an error for `libpng16-dev`

```
Package libpng16-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libpng-dev:i386 libpng-dev
```