### PR TITLE
Fitting algorithm field

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
@@ -1196,8 +1196,12 @@ int main(int argc,char *argv[]) {
     stid=prm->stid;
     cptab[0]=prm->cp;
     cpnum=1;
-    sprintf(revtxt,"Revision:%d.%d",fit->revision.major,
-            fit->revision.minor);
+    if (fit->algorithm !=NULL) {
+      sprintf(revtxt,"%s",fit->algorithm);
+    } else {
+      sprintf(revtxt,"Revision:%d.%d",fit->revision.major,
+              fit->revision.minor);
+    }
   }
   if (cfitflg) {
     stid=cfit->stid;

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -1161,8 +1161,12 @@ int main(int argc,char *argv[]) {
     stid=prm->stid;
     cptab[0]=prm->cp;
     cpnum=1;
-    sprintf(revtxt,"Revision:%d.%d",fit->revision.major,
-            fit->revision.minor);
+    if (fit->algorithm !=NULL) {
+      sprintf(revtxt,"%s",fit->algorithm);
+    } else {
+      sprintf(revtxt,"Revision:%d.%d",fit->revision.major,
+              fit->revision.minor);
+    }
   }
   if (sndflg) {
     stid=snd->stid;

--- a/codebase/superdarn/src.bin/tk/tool/make_fit/make_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit/make_fit.c
@@ -396,7 +396,8 @@ int main(int argc,char *argv[]) {
           }
           Copy_Fitting_Prms(site,prm,raw,fit_prms);
     	  Fitacf(fit_prms,fit, elv_version);
-        /*FitacfFree(fit_prms);*/
+          FitSetAlgorithm(fit,"fitacf3");
+          /*FitacfFree(fit_prms);*/
     	}
       else {
           fprintf(stderr, "Unable to allocate fit_prms!\n");
@@ -410,18 +411,22 @@ int main(int argc,char *argv[]) {
     fblk = FitACFMake(site,prm->time.yr);
     fblk->prm.old_elev = old_elev;        /* passing in old_elev flag */
     FitACF(prm,raw,fblk,fit,site);
+    FitSetAlgorithm(fit,"fitacf2");
   }
   else if (lmfit1) {
     fblk=FitACFMake(site,prm->time.yr);
     lmfit(prm,raw,fit,fblk,site,0);
+    FitSetAlgorithm(fit,"lmfit1");
   }
   else if (fitex2) {
     fblk=FitACFMake(site,prm->time.yr);
     fblk->prm.old_elev = old_elev;
     fitacfex2(prm,raw,fit,fblk,site,0);
+    FitSetAlgorithm(fit,"fitex2");
   }
   else if (fitex1) {
     FitACFex(prm,raw,fit);
+    FitSetAlgorithm(fit,"fitex1");
   }
 
   if (old) {
@@ -506,6 +511,7 @@ int main(int argc,char *argv[]) {
         if(fit_prms != NULL) {
           Copy_Fitting_Prms(site,prm,raw,fit_prms);
           Fitacf(fit_prms,fit, elv_version);
+          FitSetAlgorithm(fit,"fitacf3");
           /*FitacfFree(fit_prms);*/
         }
         else {
@@ -518,20 +524,24 @@ int main(int argc,char *argv[]) {
       }
       else if (fitacf2) {
         FitACF(prm,raw,fblk,fit,site);
+        FitSetAlgorithm(fit,"fitacf2");
       }
       else if (lmfit1) {
         lmfit(prm,raw,fit,fblk,site,0);
+        FitSetAlgorithm(fit,"lmfit1");
       }
       else if (fitex2) {
         fitacfex2(prm,raw,fit,fblk,site,0);
+        FitSetAlgorithm(fit,"fitex2");
       }
       else if (fitex1) {
         FitACFex(prm,raw,fit);
+        FitSetAlgorithm(fit,"fitex1");
       }
       else {
-      fprintf(stderr, "The requested fitting algorithm does not exist\n");
-      OptionFree(&opt);
-      exit(-1);
+        fprintf(stderr, "The requested fitting algorithm does not exist\n");
+        OptionFree(&opt);
+        exit(-1);
       }
     }
 

--- a/codebase/superdarn/src.idl/lib/main.1.25/fit.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/fit.pro
@@ -67,6 +67,7 @@ pro FitMakeFitData,fit
   MAX_RANGE=300
 
   fit={FitData, $
+         algorithm: ' ', $
          revision: {rlstr, major: 0L, minor: 0L}, $ 
          noise: {nfstr, sky: 0.0, lag0: 0.0, vel: 0.0}, $
          pwr0: fltarr(MAX_RANGE), $
@@ -152,10 +153,10 @@ function FitRead,unit,prm,fit
    return,s
   endif
 
-  sclname=['fitacf.revision.major','fitacf.revision.minor', $
+  sclname=['algorithm','fitacf.revision.major','fitacf.revision.minor', $
            'noise.sky','noise.lag0','noise.vel']
 
-  scltype=[3,3,4,4,4]
+  scltype=[9,3,3,4,4,4]
   
   sclid=intarr(n_elements(sclname))
   sclid[*]=-1
@@ -195,11 +196,12 @@ function FitRead,unit,prm,fit
  
   ; populate the structures
 
-  fit.revision.major=*(sclvec[sclid[0]].ptr)
-  fit.revision.minor=*(sclvec[sclid[1]].ptr)
-  fit.noise.sky=*(sclvec[sclid[2]].ptr)
-  fit.noise.lag0=*(sclvec[sclid[3]].ptr)
-  fit.noise.vel=*(sclvec[sclid[4]].ptr)
+  if (sclid[0] ne -1) then fit.algorithm=*(sclvec[sclid[0]].ptr)
+  fit.revision.major=*(sclvec[sclid[1]].ptr)
+  fit.revision.minor=*(sclvec[sclid[2]].ptr)
+  fit.noise.sky=*(sclvec[sclid[3]].ptr)
+  fit.noise.lag0=*(sclvec[sclid[4]].ptr)
+  fit.noise.vel=*(sclvec[sclid[5]].ptr)
 
   if (prm.nrang gt 0) then fit.pwr0[0:prm.nrang-1]=*(arrvec[arrid[1]].ptr)
 
@@ -294,6 +296,7 @@ function FitWrite,unit,prm,fit
 
   s=RadarEncodeRadarPrm(prm,sclvec,arrvec,/new)
 
+  s=DataMapMakeScalar('algorithm',fit.algorithm,sclvec)
   s=DataMapMakeScalar('fitacf.revision.major',fit.revision.major,sclvec)
   s=DataMapMakeScalar('fitacf.revision.minor',fit.revision.minor,sclvec)
   s=DataMapMakeScalar('noise.sky',fit.noise.sky,sclvec)

--- a/codebase/superdarn/src.lib/tk/fit.1.35/doc/fit.doc.xml
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/doc/fit.doc.xml
@@ -207,6 +207,11 @@
   <struct>
 
     <member>
+      <proto>char *algorithm;</proto>
+      <description>The fitting algorithm used to generate the file.</description>
+    </member>
+
+    <member>
       <struct>
         <member>
           <proto>char major;</proto>

--- a/codebase/superdarn/src.lib/tk/fit.1.35/include/fitdata.h
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/include/fitdata.h
@@ -32,6 +32,7 @@ Modifications:
 #endif
 
 struct FitData {
+  char *algorithm;
   struct {
     int major;
     int minor;
@@ -39,7 +40,7 @@ struct FitData {
   struct FitNoise noise;
   struct FitRange *rng;
   struct FitRange *xrng;
-  struct FitElv  *elv;
+  struct FitElv *elv;
 };
 
 struct FitData *FitMake();

--- a/codebase/superdarn/src.lib/tk/fit.1.35/include/fitdata.h
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/include/fitdata.h
@@ -45,6 +45,7 @@ struct FitData {
 
 struct FitData *FitMake();
 void FitFree(struct FitData *ptr);
+int FitSetAlgorithm(struct FitData *ptr,char *str);
 int FitSetRng(struct FitData *ptr,int nrang);
 int FitSetXrng(struct FitData *ptr,int nrang);
 int FitSetElv(struct FitData *ptr,int nrang);

--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fit.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fit.c
@@ -38,6 +38,7 @@ struct FitData *FitMake() {
   ptr=malloc(sizeof(struct FitData));
   if (ptr==NULL) return NULL;
   memset(ptr,0,sizeof(struct FitData));
+  ptr->algorithm=NULL;
   ptr->rng=NULL;
   ptr->xrng=NULL;
   ptr->elv=NULL;
@@ -47,12 +48,34 @@ struct FitData *FitMake() {
 void FitFree(struct FitData *ptr) {
 
   if (ptr==NULL) return;
+  if (ptr->algorithm !=NULL) free(ptr->algorithm);
   if (ptr->rng !=NULL) free(ptr->rng);
   if (ptr->xrng !=NULL) free(ptr->xrng);
   if (ptr->elv !=NULL) free(ptr->elv);
   free(ptr);
   return;
 }
+
+
+int FitSetAlgorithm(struct FitData *ptr,char *str) {
+  char *tmp=NULL;
+  if (ptr==NULL) return -1;
+
+  if (str==NULL) {
+    if (ptr->algorithm !=NULL) free(ptr->algorithm);
+    ptr->algorithm=NULL;
+    return 0;
+  }
+
+  if (ptr->algorithm==NULL) tmp=malloc(strlen(str+1));
+  else tmp=realloc(ptr->algorithm,strlen(str)+1);
+
+  if (tmp==NULL) return -1;
+  strcpy(tmp,str);
+  ptr->algorithm=tmp;
+  return 0;
+}
+
 
 int FitSetRng(struct FitData *ptr,int nrang) {
   void *tmp=NULL;

--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fitread.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fitread.c
@@ -61,6 +61,9 @@ int FitDecode(struct DataMap *ptr,
   for (c=0;c<ptr->snum;c++) {
     s=ptr->scl[c];
 
+    if ((strcmp(s->name,"algorithm")==0) && (s->type=DATASTRING))
+      FitSetAlgorithm(fit,*((char **) s->data.vptr));
+
     if ((strcmp(s->name,"fitacf.revision.major")==0) && (s->type==DATAINT))
       fit->revision.major=*(s->data.iptr);
     if ((strcmp(s->name,"fitacf.revision.minor")==0) && (s->type==DATAINT))

--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fitwrite.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fitwrite.c
@@ -94,6 +94,8 @@ int FitEncode(struct DataMap *ptr,struct RadarParm *prm, struct FitData *fit) {
   float lag0_noise;
   float vel_noise;
 
+  DataMapAddScalar(ptr,"algorithm",DATASTRING,&fit->algorithm);
+
   DataMapAddScalar(ptr,"fitacf.revision.major",DATAINT,
 		    &fit->revision.major);
   DataMapAddScalar(ptr,"fitacf.revision.minor",DATAINT,

--- a/codebase/superdarn/src.lib/tk/idl/fitidl.1.5/include/fitidl.h
+++ b/codebase/superdarn/src.lib/tk/idl/fitidl.1.5/include/fitidl.h
@@ -29,6 +29,7 @@ Modifications:
 
 
 struct FitIDLData {
+  IDL_STRING algorithm;
   struct {
     IDL_LONG major;
     IDL_LONG minor;

--- a/codebase/superdarn/src.lib/tk/idl/fitidl.1.5/src/fitidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/fitidl.1.5/src/fitidl.c
@@ -112,7 +112,7 @@ void IDLCopyFitDataToIDL(int nrang,int xcf,struct FitData *fit,
 
   int n;
 
-  char algorithmtmp[ALGORITHM_SIZE+1]
+  char algorithmtmp[ALGORITHM_SIZE+1];
 
   memset(&algorithmtmp,0,ALGORITHM_SIZE+1);
 
@@ -191,7 +191,7 @@ struct FitIDLData *IDLMakeFitData(IDL_VPTR *vptr) {
 
   
   static IDL_STRUCT_TAG_DEF fitdata[]={    
-    {"ALGORITHM",0,NULL},  /* 0 */
+    {"ALGORITHM",0,(void *) IDL_TYP_STRING},  /* 0 */
     {"REVISION",0,NULL},   /* 1 */
     {"NOISE",0,NULL},   /* 2 */ 
     {"PWR0",rdim,(void *) IDL_TYP_FLOAT}, /* 3 */
@@ -237,8 +237,8 @@ struct FitIDLData *IDLMakeFitData(IDL_VPTR *vptr) {
   static IDL_MEMINT ilDims[IDL_MAX_ARRAY_DIM];
  
     
-  fitdata[0].type=IDL_MakeStruct("RLSTR",revision);
-  fitdata[1].type=IDL_MakeStruct("NFSTR",noise);
+  fitdata[1].type=IDL_MakeStruct("RLSTR",revision);
+  fitdata[2].type=IDL_MakeStruct("NFSTR",noise);
 
   s=IDL_MakeStruct("FITDATA",fitdata);
            

--- a/codebase/superdarn/src.lib/tk/idl/fitidl.1.5/src/fitidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/fitidl.1.5/src/fitidl.c
@@ -40,6 +40,8 @@
 #include "rprmidl.h"
 #include "fitidl.h"
 
+#define ALGORITHM_SIZE 80
+
 void IDLCopyFitDataFromIDL(int nrang,int xcf,struct FitIDLData *ifit,
                            struct FitData *fit) {
 
@@ -50,6 +52,9 @@ void IDLCopyFitDataFromIDL(int nrang,int xcf,struct FitIDLData *ifit,
      FitSetXrng(fit,nrang);
      FitSetElv(fit,nrang);
   }
+
+  if (strlen(IDL_STRING_STR(&ifit->algorithm)) !=0)
+    FitSetAlgorithm(fit,IDL_STRING_STR(&ifit->algorithm));
 
   fit->revision.major=ifit->revision.major;
   fit->revision.minor=ifit->revision.minor;
@@ -107,7 +112,16 @@ void IDLCopyFitDataToIDL(int nrang,int xcf,struct FitData *fit,
 
   int n;
 
+  char algorithmtmp[ALGORITHM_SIZE+1]
+
+  memset(&algorithmtmp,0,ALGORITHM_SIZE+1);
+
   memset(ifit,0,sizeof(struct FitIDLData));
+
+  if (fit->algorithm !=NULL) {
+    strncpy(algorithmtmp,fit->algorithm,ALGORITHM_SIZE);
+    IDL_StrStore(&ifit->algorithm,algorithmtmp);
+  }
 
   ifit->revision.major=fit->revision.major;
   ifit->revision.minor=fit->revision.minor;
@@ -177,45 +191,46 @@ struct FitIDLData *IDLMakeFitData(IDL_VPTR *vptr) {
 
   
   static IDL_STRUCT_TAG_DEF fitdata[]={    
-    {"REVISION",0,NULL},   /* 0 */
-    {"NOISE",0,NULL},   /* 1 */ 
-    {"PWR0",rdim,(void *) IDL_TYP_FLOAT}, /* 2 */
-    {"NLAG",rdim,(void *) IDL_TYP_INT}, /* 3 */
-    {"QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 4 */
-    {"GFLG",rdim,(void *) IDL_TYP_BYTE}, /* 5 */
-    {"P_L",rdim,(void *) IDL_TYP_FLOAT}, /* 6 */
-    {"P_L_E",rdim,(void *) IDL_TYP_FLOAT}, /* 7 */
-    {"P_S",rdim,(void *) IDL_TYP_FLOAT}, /* 8 */
-    {"P_S_E",rdim,(void *) IDL_TYP_FLOAT}, /* 9 */
-    {"V",rdim,(void *) IDL_TYP_FLOAT}, /* 10 */
-    {"V_E",rdim,(void *) IDL_TYP_FLOAT}, /* 11 */
-    {"W_L",rdim,(void *) IDL_TYP_FLOAT}, /* 12 */
-    {"W_L_E",rdim,(void *) IDL_TYP_FLOAT}, /* 13 */
-    {"W_S",rdim,(void *) IDL_TYP_FLOAT}, /* 14 */
-    {"W_S_E",rdim,(void *) IDL_TYP_FLOAT}, /* 15 */
-    {"SD_L",rdim,(void *) IDL_TYP_FLOAT}, /* 16 */
-    {"SD_S",rdim,(void *) IDL_TYP_FLOAT}, /* 17 */
-    {"SD_PHI",rdim,(void *) IDL_TYP_FLOAT}, /* 18 */
-    {"X_QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 19 */
-    {"X_GFLG",rdim,(void *) IDL_TYP_BYTE}, /* 20 */
-    {"X_P_L",rdim,(void *) IDL_TYP_FLOAT}, /* 21 */
-    {"X_P_L_E",rdim,(void *) IDL_TYP_FLOAT}, /* 22 */
-    {"X_P_S",rdim,(void *) IDL_TYP_FLOAT}, /* 23 */
-    {"X_P_S_E",rdim,(void *) IDL_TYP_FLOAT}, /* 24 */
-    {"X_V",rdim,(void *) IDL_TYP_FLOAT}, /* 25 */
-    {"X_V_E",rdim,(void *) IDL_TYP_FLOAT}, /* 26 */
-    {"X_W_L",rdim,(void *) IDL_TYP_FLOAT}, /* 27 */
-    {"X_W_L_E",rdim,(void *) IDL_TYP_FLOAT}, /* 28 */
-    {"X_W_S",rdim,(void *) IDL_TYP_FLOAT}, /* 29 */
-    {"X_W_S_E",rdim,(void *) IDL_TYP_FLOAT}, /* 30 */
-    {"PHI0",rdim,(void *) IDL_TYP_FLOAT}, /* 31 */
-    {"PHI0_E",rdim,(void *) IDL_TYP_FLOAT}, /* 32 */
-    {"ELV",rdim,(void *) IDL_TYP_FLOAT}, /* 33 */  
-    {"ELV_LOW",rdim,(void *) IDL_TYP_FLOAT}, /* 34 */
-    {"ELV_HIGH",rdim,(void *) IDL_TYP_FLOAT}, /* 35 */
-    {"X_SD_L",rdim,(void *) IDL_TYP_FLOAT}, /* 36 */
-    {"X_SD_S",rdim,(void *) IDL_TYP_FLOAT}, /* 37 */
-    {"X_SD_PHI",rdim,(void *) IDL_TYP_FLOAT}, /* 38 */
+    {"ALGORITHM",0,NULL},  /* 0 */
+    {"REVISION",0,NULL},   /* 1 */
+    {"NOISE",0,NULL},   /* 2 */ 
+    {"PWR0",rdim,(void *) IDL_TYP_FLOAT}, /* 3 */
+    {"NLAG",rdim,(void *) IDL_TYP_INT}, /* 4 */
+    {"QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 5 */
+    {"GFLG",rdim,(void *) IDL_TYP_BYTE}, /* 6 */
+    {"P_L",rdim,(void *) IDL_TYP_FLOAT}, /* 7 */
+    {"P_L_E",rdim,(void *) IDL_TYP_FLOAT}, /* 8 */
+    {"P_S",rdim,(void *) IDL_TYP_FLOAT}, /* 9 */
+    {"P_S_E",rdim,(void *) IDL_TYP_FLOAT}, /* 10 */
+    {"V",rdim,(void *) IDL_TYP_FLOAT}, /* 11 */
+    {"V_E",rdim,(void *) IDL_TYP_FLOAT}, /* 12 */
+    {"W_L",rdim,(void *) IDL_TYP_FLOAT}, /* 13 */
+    {"W_L_E",rdim,(void *) IDL_TYP_FLOAT}, /* 14 */
+    {"W_S",rdim,(void *) IDL_TYP_FLOAT}, /* 15 */
+    {"W_S_E",rdim,(void *) IDL_TYP_FLOAT}, /* 16 */
+    {"SD_L",rdim,(void *) IDL_TYP_FLOAT}, /* 17 */
+    {"SD_S",rdim,(void *) IDL_TYP_FLOAT}, /* 18 */
+    {"SD_PHI",rdim,(void *) IDL_TYP_FLOAT}, /* 19 */
+    {"X_QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 20 */
+    {"X_GFLG",rdim,(void *) IDL_TYP_BYTE}, /* 21 */
+    {"X_P_L",rdim,(void *) IDL_TYP_FLOAT}, /* 22 */
+    {"X_P_L_E",rdim,(void *) IDL_TYP_FLOAT}, /* 23 */
+    {"X_P_S",rdim,(void *) IDL_TYP_FLOAT}, /* 24 */
+    {"X_P_S_E",rdim,(void *) IDL_TYP_FLOAT}, /* 25 */
+    {"X_V",rdim,(void *) IDL_TYP_FLOAT}, /* 26 */
+    {"X_V_E",rdim,(void *) IDL_TYP_FLOAT}, /* 27 */
+    {"X_W_L",rdim,(void *) IDL_TYP_FLOAT}, /* 28 */
+    {"X_W_L_E",rdim,(void *) IDL_TYP_FLOAT}, /* 29 */
+    {"X_W_S",rdim,(void *) IDL_TYP_FLOAT}, /* 30 */
+    {"X_W_S_E",rdim,(void *) IDL_TYP_FLOAT}, /* 31 */
+    {"PHI0",rdim,(void *) IDL_TYP_FLOAT}, /* 32 */
+    {"PHI0_E",rdim,(void *) IDL_TYP_FLOAT}, /* 33 */
+    {"ELV",rdim,(void *) IDL_TYP_FLOAT}, /* 34 */  
+    {"ELV_LOW",rdim,(void *) IDL_TYP_FLOAT}, /* 35 */
+    {"ELV_HIGH",rdim,(void *) IDL_TYP_FLOAT}, /* 36 */
+    {"X_SD_L",rdim,(void *) IDL_TYP_FLOAT}, /* 37 */
+    {"X_SD_S",rdim,(void *) IDL_TYP_FLOAT}, /* 38 */
+    {"X_SD_PHI",rdim,(void *) IDL_TYP_FLOAT}, /* 39 */
  
     {0}};
 


### PR DESCRIPTION
This pull request adds a new `algorithm` field to `fitacf`-format files, which uses @ecbland's new consolidated `make_fit` to store an appropriate string for each fitting algorithm and (partially) addresses #479.  Similar to #512, the addition of this new field will eventually need to be coordinated with `pydarn` and `pydarnio`.

Note the target of this pull request is the `feature/make_fit` branch rather than `develop`.