### PR TITLE
Modifying LMFIT2 to include support for bmoff parameter

### DIFF
--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/include/lmfit_structures.h
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/include/lmfit_structures.h
@@ -124,6 +124,7 @@ typedef struct fit_prms {
   double **acfd;
   double **xcfd;
   int maxbeam;
+  double bmoff;
   double bmsep;
   double interfer_x;
   double interfer_y;

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit2toplevel.c
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit2toplevel.c
@@ -149,6 +149,7 @@ void Copy_Fitting_Prms(struct RadarSite *radar_site, struct RadarParm *radar_prm
     fit_prms->interfer_x=radar_site->interfer[0];
     fit_prms->interfer_y=radar_site->interfer[1];
     fit_prms->interfer_z=radar_site->interfer[2];
+    fit_prms->bmoff=radar_site->bmoff;
     fit_prms->bmsep=radar_site->bmsep;
     fit_prms->phidiff=radar_site->phidiff;
     if ((radar_prms->offset == 0) || (radar_prms->channel < 2)) {

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_determinations.c
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_determinations.c
@@ -398,7 +398,7 @@ void find_elevation(llist_node range, struct FitElv* fit_elev_array, FITPRMS* fi
 	}
 
 	azi_offset = fit_prms->maxbeam/2 - 0.5;
-	phi_0 = fit_prms->bmsep * (fit_prms->bmnum - azi_offset) * M_PI/180;
+	phi_0 = (fit_prms->bmoff + fit_prms->bmsep * (fit_prms->bmnum - azi_offset)) * M_PI/180;
 	c_phi_0 = cos(phi_0);
 
 	wave_num = 2 * M_PI * fit_prms->tfreq * 1000/C;

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_determinations.c
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_determinations.c
@@ -361,6 +361,8 @@ void set_nump(llist_node range, struct FitRange* fit_range_array){
 
 /**
 Determines the elevation angle from the fitted XCF phase
+//TODO Modify this function to call elevation_v2()/elevation() from the elevation library
+       (see equivalent function in fitacf_v3:determinations.c)
 */
 void find_elevation(llist_node range, struct FitElv* fit_elev_array, FITPRMS* fit_prms){
 	double x,y,z;


### PR DESCRIPTION
Sorry for not including this in the previous pull request - this one final commit adds support for the recently introduced `bmoff` parameter in the `hdw.dat` files to the `lmfit2` library (it looks like @ecbland already included the relevant `tdiff` functionality).