### PR TITLE
Modifying IDL MAX_RANGE to match C / DLM code

### DIFF
--- a/codebase/superdarn/src.idl/lib/main.1.25/fit.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/fit.pro
@@ -64,7 +64,7 @@
 
 pro FitMakeFitData,fit
 
-  MAX_RANGE=300
+  MAX_RANGE=800
 
   fit={FitData, $
          algorithm: ' ', $


### PR DESCRIPTION
This pull request fixes an error when trying to initialize a `fit` structure within IDL using the `FitMakeFitData` routine while also reading a record from a `fitacf`-format file.  The problem is that the native IDL code initializes the size of the arrays in the `fit` structure to 300 while the C / DLM code initializes the arrays to 800 elements.  Using something like the following code will cause a `free(): corrupted unsorted chunks` core dump:

```
FitMakeFitData, fit                  ; this initializes a fit structure in IDL with a MAX_RANGE of 300 gates

inp = FitOpen(fitacf_name, /read)    ; open a FITACF-format file
ret = FitRead(inp, prm, fit)         ; read from the FITACF-format file, trying to return a fit structure with a MAX_RANGE of 800 gates
```

If you try reading a `fit` structure from a `fitacf`-format file first (using the DLMs) and then creating a `fit` structure with `FitMakeFitData`, I believe that causes a `Conflicting data structures: <FLOAT     Array[300]>,FITDATA.` error instead.  On this branch, all of these errors should be fixed.