### PR TITLE
AACGM_v2 / MLT_v2 update

### DIFF
--- a/codebase/analysis/src.lib/aacgm_v2/aacgm.1.0/include/aacgmlib_v2.h
+++ b/codebase/analysis/src.lib/aacgm_v2/aacgm.1.0/include/aacgmlib_v2.h
@@ -63,6 +63,8 @@ int AACGM_v2_SetDateTime(int year, int month, int day,
                          int hour, int minute, int second);
 int AACGM_v2_GetDateTime(int *year, int *month, int *day,
                          int *hour, int *minute, int *second, int *dayno);
+int AACGM_v2_SetLock(int lock);
+int AACGM_v2_GetLock(int *lock);
 int AACGM_v2_SetNow(void);
 
 #endif

--- a/codebase/analysis/src.lib/aacgm_v2/aacgm.1.0/src/aacgmlib_v2.c
+++ b/codebase/analysis/src.lib/aacgm_v2/aacgm.1.0/src/aacgmlib_v2.c
@@ -37,6 +37,8 @@
 ; AACGM_v2_SetDateTime
 ; AACGM_v2_GetDateTime
 ; AACGM_v2_SetNow
+; AACGM_v2_SetLock
+; AACGM_v2_GetLock
 ; AACGM_v2_errmsg
 ;
 
@@ -69,7 +71,8 @@ static struct {
   int second;
   int dayno;
   int daysinyear;
-} aacgm_date = {-1,-1,-1,-1,-1,-1,-1,-1};
+  int lock;
+} aacgm_date = {-1,-1,-1,-1,-1,-1,-1,-1,-1};
 
 static int myear = 0;       /* model year: 5-year epoch */
 static double fyear = 0.;   /* floating point year */
@@ -1205,6 +1208,62 @@ int AACGM_v2_SetNow(void)
   err = AACGM_v2_TimeInterp();
 
   return err;
+}
+
+/*-----------------------------------------------------------------------------
+;
+; NAME:
+;       AACGM_v2_SetLock
+;
+; PURPOSE:
+;       Function to set lock, which can be used to prevent extra date and time
+;       checks when performing MLT_v2 conversions.
+;
+; CALLING SEQUENCE:
+;       err = AACGM_v2_SetLock(lock);
+;
+;     Input Arguments:
+;       lock          - lock [-1 or 1]
+;
+;     Return Value:
+;       error code
+;
+;+-----------------------------------------------------------------------------
+*/
+
+int AACGM_v2_SetLock(int lock)
+{
+  aacgm_date.lock = lock;
+
+  return 0;
+}
+
+/*-----------------------------------------------------------------------------
+;
+; NAME:
+;       AACGM_v2_GetLock
+;
+; PURPOSE:
+;       Function to get lock, which can be used to prevent extra date and time
+;       checks when performing MLT_v2 conversions.
+;
+; CALLING SEQUENCE:
+;       err = AACGM_v2_GetLock(lock);
+;
+;     Output Arguments (integer pointer):
+;       lock          - lock [-1 or 1]
+;
+;     Return Value:
+;       error code
+;
+;+-----------------------------------------------------------------------------
+*/
+
+int AACGM_v2_GetLock(int *lock)
+{
+  *lock = aacgm_date.lock;
+
+  return 0;
 }
 
 /*-----------------------------------------------------------------------------

--- a/codebase/analysis/src.lib/mlt_v2/mlt.1.0/src/mlt_v2.c
+++ b/codebase/analysis/src.lib/mlt_v2/mlt.1.0/src/mlt_v2.c
@@ -87,7 +87,7 @@ struct {
 double MLTConvert_v2(int yr, int mo, int dy, int hr, int mt ,int sc,
                       double mlon)
 {
-  int err;
+  int err,lock;
   int ayr,amo,ady,ahr,amt,asc,adyn;
   double dd,jd,eqt,dec,ut,at;
   double slon,mlat,r;
@@ -101,14 +101,17 @@ double MLTConvert_v2(int yr, int mo, int dy, int hr, int mt ,int sc,
     err = AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,sc);
     if (err != 0) return (err);
   } else {
-    /* If date/time passed into function differs from AACGM data/time by more
-     * than 30 days, recompute the AACGM-v2 coefficients */
-    ajd = TimeYMDHMSToJulian(ayr,amo,ady,ahr,amt,asc);
-    jd =  TimeYMDHMSToJulian(yr,mo,dy,hr,mt,sc);
-    if (abs((int)(jd-ajd)) > 30) {
-      err = AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,sc);
+    AACGM_v2_GetLock(&lock);
+    if (lock != 1) {
+      /* If date/time passed into function differs from AACGM data/time by more
+       * than 30 days, recompute the AACGM-v2 coefficients */
+      ajd = TimeYMDHMSToJulian(ayr,amo,ady,ahr,amt,asc);
+      jd =  TimeYMDHMSToJulian(yr,mo,dy,hr,mt,sc);
+      if (abs((int)(jd-ajd)) > 30) {
+        err = AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,sc);
+      }
+      if (err != 0) return (err);
     }
-    if (err != 0) return (err);
   }
 
 /* check for bad input, which can come from undefined region, and return NAN */

--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
@@ -1224,7 +1224,10 @@ int main(int argc,char *argv[]) {
   radar=RadarGetRadar(network,scn->stid);
   site=RadarYMDHMSGetSite(radar,yr,mo,dy,hr,mt,(int) sc);
 
-  if (!old_aacgm) AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,(int)sc); /* required */
+  if (!old_aacgm) {
+    AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,(int)sc); /* required */
+    if (magflg) AACGM_v2_SetLock(1);
+  }
 
   if (site->geolat>0) hemisphere=1;
   else hemisphere=-1;

--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
@@ -651,7 +651,10 @@ int main(int argc,char *argv[]) {
   TimeEpochToYMDHMS(tval,&yr,&mo,&dy,&hr,&mt,&sc);
   yrsec=TimeYMDHMSToYrsec(yr,mo,dy,hr,mt,sc);
 
-  if (!old_aacgm) AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,(int)sc); /* required */
+  if (!old_aacgm) {
+    AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,(int)sc); /* required */
+    if (magflg) AACGM_v2_SetLock(1);
+  }
 
   if (magflg) {
     if (old_aacgm) {

--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
@@ -931,7 +931,10 @@ int main(int argc,char *argv[]) {
     s = (*Grid_Read)(fp,rgrid);
   }
  
-  if (!old_aacgm) AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,(int)sc); /* required */
+  if (!old_aacgm) {
+    AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,(int)sc); /* required */
+    if (magflg) AACGM_v2_SetLock(1);
+  }
 
   if (!sqflg) clip=MapCircleClip(10);
   else clip=MapSquareClip();

--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
@@ -844,7 +844,10 @@ int main(int argc,char *argv[]) {
 
   noigrf = rcmap->noigrf;
   if (!noigrf)    IGRF_SetDateTime(yr,mo,dy,hr,mt,(int)sc);
-  if (!old_aacgm) AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,(int)sc); /* required */
+  if (!old_aacgm) {
+    AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,(int)sc); /* required */
+    if (magflg) AACGM_v2_SetLock(1);
+  }
 
   if (!sqflg) clip=MapCircleClip(10);
   else clip=MapSquareClip();

--- a/codebase/superdarn/src.bin/tk/plot/vec_plot.1.9/vec_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/vec_plot.1.9/vec_plot.c
@@ -630,7 +630,10 @@ int main(int argc,char *argv[]) {
 
       yrsec=TimeYMDHMSToYrsec(yr,mo,dy,hr,mt,sc);
 
-      if (!old_aacgm) AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,(int)sc); /* required */
+      if (!old_aacgm) {
+        AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,(int)sc); /* required */
+        AACGM_v2_SetLock(1);
+      }
 
       if (mlon_av_cnt !=0) {
         mlon_av_val=mlon_av_val/mlon_av_cnt;

--- a/codebase/superdarn/src.bin/tk/tool/map_addhmb.1.17/map_addhmb.c
+++ b/codebase/superdarn/src.bin/tk/tool/map_addhmb.1.17/map_addhmb.c
@@ -275,6 +275,7 @@ int main(int argc,char *argv[])
         tme=(grd[buf]->st_time+grd[buf]->ed_time)/2.0;
         TimeEpochToYMDHMS(tme,&yr,&mo,&dy,&hr,&mt,&sc);
         AACGM_v2_SetDateTime(yr,mo,dy,hr,mt,(int)sc);
+        AACGM_v2_SetLock(1);
       }
     }
 

--- a/codebase/superdarn/src.bin/tk/tool/map_grd.1.16/map_grd.c
+++ b/codebase/superdarn/src.bin/tk/tool/map_grd.1.16/map_grd.c
@@ -240,6 +240,8 @@ int main(int argc,char *argv[]) {
   if (old_aacgm) MLTCnv = &MLTConvertYrsec;
   else           MLTCnv = &MLTConvertYrsec_v2;
 
+  if (!old_aacgm) AACGM_v2_SetLock(1);
+
   if (sh==1) map->hemisphere=-1;
 
   if (empty) {


### PR DESCRIPTION
This (draft) pull request fixes an issue I noticed several years ago after we implemented AACGM_v2 / MLT_v2 into the RST.  Specifically, I noticed a dramatic slowdown when using `map_addhmb` with the new -v2 coordinate transformations as compared to using the old AACGM coefficients (via the `-old_aacgm` flag).

The two new functions (`AACGM_v2_SetLock` and `AACGM_v2_GetLock`) allow the user to bypass certain date/time checks within `MLTConvert_v2` which were causing the performance decrease (and typically unnecessary when working with <= 24 hours of data from a single file).

I still need to coordinate this with Simon, which is why this pull request is currently marked as a draft.