### PR TITLE
More simulator updates

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/doc/make_sim.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/doc/make_sim.doc.xml
@@ -19,7 +19,11 @@
 </option>
 <option><on>-oldscan</on><od>use the old 7-pulse sequence.</od>
 </option>
-<option><on>-xcf</on><od>calculate XCFs (using a virtual height model).</od>
+<option><on>-xcf</on><od>calculate interferometer samples and XCFs (default is to use a virtual height model).</od>
+</option>
+<option><on>-elv <ar>elv</ar></on><od>set the elevation angle to <ar>elv</ar> degrees (instead of using a virtual height model).</od>
+</option>
+<option><on>-vht <ar>vht</ar></on><od>set the virtual height to <ar>vht</ar> degrees (instead of using a virtual height model).</od>
 </option>
 <option><on>-freq <ar>f</ar></on><od>set the radar frequency to <ar>f</ar> MHz (default is 12 MHz).</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/doc/make_sim.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/doc/make_sim.doc.xml
@@ -21,9 +21,11 @@
 </option>
 <option><on>-xcf</on><od>calculate interferometer samples and XCFs (default is to use a virtual height model).</od>
 </option>
-<option><on>-elv <ar>elv</ar></on><od>set the elevation angle to <ar>elv</ar> degrees (instead of using a virtual height model).</od>
+<option><on>-elv <ar>elv</ar></on><od>set the elevation angle to <ar>elv</ar> degrees for all ranges (instead of using a virtual height model).</od>
 </option>
-<option><on>-vht <ar>vht</ar></on><od>set the virtual height to <ar>vht</ar> degrees (instead of using a virtual height model).</od>
+<option><on>-vht <ar>vht</ar></on><od>set the virtual height to <ar>vht</ar> km for all ranges (instead of using a virtual height model).</od>
+</option>
+<option><on>-tdiff <ar>tdiff</ar></on><od>set the tdiff value to <ar>tdiff</ar> microseconds when calculating interferometer samples and XCFs (default is to use hardware value).</od>
 </option>
 <option><on>-freq <ar>f</ar></on><od>set the radar frequency to <ar>f</ar> MHz (default is 12 MHz).</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/doc/make_sim.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/doc/make_sim.doc.xml
@@ -15,6 +15,8 @@
 </option>
 <option><on>-tauscan</on><od>use Ray Greenwald's 13-pulse sequence.</od>
 </option>
+<option><on>-spaletascan</on><od>use Mrinal Balaji / Jef Spaleta's 16-pulse sequence.</od>
+</option>
 <option><on>-oldscan</on><od>use the old 7-pulse sequence.</od>
 </option>
 <option><on>-freq <ar>f</ar></on><od>set the radar frequency to <ar>f</ar> MHz (default is 12 MHz).</od>

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/doc/make_sim.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/doc/make_sim.doc.xml
@@ -19,6 +19,8 @@
 </option>
 <option><on>-oldscan</on><od>use the old 7-pulse sequence.</od>
 </option>
+<option><on>-xcf</on><od>calculate XCFs (using a virtual height model).</od>
+</option>
 <option><on>-freq <ar>f</ar></on><od>set the radar frequency to <ar>f</ar> MHz (default is 12 MHz).</od>
 </option>
 <option><on>-vel <ar>v</ar></on><od>set the background Doppler velocity to <ar>v</ar> m/s (default is 450 m/s).</od>

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/doc/make_sim.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/doc/make_sim.doc.xml
@@ -33,6 +33,8 @@
 </option>
 <option><on>-v_spread <ar>v_s</ar></on><od>set the Gaussian Doppler velocity spread (standard deviation) to <ar>v_s</ar> m/s (default is 0 m/s).</od>
 </option>
+<option><on>-width <ar>w</ar></on><od>set the spectral width to <ar>w</ar> m/s (default is 120 m/s).</od>
+</option>
 <option><on>-t_d <ar>t_d</ar></on><od>set the irregularity decay time to <ar>t_d</ar> milliseconds (default is 40 ms).</od>
 </option>
 <option><on>-t_g <ar>t_g</ar></on><od>set the irregularity growth time to <ar>t_d</ar> microseconds (default is 1 us, ie negligible).</od>

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
@@ -654,8 +654,8 @@ int main(int argc,char *argv[])
       }
       /*interferometer array samples*/
       for (j=0;j<n_samples;j++) {
-        samples[i*n_samples*2*2+j*2+n_samples] = (int16)(xcf*creal(raw_samples[i*n_samples+j])*(cos(psi_obs[i])+I*sin(psi_obs[i])));
-        samples[i*n_samples*2*2+j*2+1+n_samples] = (int16)(xcf*cimag(raw_samples[i*n_samples+j])*(cos(psi_obs[i])+I*sin(psi_obs[i])));
+        samples[i*n_samples*2*2+j*2+n_samples] = (int16)(xcf*creal(raw_samples[i*n_samples+j]*(cos(psi_obs[i])+I*sin(psi_obs[i]))));
+        samples[i*n_samples*2*2+j*2+1+n_samples] = (int16)(xcf*cimag(raw_samples[i*n_samples+j]*(cos(psi_obs[i])+I*sin(psi_obs[i]))));
       }
     }
 

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
@@ -153,7 +153,7 @@ void makeRadarParm(struct RadarParm * prm, char * argv[], int argc, int cpid, in
   if (site == NULL || stid == 0) prm->bmazm = 0;
   else {
     offset = site->maxbeam/2.0-0.5;
-    prm->bmazm = site->boresite + site->bmsep*(prm->bmnum-offset);
+    prm->bmazm = site->boresite + site->bmsep*(prm->bmnum-offset) + site->bmoff;
   }
 
   prm->scan = 1;

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
@@ -270,6 +270,7 @@ int main(int argc,char *argv[])
   int srng = 0;                             /*first range gate containing scatter*/
   double elv = -9999.;                      /*elevation angle*/
   double vht = -9999.;                      /*virtual height*/
+  double tdiff = -9999.;                    /*tdiff*/
 
   /*other variables*/
   long i,j;
@@ -287,6 +288,7 @@ int main(int argc,char *argv[])
   OptionAdd(&opt,"xcf",'x',&xcf);               /* calculate interferometer samples / XCFs */
   OptionAdd(&opt,"elv",'d',&elv);               /* elevation angle [deg] */
   OptionAdd(&opt,"vht",'d',&vht);               /* virtual height [km] */
+  OptionAdd(&opt,"tdiff",'d',&tdiff);           /* tdiff [us] */
 
   OptionAdd(&opt,"constant",'x',&life_dist);    /* irregularity distribution */
   OptionAdd(&opt,"freq",'d',&freq);             /* frequency [MHz] */
@@ -572,6 +574,10 @@ int main(int argc,char *argv[])
     double alpha;
     double sa;
 
+    if (tdiff == -9999.) {
+      tdiff = site->tdiff[0];
+    }
+
     X = site->interfer[0];
     Y = site->interfer[1];
     Z = site->interfer[2];
@@ -596,7 +602,7 @@ int main(int argc,char *argv[])
       }
       sa = sin(alpha);
 
-      psi_obs[i] = 2*PI*freq*((1/C)*(X*sp0 + Y*sqrt(cp0*cp0-sa*sa) + Z*sa) - site->tdiff[0]*1e-6);
+      psi_obs[i] = 2*PI*freq*((1/C)*(X*sp0 + Y*sqrt(cp0*cp0-sa*sa) + Z*sa) - tdiff*1e-6);
     }
   }
 

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
@@ -68,14 +68,14 @@ int rst_opterr(char *txt) {
   return(-1);
 }
 
-void makeRadarParm(struct RadarParm * prm, char * argv[], int argc, int cpid, int nave,
+void makeRadarParm(struct RadarParm *prm, char *argv[], int argc, int cpid, int nave,
                     int lagfr, double smsep, double noise_lev, double amp0, int n_samples,
                     double dt, int n_pul, int n_lags, int nrang, double rngsep, double freq,
-                    int * pulse_t, int stid, int beam)
+                    int *pulse_t, int stid, int beam)
 {
   int i;
   time_t rawtime;
-  struct tm * timeinfo;
+  struct tm *timeinfo;
   char tmstr[40];
 
   char *envstr=NULL;
@@ -110,8 +110,7 @@ void makeRadarParm(struct RadarParm * prm, char * argv[], int argc, int cpid, in
   RadarParmSetOriginTime(prm,tmstr);
   char *tempstr = malloc(argc*15);
   strcpy(tempstr,argv[0]);
-  for(i=1;i<argc;i++)
-  {
+  for (i=1;i<argc;i++) {
     strcat(tempstr," ");
     strcat(tempstr,argv[i]);
   }
@@ -179,26 +178,21 @@ void makeRadarParm(struct RadarParm * prm, char * argv[], int argc, int cpid, in
 
   int16 temp_pul[n_pul];
 
-  for(i=0;i<n_pul;i++)
+  for (i=0;i<n_pul;i++)
     temp_pul[i] = (int16)pulse_t[i];
 
   RadarParmSetPulse(prm,n_pul,temp_pul);
 
 
-  if(cpid == 1)
-  {
+  if (cpid == 1) {
     int16 temp_lag[100] = {0,0,26,27,20,22,9,12,22,26,22,27,20,26,20,27,12,20,0,9,
                                 12,22,9,20,0,12,9,22,12,26,12,27,9,26,9,27};
     RadarParmSetLag(prm,n_lags,temp_lag);
-  }
-  else if(cpid == 503)
-  {
+  } else if (cpid == 503) {
     int16 temp_lag[100] = {0,0,15,16,27,29,29,32,23,27,27,32,23,29,16,23,15,23,
                             23,32,16,27,15,27,16,29,15,29,32,47,16,32,15,32};
     RadarParmSetLag(prm,n_lags,temp_lag);
-  }
-  else
-  {
+  } else {
     int16 temp_lag[100] = {0,0,42,43,22,24,24,27,27,31,22,27,24,31,14,22,22,
                                 31,14,24,31,42,31,43,14,27,0,14,27,42,27,43,14,31,
                                 24,42,24,43,22,42,22,43,0,22,0,24};
@@ -207,9 +201,6 @@ void makeRadarParm(struct RadarParm * prm, char * argv[], int argc, int cpid, in
 
   RadarParmSetCombf(prm,tempstr);
 
-  /*
-  prm->pulse = malloc(n_pul*sizeof(int16));
-  memcpy(prm->pulse,temp_pul,sizeof(int16)*n_pul);*/
   free(tempstr);
 }
 /*this is a driver program for the data simulator*/
@@ -327,18 +318,17 @@ int main(int argc,char *argv[])
   cri_flg = !cri_flg;
 
   double lambda = C/freq;
-  if(w != -9999.)
+  if (w != -9999.)
     t_d = lambda/(w*2.*PI);
 
   /*oldscan*/
-  if(oldscan)
-  {
+  if (oldscan) {
     cpid = 1;
     dt = 2.4e-3;                          /*basic lag time*/
     n_pul = 7;                            /*number of pulses*/
     n_lags = 18;                          /*number of lags in the ACFs*/
     /*if the user did not set nave*/
-    if(!nave_flg)
+    if (!nave_flg)
       nave = 70;                          /*number of averages*/
 
     /*fill the pulse table*/
@@ -353,21 +343,20 @@ int main(int argc,char *argv[])
 
     /*Creating lag array*/
     tau = malloc(n_lags*sizeof(int));
-    for(i=0;i<n_lags;i++)
+    for (i=0;i<n_lags;i++)
       tau[i] = i;
     /*no lag 16*/
     tau[16] += 1;
     tau[17] += 1;
   }
   /*tauscan*/
-  else if(tauscan)
-  {
+  else if (tauscan) {
     cpid = 503;
     dt = 2.4e-3;                          /*basic lag time*/
     n_pul = 13;                           /*number of pulses*/
     n_lags = 17;                          /*number of lags in the ACFs*/
     /*if the user did not set nave*/
-    if(!nave_flg)
+    if (!nave_flg)
       nave = 20;                          /*number of averages*/
 
     /*fill the pulse table*/
@@ -388,20 +377,19 @@ int main(int argc,char *argv[])
 
     /*Creating lag array*/
     tau = malloc(n_lags*sizeof(int));
-    for(i=0;i<10;i++)
+    for (i=0;i<10;i++)
       tau[i] = i;
     /*no lag 10*/
-    for(i=10;i<18;i++)
+    for (i=10;i<18;i++)
       tau[i] = (i+1);
   }
   /*katscan (default)*/
-  else
-  {
+  else {
     dt = 1.5e-3;                          /*basic lag time*/
     n_pul = 8;                            /*number of pulses*/
     n_lags = 23;                          /*number of lags in the ACFs*/
     /*if the user did not set nave*/
-    if(!nave_flg)
+    if (!nave_flg)
       nave = 50;                          /*number of averages*/
 
     /*fill the pulse table*/
@@ -417,10 +405,10 @@ int main(int argc,char *argv[])
 
     /*Creating lag array*/
     tau = malloc(n_lags*sizeof(int));
-    for(i=0;i<6;i++)
+    for (i=0;i<6;i++)
       tau[i] = i;
     /*no lag 6*/
-    for(i=6;i<22;i++)
+    for (i=6;i<22;i++)
       tau[i] = (i+1);
     /*no lag 23*/
     tau[22] = 24;
@@ -432,20 +420,19 @@ int main(int argc,char *argv[])
   n_samples = (pulse_t[n_pul-1]*taus+nrang+lagfr);      /*number of samples in 1 pulse sequence*/
 
   /*Creating the output array for ACFs*/
-  complex double ** acfs = malloc(nrang*sizeof(complex double *));
-  for(i=0;i<nrang;i++)
-  {
+  complex double **acfs = malloc(nrang*sizeof(complex double *));
+  for (i=0;i<nrang;i++) {
     acfs[i] = malloc(n_lags*sizeof(complex double));
-    for(j=0;j<n_lags;j++)
+    for (j=0;j<n_lags;j++)
       acfs[i][j] = 0.+I*0.;
   }
 
   /*flags to tell which range gates contain scatter*/
-  int * qflg = malloc(nrang*sizeof(int));
-  for(i=0;i<srng;i++)
+  int *qflg = malloc(nrang*sizeof(int));
+  for (i=0;i<srng;i++)
     qflg[i] = 0;
-  for(i=srng;i<nrang;i++)
-    if(i < srng+n_good)
+  for (i=srng;i<nrang;i++)
+    if (i < srng+n_good)
       qflg[i] = 1;
     else
       qflg[i] = 0;
@@ -453,44 +440,43 @@ int main(int argc,char *argv[])
 
 
   /*create a structure to store the raw samples from each pulse sequence*/
-  complex double * raw_samples = malloc(n_samples*nave*sizeof(complex double));
+  complex double *raw_samples = malloc(n_samples*nave*sizeof(complex double));
 
   /**********************************************************
   ****FILL THESE ARRAYS WITH THE SIMULATION PARAMETERS*******
   **********************************************************/
 
   /*array with the irregularity decay time for each range gate*/
-  double * t_d_arr = malloc(nrang*sizeof(double));
-  for(i=0;i<nrang;i++)
+  double *t_d_arr = malloc(nrang*sizeof(double));
+  for (i=0;i<nrang;i++)
     t_d_arr[i] = t_d;
 
   /*array with the irregularity growth time for each range gate*/
-  double * t_g_arr = malloc(nrang*sizeof(double));
-  for(i=0;i<nrang;i++)
+  double *t_g_arr = malloc(nrang*sizeof(double));
+  for (i=0;i<nrang;i++)
     t_g_arr[i] = t_g;
 
   /*array with the irregularity lifetime for each range gate*/
-  double * t_c_arr = malloc(nrang*sizeof(double));
-  for(i=0;i<nrang;i++)
+  double *t_c_arr = malloc(nrang*sizeof(double));
+  for (i=0;i<nrang;i++)
     t_c_arr[i] = t_c;
 
   /*array with the irregularity doppler velocity for each range gate*/
-  double * v_dop_arr = malloc(nrang*sizeof(double));
-  for(i=0;i<nrang;i++)
+  double *v_dop_arr = malloc(nrang*sizeof(double));
+  for (i=0;i<nrang;i++)
     v_dop_arr[i] = v_dop;
 
   /*array with the irregularity doppler velocity for each range gate*/
-  double * velo_arr = malloc(nrang*sizeof(double));
-  for(i=0;i<nrang;i++)
+  double *velo_arr = malloc(nrang*sizeof(double));
+  for (i=0;i<nrang;i++)
     velo_arr[i] = velo;
 
-
   /*array with the ACF amplitude for each range gate*/
-  double * amp0_arr = malloc(nrang*sizeof(double));
-  for(i=0;i<nrang;i++)
+  double *amp0_arr = malloc(nrang*sizeof(double));
+  for (i=0;i<nrang;i++)
     amp0_arr[i] = amp0;
 	
-  if(noise_flg) noise_lev *= amp0;
+  if (noise_flg) noise_lev *= amp0;
 
   /*call the simulation function*/
   sim_data(t_d_arr, t_g_arr, t_c_arr, v_dop_arr, qflg, velo_arr, amp0_arr, freq, noise_lev,
@@ -498,30 +484,27 @@ int main(int argc,char *argv[])
            n_pul, cri_flg, n_lags, pulse_t, tau, dt, raw_samples, acfs, decayflg);
 
   /*fill the parameter structure*/
-  struct RadarParm * prm;
+  struct RadarParm *prm;
   prm = RadarParmMake();
   makeRadarParm(prm, argv, argc, cpid, nave, lagfr, smsep, noise_lev, amp0, n_samples,
                 dt, n_pul, n_lags, nrang, rngsep, freq, pulse_t, stid, beam);
 
-  if(!smp_flg)
-  {
+  if (!smp_flg) {
     /*fill the rawdata structure*/
-    struct RawData * raw;
+    struct RawData *raw;
     raw = RawMake();
 
     raw->revision.major = 1;
     raw->revision.minor = 1;
     raw->thr=0.0;
-    int * slist = malloc(nrang*sizeof(int));
-    float * pwr0 = malloc(nrang*sizeof(float));
-    float * acfd = malloc(nrang*n_lags*2*sizeof(float));
-    float * xcfd = malloc(nrang*n_lags*2*sizeof(float));
-    for(i=0;i<nrang;i++)
-    {
+    int *slist = malloc(nrang*sizeof(int));
+    float *pwr0 = malloc(nrang*sizeof(float));
+    float *acfd = malloc(nrang*n_lags*2*sizeof(float));
+    float *xcfd = malloc(nrang*n_lags*2*sizeof(float));
+    for (i=0;i<nrang;i++) {
       slist[i] = i;
       pwr0[i] = creal(acfs[i][0]);
-      for(j=0;j<n_lags;j++)
-      {
+      for (j=0;j<n_lags;j++) {
         acfd[i*n_lags*2+j*2] = creal(acfs[i][j]);
         acfd[i*n_lags*2+j*2+1] = cimag(acfs[i][j]);
         xcfd[i*n_lags*2+j*2] = 0.;
@@ -537,9 +520,7 @@ int main(int argc,char *argv[])
     free(pwr0);
     free(acfd);
     free(xcfd);
-  }
-  else
-  {
+  } else {
     /*fill the iqdata structure*/
     struct IQ *iq;
     iq=IQMake();
@@ -558,9 +539,8 @@ int main(int argc,char *argv[])
 
     gettimeofday(&tick,NULL);
 
-    int16 * samples = malloc(n_samples*nave*2*2*sizeof(int16));
-    for(i=0;i<nave;i++)
-    {
+    int16 *samples = malloc(n_samples*nave*2*2*sizeof(int16));
+    for (i=0;i<nave;i++) {
       /*iq structure values*/
       seqtval[i].tv_sec = tick.tv_sec + (int)(i*n_samples*smsep);
       seqtval[i].tv_nsec = (tick.tv_usec + (i*n_samples*smsep-(int)(i*n_samples*smsep))*1e6)*1000;
@@ -570,14 +550,12 @@ int main(int argc,char *argv[])
       seqsze[i] = n_samples*2*2;
 
       /*main array samples*/
-      for(j=0;j<n_samples;j++)
-      {
+      for (j=0;j<n_samples;j++) {
         samples[i*n_samples*2*2+j*2] = (int16)(creal(raw_samples[i*n_samples+j]));
         samples[i*n_samples*2*2+j*2+1] = (int16)(cimag(raw_samples[i*n_samples+j]));
       }
       /*interferometer array samples*/
-      for(j=0;j<n_samples;j++)
-      {
+      for (j=0;j<n_samples;j++) {
         samples[i*n_samples*2*2+j*2+n_samples] = 0;
         samples[i*n_samples*2*2+j*2+1+n_samples] = 0;
       }
@@ -589,7 +567,7 @@ int main(int argc,char *argv[])
     IQSetOffset(iq,nave,seqoff);
     IQSetSize(iq,nave,seqsze);
 
-    unsigned int * badtr = malloc(nave*n_pul*2*sizeof(int));
+    unsigned int *badtr = malloc(nave*n_pul*2*sizeof(int));
 
     IQFwrite(stdout,prm,iq,badtr,samples);
     free(samples);
@@ -597,7 +575,7 @@ int main(int argc,char *argv[])
   }
 
   /*free dynamically allocated memory*/
-  for(i=0;i<nrang;i++)
+  for (i=0;i<nrang;i++)
     free(acfs[i]);
   free(acfs);
   free(pulse_t);

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
@@ -268,6 +268,8 @@ int main(int argc,char *argv[])
   int smp_flg = 0;                          /*output raw samples flag*/
   int decayflg = 0;
   int srng = 0;                             /*first range gate containing scatter*/
+  double elv = -9999.;                      /*elevation angle*/
+  double vht = -9999.;                      /*virtual height*/
 
   /*other variables*/
   long i,j;
@@ -282,7 +284,9 @@ int main(int argc,char *argv[])
   OptionAdd(&opt,"tauscan",'x',&tauscan);
   OptionAdd(&opt,"spaletascan",'x',&spaletascan);
 
-  OptionAdd(&opt,"xcf",'x',&xcf);
+  OptionAdd(&opt,"xcf",'x',&xcf);               /* calculate interferometer samples / XCFs */
+  OptionAdd(&opt,"elv",'d',&elv);               /* elevation angle [deg] */
+  OptionAdd(&opt,"vht",'d',&vht);               /* virtual height [km] */
 
   OptionAdd(&opt,"constant",'x',&life_dist);    /* irregularity distribution */
   OptionAdd(&opt,"freq",'d',&freq);             /* frequency [MHz] */
@@ -578,9 +582,18 @@ int main(int argc,char *argv[])
     sp0 = sin(phi0);
 
     for (i=0;i<nrang;i++) {
-      rng = slant_range(rngsep*lagfr*1e-3, rngsep*1e-3, 0, 0, i+1);
-      xh = calc_cv_vhm(rng, 0, &hop);
-      alpha = calc_elevation_angle(rng, xh, hop, 0)*PI/180.;
+      if (elv != -9999.) {
+        alpha = elv*PI/180.;
+      } else {
+        rng = slant_range(rngsep*lagfr*1e-3, rngsep*1e-3, 0, 0, i+1);
+        if (vht != -9999.) {
+          xh = vht;
+          hop = 0.5;
+        } else {
+          xh = calc_cv_vhm(rng, 0, &hop);
+        }
+        alpha = calc_elevation_angle(rng, xh, hop, 0)*PI/180.;
+      }
       sa = sin(alpha);
 
       psi_obs[i] = 2*PI*freq*((1/C)*(X*sp0 + Y*sqrt(cp0*cp0-sa*sa) + Z*sa) - site->tdiff[0]*1e-6);

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
@@ -192,6 +192,21 @@ void makeRadarParm(struct RadarParm *prm, char *argv[], int argc, int cpid, int 
     int16 temp_lag[100] = {0,0,15,16,27,29,29,32,23,27,27,32,23,29,16,23,15,23,
                             23,32,16,27,15,27,16,29,15,29,32,47,16,32,15,32};
     RadarParmSetLag(prm,n_lags,temp_lag);
+  } else if (cpid == 9100) {
+    int16 temp_lag[244] = {1495,1495,0,4,4,19,0,19,19,42,42,78,4,42,0,42,78,127,19,78,
+                           127,191,4,78,0,78,191,270,42,127,270,364,19,127,364,474,78,191,4,127,
+                           474,600,0,127,127,270,600,745,42,191,745,905,191,364,19,191,905,1083,4,191,
+                           0,191,78,270,1083,1280,270,474,1280,1495,42,270,127,364,364,600,19,270,4,270,
+                           0,270,474,745,191,474,78,364,600,905,42,364,270,600,745,1083,19,364,127,474,
+                           4,364,0,364,905,1280,364,745,78,474,191,600,1083,1495,474,905,42,474,19,474,
+                           4,474,127,600,0,474,270,745,600,1083,78,600,745,1280,364,905,191,745,42,600,
+                           19,600,905,1495,4,600,0,600,474,1083,127,745,270,905,78,745,600,1280,42,745,
+                           191,905,364,1083,19,745,4,745,0,745,745,1495,127,905,474,1280,270,1083,78,905,
+                           42,905,19,905,191,1083,600,1495,4,905,0,905,364,1280,127,1083,78,1083,270,1280,
+                           474,1495,42,1083,19,1083,4,1083,0,1083,191,1280,364,1495,127,1280,78,1280,270,1495,
+                           42,1280,19,1280,4,1280,0,1280,191,1495,127,1495,78,1495,42,1495,19,1495,4,1495,
+                           0,1495,1495,1495};
+    RadarParmSetLag(prm,n_lags,temp_lag);
   } else {
     int16 temp_lag[100] = {0,0,42,43,22,24,24,27,27,31,22,27,24,31,14,22,22,
                                 31,14,24,31,42,31,43,14,27,0,14,27,42,27,43,14,31,
@@ -220,6 +235,7 @@ int main(int argc,char *argv[])
   int katscan = 0;
   int oldscan = 0;
   int tauscan = 0;
+  int spaletascan = 0;
 
   /********************************************************
   ** definitions of variables needed for data generation **
@@ -261,6 +277,7 @@ int main(int argc,char *argv[])
   OptionAdd(&opt,"katscan",'x',&katscan);       /* control program */
   OptionAdd(&opt,"oldscan",'x',&oldscan);
   OptionAdd(&opt,"tauscan",'x',&tauscan);
+  OptionAdd(&opt,"spaletascan",'x',&spaletascan);
 
   OptionAdd(&opt,"constant",'x',&life_dist);    /* irregularity distribution */
   OptionAdd(&opt,"freq",'d',&freq);             /* frequency [MHz] */
@@ -382,6 +399,45 @@ int main(int argc,char *argv[])
     /*no lag 10*/
     for (i=10;i<18;i++)
       tau[i] = (i+1);
+  }
+  /*spaletascan*/
+  else if (spaletascan) {
+    cpid = 9100;
+    dt = 0.1e-3;                          /*basic lag time*/
+    n_pul = 16;                           /*number of pulses*/
+    n_lags = 121;                         /*number of lags in the ACFs*/
+    /*if the user did not set nave*/
+    if (!nave_flg)
+      nave = 16;                          /*number of averages*/
+
+    smsep = 100.e-6;
+    rngsep = 15.0e3;
+    lagfr = 12;
+    nrang = 225;
+
+    /*fill the pulse table*/
+    pulse_t = malloc(n_pul*sizeof(int));
+    pulse_t[0] = 0;
+    pulse_t[1] = 4;
+    pulse_t[2] = 19;
+    pulse_t[3] = 42;
+    pulse_t[4] = 78;
+    pulse_t[5] = 127;
+    pulse_t[6] = 191;
+    pulse_t[7] = 270;
+    pulse_t[8] = 364;
+    pulse_t[9] = 474;
+    pulse_t[10] = 600;
+    pulse_t[11] = 745;
+    pulse_t[12] = 905;
+    pulse_t[13] = 1083;
+    pulse_t[14] = 1280;
+    pulse_t[15] = 1495;
+
+    /*Creating lag array*/
+    tau = malloc(n_lags*sizeof(int));
+    for (i=0;i<n_lags;i++)
+      tau[i] = i;
   }
   /*katscan (default)*/
   else {

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
@@ -27,6 +27,8 @@ THE SOFTWARE.
  Evan Thomas 2021
  Modified to use standard RST documentation and command line options,
  fixed iqdat-format output, and added several other user options
+
+ E.G.Thomas 2022-08: added support for bmoff parameter, XCFs, extended pulse sequence
 */
 
 #include <errno.h>

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/makefile
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/makefile
@@ -11,7 +11,7 @@ OBJS = make_sim.o
 SRC = hlpstr.h errstr.h make_sim.c
 DSTPATH = $(BINPATH)
 OUTPUT = make_sim
-LIBS=-lsim_data.1 -loldraw.1 -loldfit.1 -lcfit.1 -lrscan.1 -lradar.1 -lfitacf.1 -lraw.1 -lfit.1 -ldmap.1 -lopt.1 -lrtime.1 -lrcnv.1 -lrmath.1 -liqdata.1
+LIBS=-lsim_data.1 -lrpos.1 -laacgm.1 -ligrf.1 -laacgm_v2.1 -ligrf_v2.1 -lastalg.1 -loldraw.1 -loldfit.1 -lcfit.1 -lrscan.1 -lradar.1 -lfitacf.1 -lraw.1 -lfit.1 -ldmap.1 -lopt.1 -lrtime.1 -lrcnv.1 -lrmath.1 -liqdata.1
 SLIB=-lm -lz
  
 

--- a/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/doc/sim_real.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/doc/sim_real.doc.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<binary>
+<project>superdarn</project>
+<name>sim_real</name>
+<location>src.bin/tk/tool/sim_real</location>
+
+<syntax>sim_real --help</syntax>
+<syntax>sim_real [-vb] <ar>fitacfname</ar></syntax>
+
+<option><on>--help</on><od>print the help message and exit.</od>
+</option>
+<option><on>--version</on><od>print the RST version number and exit.</od>
+</option>
+<option><on>-katscan</on><od>use Kathrn McWilliams' 8-pulse sequence (default).</od>
+</option>
+<option><on>-tauscan</on><od>use Ray Greenwald's 13-pulse sequence.</od>
+</option>
+<option><on>-oldscan</on><od>use the old 7-pulse sequence.</od>
+</option>
+<option><on>-constant</on><od>use a constant irregularity lifetime distribution (default is exponential).</od>
+</option>
+<option><on>-nocri</on><od>Remove cross-range interference from the ACFs (default is CRI on). WARNING: removing cross-range interference will make the raw samples unusable, since each range gate will have to be integrated separately.</od>
+</option>
+<option><on>-iq</on><od>Output raw samples (in <code>iqdat</code> format) instead of ACFs (in <code>rawacf</code> format).</od>
+</option>
+<synopsis><p>Generates simulated single-component Lorentzian ACFs based on an input <code>fitacf</code> file.</p></synopsis>
+<description><p>Reads a <code>fitacf</code> format file and generates simulated single-component Lorentzian ACFs at ranges where scatter was observed in either <code>rawacf</code> (default) or <code>iqdat</code> format, which is then written to standard output.</p>
+</description>
+
+<example>
+<command>sim_real input.fitacf &gt; output.rawacf</command>
+<description>Generates simulated single-component Lorentzian ACFs in <code>rawacf</code> format.</description>
+</example>
+
+</binary>

--- a/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/makefile
+++ b/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/makefile
@@ -8,10 +8,10 @@ include $(MAKECFG).$(SYSTEM)
 
 INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn
 OBJS = sim_real.o
-SRC=sim_real.c
+SRC = hlpstr.h errstr.h sim_real.c
 DSTPATH = $(BINPATH)
 OUTPUT = sim_real
-LIBS=-lsim_data.1 -lradar.1 -lfitacf.1 -lraw.1 -lfit.1 -ldmap.1 -lrtime.1 -lrcnv.1 -lrmath.1 -liqdata.1
+LIBS=-lsim_data.1 -lradar.1 -lfitacf.1 -lraw.1 -lfit.1 -ldmap.1 -lopt.1 -lrtime.1 -lrcnv.1 -lrmath.1 -liqdata.1
 SLIB=-lm -lz
  
 

--- a/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
+++ b/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
@@ -49,13 +49,6 @@ THE SOFTWARE.
 #include "iq.h"
 #include "iqwrite.h"
 
-struct gates
-{
-  double vel;
-	double wid;
-	double pow;
-};
-
 
 void makeRadarParm2(struct RadarParm * prm, char * argv[], int argc, int cpid, int nave,
                     int lagfr, double smsep, double noise_lev, double amp0, int n_samples,
@@ -68,7 +61,7 @@ void makeRadarParm2(struct RadarParm * prm, char * argv[], int argc, int cpid, i
   time (&rawtime);
   timeinfo = gmtime(&rawtime);
 
-	if (prm->origin.time !=NULL) free(prm->origin.time);
+  if (prm->origin.time !=NULL) free(prm->origin.time);
   if (prm->origin.command !=NULL) free(prm->origin.command);
   if (prm->pulse !=NULL) free(prm->pulse);
   for (i=0;i<2;i++) if (prm->lag[i] !=NULL) free(prm->lag[i]);
@@ -81,7 +74,6 @@ void makeRadarParm2(struct RadarParm * prm, char * argv[], int argc, int cpid, i
   prm->lag[1]=NULL;
   prm->combf=NULL;
 
-
   prm->revision.major = 1;
   prm->revision.minor = 0;
   // set to 1 as it is not produced on site 
@@ -89,7 +81,6 @@ void makeRadarParm2(struct RadarParm * prm, char * argv[], int argc, int cpid, i
 
   RadarParmSetOriginTime(prm,asctime(timeinfo));
   RadarParmSetOriginCommand(prm,"sim_real");
-
 
   prm->cp = (int16)cpid;
   prm->stid = 0;
@@ -100,9 +91,8 @@ void makeRadarParm2(struct RadarParm * prm, char * argv[], int argc, int cpid, i
   prm->time.hr = (int16)hr;
   prm->time.mt = (int16)mt;
   prm->time.sc = (int16)sc;
-	prm->bmnum = bmnum;
+  prm->bmnum = bmnum;
 
-	
   prm->time.us = 0;
 
   prm->txpow = 9000;
@@ -143,20 +133,15 @@ void makeRadarParm2(struct RadarParm * prm, char * argv[], int argc, int cpid, i
   RadarParmSetPulse(prm,n_pul,temp_pul);
 
 
-  if(cpid == 1)
-  {
+  if(cpid == 1) {
     int16 temp_lag[100] = {0,0,26,27,20,22,9,12,22,26,22,27,20,26,20,27,12,20,0,9,
                                 12,22,9,20,0,12,9,22,12,26,12,27,9,26,9,27};
     RadarParmSetLag(prm,n_lags,temp_lag);
-  }
-  else if(cpid == 503)
-  {
+  } else if(cpid == 503) {
     int16 temp_lag[100] = {0,0,15,16,27,29,29,32,23,27,27,32,23,29,16,23,15,23,
                             23,32,16,27,15,27,16,29,15,29,32,47,16,32,15,32};
     RadarParmSetLag(prm,n_lags,temp_lag);
-  }
-  else
-  {
+  } else {
     int16 temp_lag[100] = {0,0,42,43,22,24,24,27,27,31,22,27,24,31,14,22,22,
                                 31,14,24,31,42,31,43,14,27,0,14,27,42,27,43,14,31,
                                 24,42,24,43,22,42,22,43,0,22,0,24};
@@ -204,14 +189,13 @@ int main(int argc,char *argv[])
   long i,j;
   double taus;
 
-	/*fit file to recreate*/
-	char * filename = argv[argc-1];
+  /*fit file to recreate*/
+  char * filename = argv[argc-1];
 
   /*read the first radar's file*/
   FILE * fitfp=fopen(filename,"r");
   fprintf(stderr,"%s\n",filename);
-  if(fitfp==NULL)
-  {
+  if(fitfp==NULL) {
     fprintf(stderr,"File %s not found.\n",filename);
     exit(-1);
   }
@@ -220,266 +204,253 @@ int main(int argc,char *argv[])
   struct RadarParm * prm;
   prm = RadarParmMake();
 
-	/*array with the irregularity decay time for each range gate*/
-	double * t_d_arr = malloc(nrang*sizeof(double));
-	for(i=0;i<nrang;i++)
-		t_d_arr[i] = 0;
+  /*array with the irregularity decay time for each range gate*/
+  double * t_d_arr = malloc(nrang*sizeof(double));
+  for(i=0;i<nrang;i++)
+    t_d_arr[i] = 0;
 
-	/*array with the irregularity growth time for each range gate*/
-	double * t_g_arr = malloc(nrang*sizeof(double));
-	for(i=0;i<nrang;i++)
-		t_g_arr[i] = 1.e-6;
+  /*array with the irregularity growth time for each range gate*/
+  double * t_g_arr = malloc(nrang*sizeof(double));
+  for(i=0;i<nrang;i++)
+    t_g_arr[i] = 1.e-6;
 
-	/*array with the irregularity lifetime for each range gate*/
-	double * t_c_arr = malloc(nrang*sizeof(double));
-	for(i=0;i<nrang;i++)
-		t_c_arr[i] = 1000;
+  /*array with the irregularity lifetime for each range gate*/
+  double * t_c_arr = malloc(nrang*sizeof(double));
+  for(i=0;i<nrang;i++)
+    t_c_arr[i] = 1000;
 
-	/*array with the irregularity doppler velocity for each range gate*/
-	double * v_dop_arr = malloc(nrang*sizeof(double));
-	for(i=0;i<nrang;i++)
-		v_dop_arr[i] = 0;
+  /*array with the irregularity doppler velocity for each range gate*/
+  double * v_dop_arr = malloc(nrang*sizeof(double));
+  for(i=0;i<nrang;i++)
+    v_dop_arr[i] = 0;
 
-	/*array with the irregularity doppler velocity for each range gate*/
-	double * velo_arr = malloc(nrang*sizeof(double));
-	for(i=0;i<nrang;i++)
-		velo_arr[i] = 0;
+  /*array with the irregularity doppler velocity for each range gate*/
+  double * velo_arr = malloc(nrang*sizeof(double));
+  for(i=0;i<nrang;i++)
+    velo_arr[i] = 0;
 
-	/*array with the ACF amplitude for each range gate*/
-	double * amp0_arr = malloc(nrang*sizeof(double));
-	for(i=0;i<nrang;i++)
-		amp0_arr[i] = 0;
-	
-	/*flags to tell which range gates contain scatter*/
-	int * qflg = malloc(nrang*sizeof(int));
-	for(i=0;i<nrang;i++)
-		qflg[i] = 0;
+  /*array with the ACF amplitude for each range gate*/
+  double * amp0_arr = malloc(nrang*sizeof(double));
+  for(i=0;i<nrang;i++)
+    amp0_arr[i] = 0;
 
-	/*Creating the output array for ACFs*/
-	complex double ** acfs = malloc(nrang*sizeof(complex double *));
+  /*flags to tell which range gates contain scatter*/
+  int * qflg = malloc(nrang*sizeof(int));
+  for(i=0;i<nrang;i++)
+    qflg[i] = 0;
+
+  /*Creating the output array for ACFs*/
+  complex double ** acfs = malloc(nrang*sizeof(complex double *));
 
 
-	do
-	{
+  do {
 
-		rt = fscanf(fitfp,"%hd  %hd  %hd  %hd  %hd  %hd\n",&prm->time.yr,&prm->time.mo,&prm->time.dy,&prm->time.hr,&prm->time.mt,&prm->time.sc);
-		if (rt == 0)
-        {
-            fprintf(stderr, "Error: unable to read all variables\n");
-            exit(-1);
-        }
-        fprintf(stderr,"%d  %d  %d  %d  %d  %d\n",prm->time.yr,prm->time.mo,prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc);
-		rt = fscanf(fitfp,"%d  %lf  %hd  %lf  %d  %d  %lf  %lf  %lf  %d\n",&cpid,&freq,&prm->bmnum,&noise_lev,&nave,&lagfr,&dt,&smsep,&rngsep,&nrang);
-		if (rt == 0)
-        {
-            fprintf(stderr, "Error: unable to read all variables\n");
-            exit(-1);
-        }
-        lagfr /= smsep;
-		rngsep *= 1.e3;
-		smsep *= 1.e-6;
-		dt *= 1.e-6;
-		freq *= 1.e3;
+    rt = fscanf(fitfp,"%hd  %hd  %hd  %hd  %hd  %hd\n",&prm->time.yr,&prm->time.mo,&prm->time.dy,&prm->time.hr,&prm->time.mt,&prm->time.sc);
+    if (rt == 0) {
+      fprintf(stderr, "Error: unable to read all variables\n");
+      exit(-1);
+    }
+    fprintf(stderr,"%d  %d  %d  %d  %d  %d\n",prm->time.yr,prm->time.mo,prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc);
 
-		double lambda = C/freq;
-		if(w != -9999.)
-			t_d = lambda/(w*2.*PI);
+    rt = fscanf(fitfp,"%d  %lf  %hd  %lf  %d  %d  %lf  %lf  %lf  %d\n",&cpid,&freq,&prm->bmnum,&noise_lev,&nave,&lagfr,&dt,&smsep,&rngsep,&nrang);
+    if (rt == 0) {
+      fprintf(stderr, "Error: unable to read all variables\n");
+      exit(-1);
+    }
 
-		/*oldscan*/
-		if(cpid == 1)
-		{
-			n_pul = 7;                            /*number of pulses*/
-			n_lags = 18;                          /*number of lags in the ACFs*/
+    lagfr /= smsep;
+    rngsep *= 1.e3;
+    smsep *= 1.e-6;
+    dt *= 1.e-6;
+    freq *= 1.e3;
 
-			/*fill the pulse table*/
-			pulse_t = malloc(n_pul*sizeof(int));
-			pulse_t[0] = 0;
-			pulse_t[1] = 9;
-			pulse_t[2] = 12;
-			pulse_t[3] = 20;
-			pulse_t[4] = 22;
-			pulse_t[5] = 26;
-			pulse_t[6] = 27;
+    double lambda = C/freq;
+    if(w != -9999.)
+      t_d = lambda/(w*2.*PI);
 
-			/*Creating lag array*/
-			tau = malloc(n_lags*sizeof(int));
-			for(i=0;i<n_lags;i++)
-				tau[i] = i;
-			/*no lag 16*/
-			tau[16] += 1;
-			tau[17] += 1;
-		}
-		/*tauscan*/
-		else if(cpid == 503 || cpid == -3310)
-		{
-			n_pul = 13;                           /*number of pulses*/
-			n_lags = 17;                          /*number of lags in the ACFs*/
+    /*oldscan*/
+    if(cpid == 1) {
+      n_pul = 7;                            /*number of pulses*/
+      n_lags = 18;                          /*number of lags in the ACFs*/
 
-			/*fill the pulse table*/
-			pulse_t = malloc(n_pul*sizeof(int));
-			pulse_t[0] = 0;
-			pulse_t[1] = 15;
-			pulse_t[2] = 16;
-			pulse_t[3] = 23;
-			pulse_t[4] = 27;
-			pulse_t[5] = 29;
-			pulse_t[6] = 32;
-			pulse_t[7] = 47;
-			pulse_t[8] = 50;
-			pulse_t[9] = 52;
-			pulse_t[10] = 56;
-			pulse_t[11] = 63;
-			pulse_t[12] = 64;
+      /*fill the pulse table*/
+      pulse_t = malloc(n_pul*sizeof(int));
+      pulse_t[0] = 0;
+      pulse_t[1] = 9;
+      pulse_t[2] = 12;
+      pulse_t[3] = 20;
+      pulse_t[4] = 22;
+      pulse_t[5] = 26;
+      pulse_t[6] = 27;
 
-			/*Creating lag array*/
-			tau = malloc(n_lags*sizeof(int));
-			for(i=0;i<10;i++)
-				tau[i] = i;
-			/*no lag 10*/
-			for(i=10;i<18;i++)
-				tau[i] = (i+1);
-		}
-		/*katscan (default)*/
-		else
-		{
-			cpid = 150;
-			n_pul = 8;                            /*number of pulses*/
-			n_lags = 23;                          /*number of lags in the ACFs*/
+      /*Creating lag array*/
+      tau = malloc(n_lags*sizeof(int));
+      for(i=0;i<n_lags;i++)
+        tau[i] = i;
+      /*no lag 16*/
+      tau[16] += 1;
+      tau[17] += 1;
+    }
+    /*tauscan*/
+    else if(cpid == 503 || cpid == -3310) {
+      n_pul = 13;                           /*number of pulses*/
+      n_lags = 17;                          /*number of lags in the ACFs*/
 
-			/*fill the pulse table*/
-			pulse_t = malloc(n_pul*sizeof(int));
-			pulse_t[0] = 0;
-			pulse_t[1] = 14;
-			pulse_t[2] = 22;
-			pulse_t[3] = 24;
-			pulse_t[4] = 27;
-			pulse_t[5] = 31;
-			pulse_t[6] = 42;
-			pulse_t[7] = 43;
-			/*Creating lag array*/
-			tau = malloc(n_lags*sizeof(int));
-			for(i=0;i<6;i++)
-				tau[i] = i;
-			/*no lag 6*/
-			for(i=6;i<22;i++)
-				tau[i] = (i+1);
-			/*no lag 23*/
-			tau[22] = 24;
-		}
+      /*fill the pulse table*/
+      pulse_t = malloc(n_pul*sizeof(int));
+      pulse_t[0] = 0;
+      pulse_t[1] = 15;
+      pulse_t[2] = 16;
+      pulse_t[3] = 23;
+      pulse_t[4] = 27;
+      pulse_t[5] = 29;
+      pulse_t[6] = 32;
+      pulse_t[7] = 47;
+      pulse_t[8] = 50;
+      pulse_t[9] = 52;
+      pulse_t[10] = 56;
+      pulse_t[11] = 63;
+      pulse_t[12] = 64;
+
+      /*Creating lag array*/
+      tau = malloc(n_lags*sizeof(int));
+      for(i=0;i<10;i++)
+        tau[i] = i;
+      /*no lag 10*/
+      for(i=10;i<18;i++)
+        tau[i] = (i+1);
+    }
+    /*katscan (default)*/
+    else {
+      cpid = 150;
+      n_pul = 8;                            /*number of pulses*/
+      n_lags = 23;                          /*number of lags in the ACFs*/
+
+      /*fill the pulse table*/
+      pulse_t = malloc(n_pul*sizeof(int));
+      pulse_t[0] = 0;
+      pulse_t[1] = 14;
+      pulse_t[2] = 22;
+      pulse_t[3] = 24;
+      pulse_t[4] = 27;
+      pulse_t[5] = 31;
+      pulse_t[6] = 42;
+      pulse_t[7] = 43;
+      /*Creating lag array*/
+      tau = malloc(n_lags*sizeof(int));
+      for(i=0;i<6;i++)
+        tau[i] = i;
+      /*no lag 6*/
+      for(i=6;i<22;i++)
+        tau[i] = (i+1);
+      /*no lag 23*/
+      tau[22] = 24;
+    }
 
 
 
-		/*control program dependent variables*/
-		taus = dt/smsep;                                      /*lag time in samples*/
-		n_samples = (pulse_t[n_pul-1]*taus+nrang+lagfr);      /*number of samples in 1 pulse sequence*/
+    /*control program dependent variables*/
+    taus = dt/smsep;                                      /*lag time in samples*/
+    n_samples = (pulse_t[n_pul-1]*taus+nrang+lagfr);      /*number of samples in 1 pulse sequence*/
 
-		/*create a structure to store the raw samples from each pulse sequence*/
-		complex double * raw_samples = malloc(n_samples*nave*sizeof(complex double));
-		makeRadarParm2(prm, argv, argc, cpid, nave, lagfr, smsep, noise_lev, amp0, n_samples,
-                    dt, n_pul, n_lags, nrang, rngsep, freq, pulse_t,prm->time.yr,prm->time.mo,
-										prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
+    /*create a structure to store the raw samples from each pulse sequence*/
+    complex double * raw_samples = malloc(n_samples*nave*sizeof(complex double));
+    makeRadarParm2(prm, argv, argc, cpid, nave, lagfr, smsep, noise_lev, amp0, n_samples,
+                   dt, n_pul, n_lags, nrang, rngsep, freq, pulse_t,prm->time.yr,prm->time.mo,
+                   prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
 
-		/**********************************************************
-		****FILL THESE ARRAYS WITH THE SIMULATION PARAMETERS*******
-		**********************************************************/
-		for(i=0;i<nrang;i++)
-		{
-			rt = fscanf(fitfp,"%*d  %d  %lf  %lf  %lf\n",&qflg[i],&v_dop,&amp0,&t_d);
-			if (rt == 0)
-            {
+    /**********************************************************
+    ****FILL THESE ARRAYS WITH THE SIMULATION PARAMETERS*******
+    **********************************************************/
+    for(i=0;i<nrang;i++) {
+      rt = fscanf(fitfp,"%*d  %d  %lf  %lf  %lf\n",&qflg[i],&v_dop,&amp0,&t_d);
+      if (rt == 0) {
                 fprintf(stderr, "Error: unable to read all variables\n");
                 exit(-1);
-            }
-            t_d = lambda/(t_d*2.*PI);
-			if(t_d > 999999.) t_d = 0.;
-			t_d_arr[i] = t_d;
+      }
 
-			v_dop_arr[i] = v_dop;
-			
-			amp0 = noise_lev*pow(10.,(amp0/10.));
-			amp0_arr[i] = amp0;
+      t_d = lambda/(t_d*2.*PI);
+      if(t_d > 999999.) t_d = 0.;
+      t_d_arr[i] = t_d;
 
-			acfs[i] = malloc(n_lags*sizeof(complex double));
-			for(j=0;j<n_lags;j++)
-				acfs[i][j] = 0.+I*0.;
-		}
-		
-		/*call the simulation function*/
-		sim_data(t_d_arr, t_g_arr, t_c_arr, v_dop_arr, qflg, velo_arr, amp0_arr, freq, noise_lev,
-							noise_flg, nave, nrang, lagfr, smsep, cpid, life_dist,
-							n_pul, cri_flg, n_lags, pulse_t, tau, dt, raw_samples, acfs, decayflg);
+      v_dop_arr[i] = v_dop;
 
-		if(!smp_flg)
-		{
-			/*fill the rawdata structure*/
-			struct RawData * raw;
-			raw = RawMake();
+      amp0 = noise_lev*pow(10.,(amp0/10.));
+      amp0_arr[i] = amp0;
 
-			raw->revision.major = 1;
-			raw->revision.minor = 1;
-			raw->thr=0.0;
-			int * slist = malloc(nrang*sizeof(int));
-			float * pwr0 = malloc(nrang*sizeof(float));
-			float * acfd = malloc(nrang*n_lags*2*sizeof(float));
-			float * xcfd = malloc(nrang*n_lags*2*sizeof(float));
-			for(i=0;i<nrang;i++)
-			{
-				slist[i] = i;
-				pwr0[i] = creal(acfs[i][0]);
-				for(j=0;j<n_lags;j++)
-				{
-					acfd[i*n_lags*2+j*2] = creal(acfs[i][j]);
-					acfd[i*n_lags*2+j*2+1] = cimag(acfs[i][j]);
-					xcfd[i*n_lags*2+j*2] = 0.;
-					xcfd[i*n_lags*2+j*2+1] = 0.;
-				}
-			}
+      acfs[i] = malloc(n_lags*sizeof(complex double));
+      for(j=0;j<n_lags;j++)
+        acfs[i][j] = 0.+I*0.;
+    }
 
-			RawSetPwr(raw,nrang,pwr0,nrang,slist);
-			RawSetACF(raw,nrang,n_lags,acfd,nrang,slist);
-			RawSetXCF(raw,nrang,n_lags,xcfd,nrang,slist);
-			i=RawFwrite(stdout,prm,raw);
-			free(slist);
-			free(pwr0);
-			free(acfd);
-			free(xcfd);
-		}
-		else
-		{
-			/*fill the iqdata structure*/
-			struct IQ *iq;
-			iq=IQMake();
+    /*call the simulation function*/
+    sim_data(t_d_arr, t_g_arr, t_c_arr, v_dop_arr, qflg, velo_arr, amp0_arr, freq, noise_lev,
+             noise_flg, nave, nrang, lagfr, smsep, cpid, life_dist,
+             n_pul, cri_flg, n_lags, pulse_t, tau, dt, raw_samples, acfs, decayflg);
 
-			int16 * samples = malloc(n_samples*nave*2*2*sizeof(int16));
-			for(i=0;i<nave;i++)
-			{
-				/*main array samples*/
-				for(j=0;j<n_samples;j++)
-				{
-					samples[i*n_samples*2*2+j*2] = (int16)(creal(raw_samples[i*n_samples+j]));
-					samples[i*n_samples*2*2+j*2+1] = (int16)(cimag(raw_samples[i*n_samples+j]));
-				}
-				/*interferometer array samples*/
-				for(j=0;j<n_samples;j++)
-				{
-					samples[i*n_samples*2*2+j*2+n_samples] = 0;
-					samples[i*n_samples*2*2+j*2+1+n_samples] = 0;
-				}
-			}
+    if(!smp_flg) {
+      /*fill the rawdata structure*/
+      struct RawData * raw;
+      raw = RawMake();
 
-			unsigned int * badtr = malloc(nave*n_pul*2*sizeof(int));
+      raw->revision.major = 1;
+      raw->revision.minor = 1;
+      raw->thr=0.0;
+      int * slist = malloc(nrang*sizeof(int));
+      float * pwr0 = malloc(nrang*sizeof(float));
+      float * acfd = malloc(nrang*n_lags*2*sizeof(float));
+      float * xcfd = malloc(nrang*n_lags*2*sizeof(float));
+      for(i=0;i<nrang;i++) {
+        slist[i] = i;
+        pwr0[i] = creal(acfs[i][0]);
+        for(j=0;j<n_lags;j++) {
+          acfd[i*n_lags*2+j*2] = creal(acfs[i][j]);
+          acfd[i*n_lags*2+j*2+1] = cimag(acfs[i][j]);
+          xcfd[i*n_lags*2+j*2] = 0.;
+          xcfd[i*n_lags*2+j*2+1] = 0.;
+        }
+      }
 
-			IQFwrite(stdout,prm,iq,badtr,samples);
-			free(samples);
-			free(badtr);
-		}
+      RawSetPwr(raw,nrang,pwr0,nrang,slist);
+      RawSetACF(raw,nrang,n_lags,acfd,nrang,slist);
+      RawSetXCF(raw,nrang,n_lags,xcfd,nrang,slist);
+      i=RawFwrite(stdout,prm,raw);
+      free(slist);
+      free(pwr0);
+      free(acfd);
+      free(xcfd);
+    } else {
+      /*fill the iqdata structure*/
+      struct IQ *iq;
+      iq=IQMake();
 
-		free(pulse_t);
-		free(tau);
-		free(raw_samples);
-		for(i=0;i<nrang;i++)
-			free(acfs[i]);
-	} while(!feof(fitfp));
+      int16 * samples = malloc(n_samples*nave*2*2*sizeof(int16));
+      for(i=0;i<nave;i++) {
+        /*main array samples*/
+        for(j=0;j<n_samples;j++) {
+          samples[i*n_samples*2*2+j*2] = (int16)(creal(raw_samples[i*n_samples+j]));
+          samples[i*n_samples*2*2+j*2+1] = (int16)(cimag(raw_samples[i*n_samples+j]));
+        }
+        /*interferometer array samples*/
+        for(j=0;j<n_samples;j++) {
+          samples[i*n_samples*2*2+j*2+n_samples] = 0;
+          samples[i*n_samples*2*2+j*2+1+n_samples] = 0;
+        }
+      }
+
+      unsigned int * badtr = malloc(nave*n_pul*2*sizeof(int));
+
+      IQFwrite(stdout,prm,iq,badtr,samples);
+      free(samples);
+      free(badtr);
+    }
+
+    free(pulse_t);
+    free(tau);
+    free(raw_samples);
+    for(i=0;i<nrang;i++)
+      free(acfs[i]);
+  } while(!feof(fitfp));
 
   /*free dynamically allocated memory*/
   for(i=0;i<nrang;i++)
@@ -492,8 +463,7 @@ int main(int argc,char *argv[])
   free(v_dop_arr);
   free(velo_arr);
   free(amp0_arr);
-	fclose(fitfp);
-
+  fclose(fitfp);
 
   return 0;
 }

--- a/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
+++ b/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
@@ -45,6 +45,9 @@ THE SOFTWARE.
 #include "rtypes.h"
 #include "rprm.h"
 #include "rawdata.h"
+#include "fitblk.h"
+#include "fitdata.h"
+#include "fitread.h"
 #include "rawwrite.h"
 #include "radar.h"
 #include "iq.h"
@@ -53,6 +56,9 @@ THE SOFTWARE.
 #include "errstr.h"
 #include "hlpstr.h"
 
+struct RadarParm *prm;
+struct FitData *fit;
+struct RadarParm *prm2;
 struct OptionData opt;
 
 int rst_opterr(char *txt) {
@@ -61,106 +67,116 @@ int rst_opterr(char *txt) {
   return(-1);
 }
 
-void makeRadarParm2(struct RadarParm * prm, char * argv[], int argc, int cpid, int nave,
-                    int lagfr, double smsep, double noise_lev, double amp0, int n_samples,
-                    double dt, int n_pul, int n_lags, int nrang, double rngsep, double freq,
-                    int * pulse_t,int yr, int mo, int dy, int hr, int mt, int sc, int bmnum)
+void makeRadarParm2(struct RadarParm *prm2, char *argv[], int argc, int cpid,
+                    int nave, double smsep, double amp0, int n_samples, double dt,
+                    int n_pul, int n_lags, int *pulse_t, struct RadarParm *in_prm)
 {
   int i;
   time_t rawtime;
-  struct tm * timeinfo;
-  time (&rawtime);
+  struct tm *timeinfo;
+  char tmstr[40];
+
+  rawtime = time((time_t) 0);
   timeinfo = gmtime(&rawtime);
 
-  if (prm->origin.time !=NULL) free(prm->origin.time);
-  if (prm->origin.command !=NULL) free(prm->origin.command);
-  if (prm->pulse !=NULL) free(prm->pulse);
-  for (i=0;i<2;i++) if (prm->lag[i] !=NULL) free(prm->lag[i]);
+  strcpy(tmstr,asctime(timeinfo));
+  tmstr[24]=0;
 
-  memset(prm,0,sizeof(struct RadarParm));
-  prm->origin.time=NULL;
-  prm->origin.command=NULL;
-  prm->pulse=NULL;
-  prm->lag[0]=NULL;
-  prm->lag[1]=NULL;
-  prm->combf=NULL;
+  if (prm2->origin.time !=NULL) free(prm2->origin.time);
+  if (prm2->origin.command !=NULL) free(prm2->origin.command);
+  if (prm2->pulse !=NULL) free(prm2->pulse);
+  for (i=0;i<2;i++) if (prm2->lag[i] !=NULL) free(prm2->lag[i]);
 
-  prm->revision.major = 1;
-  prm->revision.minor = 0;
+  memset(prm2,0,sizeof(struct RadarParm));
+  prm2->origin.time=NULL;
+  prm2->origin.command=NULL;
+  prm2->pulse=NULL;
+  prm2->lag[0]=NULL;
+  prm2->lag[1]=NULL;
+  prm2->combf=NULL;
+
+  prm2->revision.major = 1;
+  prm2->revision.minor = 0;
   // set to 1 as it is not produced on site 
-  prm->origin.code = 1;
+  prm2->origin.code = 1;
 
-  RadarParmSetOriginTime(prm,asctime(timeinfo));
-  RadarParmSetOriginCommand(prm,"sim_real");
+  RadarParmSetOriginTime(prm2,tmstr);
+  char *tempstr = malloc(argc*15);
+  strcpy(tempstr,argv[0]);
+  for(i=1;i<argc;i++) {
+    strcat(tempstr," ");
+    strcat(tempstr,argv[i]);
+  }
+  RadarParmSetOriginCommand(prm2,tempstr);
 
-  prm->cp = (int16)cpid;
-  prm->stid = 0;
+  prm2->cp = (int16)cpid;
+  prm2->stid = in_prm->stid;
 
-  prm->time.yr = (int16)yr;
-  prm->time.mo = (int16)mo;
-  prm->time.dy = (int16)dy;
-  prm->time.hr = (int16)hr;
-  prm->time.mt = (int16)mt;
-  prm->time.sc = (int16)sc;
-  prm->bmnum = bmnum;
+  prm2->time.yr = in_prm->time.yr;
+  prm2->time.mo = in_prm->time.mo;
+  prm2->time.dy = in_prm->time.dy;
+  prm2->time.hr = in_prm->time.hr;
+  prm2->time.mt = in_prm->time.mt;
+  prm2->time.sc = in_prm->time.sc;
+  prm2->time.us = in_prm->time.us;
+  prm2->bmnum = in_prm->bmnum;
 
-  prm->time.us = 0;
-
-  prm->txpow = 9000;
-  prm->nave = (int16)nave;
-  prm->atten = 0;
-  prm->lagfr = (int16)(lagfr*smsep*1e6);
-  prm->smsep = (int16)(smsep*1.e6);
-  prm->ercod = 0;
-  prm->stat.agc = 8192;
-  prm->stat.lopwr = 8192;
-  prm->noise.search = noise_lev;
-  prm->noise.mean = noise_lev;
-  prm->channel = 0;
-  prm->bmazm = 0;
-  prm->scan = 1;
-  prm->rxrise = 100;
-  prm->intt.sc = (int16)(smsep*n_samples*nave);
-  prm->intt.us = (int)(((smsep*n_samples*nave)-(int)(smsep*n_samples*nave))*1e6);
-  prm->txpl = 300;
-  prm->mpinc = (int16)(dt*1e6);
-  prm->mppul = (int16)n_pul;
-  prm->mplgs = (int16)n_lags;
-  prm->mplgexs = (int16)n_lags;
-  prm->nrang = (int16)nrang;
-  prm->frang = (int16)(rngsep*lagfr*1e-3);
-  prm->rsep = (int16)(rngsep*1e-3);
-  prm->xcf = 0;
-  prm->tfreq = (int16)(freq*1e-3);
-  prm->offset = 0;
-  prm->mxpwr = 1070000000;
-  prm->lvmax = 20000;
+  prm2->txpow = in_prm->txpow;
+  prm2->nave = in_prm->nave;
+  prm2->atten = in_prm->atten;
+  prm2->lagfr = in_prm->lagfr;
+  prm2->smsep = in_prm->smsep;
+  prm2->ercod = in_prm->ercod;
+  prm2->stat.agc = in_prm->stat.agc;
+  prm2->stat.lopwr = in_prm->stat.lopwr;
+  prm2->noise.search = in_prm->noise.search;
+  prm2->noise.mean = in_prm->noise.mean;
+  prm2->channel = in_prm->channel;
+  prm2->bmazm = in_prm->bmazm;
+  prm2->scan = in_prm->scan;
+  prm2->rxrise = in_prm->rxrise;
+  prm2->intt.sc = (int16)(smsep*n_samples*nave);
+  prm2->intt.us = (int)(((smsep*n_samples*nave)-(int)(smsep*n_samples*nave))*1e6);
+  prm2->txpl = 300;
+  prm2->mpinc = (int16)(dt*1e6);
+  prm2->mppul = (int16)n_pul;
+  prm2->mplgs = (int16)n_lags;
+  prm2->mplgexs = (int16)n_lags;
+  prm2->nrang = in_prm->nrang;
+  prm2->frang = in_prm->frang;
+  prm2->rsep = in_prm->rsep;
+  prm2->xcf = 0;
+  prm2->tfreq = in_prm->tfreq;
+  prm2->offset = in_prm->offset;
+  prm2->mxpwr = in_prm->mxpwr;
+  prm2->lvmax = in_prm->lvmax;
 
   int16 temp_pul[n_pul];
 
-  for(i=0;i<n_pul;i++)
+  for (i=0;i<n_pul;i++)
     temp_pul[i] = (int16)pulse_t[i];
 
-  RadarParmSetPulse(prm,n_pul,temp_pul);
+  RadarParmSetPulse(prm2,n_pul,temp_pul);
 
 
-  if(cpid == 1) {
+  if (cpid == 1) {
     int16 temp_lag[100] = {0,0,26,27,20,22,9,12,22,26,22,27,20,26,20,27,12,20,0,9,
                                 12,22,9,20,0,12,9,22,12,26,12,27,9,26,9,27};
-    RadarParmSetLag(prm,n_lags,temp_lag);
-  } else if(cpid == 503) {
+    RadarParmSetLag(prm2,n_lags,temp_lag);
+  } else if (cpid == 503) {
     int16 temp_lag[100] = {0,0,15,16,27,29,29,32,23,27,27,32,23,29,16,23,15,23,
                             23,32,16,27,15,27,16,29,15,29,32,47,16,32,15,32};
-    RadarParmSetLag(prm,n_lags,temp_lag);
+    RadarParmSetLag(prm2,n_lags,temp_lag);
   } else {
     int16 temp_lag[100] = {0,0,42,43,22,24,24,27,27,31,22,27,24,31,14,22,22,
                                 31,14,24,31,42,31,43,14,27,0,14,27,42,27,43,14,31,
                                 24,42,24,43,22,42,22,43,0,22,0,24};
-    RadarParmSetLag(prm,n_lags,temp_lag);
+    RadarParmSetLag(prm2,n_lags,temp_lag);
   }
 
-  RadarParmSetCombf(prm,"sim_real");
+  RadarParmSetCombf(prm2,"sim_real");
 
+  free(tempstr);
 }
 /*this is a driver program for the data simulator*/
 
@@ -172,13 +188,13 @@ int main(int argc,char *argv[])
   unsigned char option=0;
   unsigned char version=0;
 
+  unsigned char vb=0;
+
+  FILE *fp=NULL;
+
   int katscan = 0;
   int oldscan = 0;
   int tauscan = 0;
-
-  OptionAdd(&opt,"katscan",'x',&katscan);       /* control program */
-  OptionAdd(&opt,"oldscan",'x',&oldscan);
-  OptionAdd(&opt,"tauscan",'x',&tauscan);
 
   /********************************************************
   ** definitions of variables needed for data generation **
@@ -195,27 +211,32 @@ int main(int argc,char *argv[])
   int lagfr = 4;                            /*lag to first range*/
   int life_dist = 0;                        /*lifetime distribution*/
   double smsep = 300.e-6;                   /*sample spearation*/
-  double rngsep = 45.e3;                    /*range gate spearation*/
   int cpid = 150;                           /*control program ID number*/
   int n_samples;                            /*Number of datapoints in a single pulse sequence*/
   int n_pul,n_lags,*pulse_t,*tau;
   double dt;                                /*basic lag time*/
-  int cri_flg = 1;                          /*cross-range interference flag*/
+  int cri_flg = 0;                          /*cross-range interference flag*/
   int smp_flg = 0;                          /*output raw samples flag*/
   int decayflg = 0;
-
-  int rt = 0;                               /* variable to catch return values of fscanf,
-                                               prevents compile warnings which resulted in
-                                               bizarre terminal behavior in Ubuntu
-                                               (copied from A.S.Reimer's fix in RSTLITE) */
 
   /*other variables*/
   long i,j;
   double taus;
+  double lambda;
 
   OptionAdd(&opt,"-help",'x',&help);
   OptionAdd(&opt,"-option",'x',&option);
   OptionAdd(&opt,"-version",'x',&version);
+
+  OptionAdd(&opt,"vb",'x',&vb);
+
+  OptionAdd(&opt,"katscan",'x',&katscan);       /* control program */
+  OptionAdd(&opt,"oldscan",'x',&oldscan);
+  OptionAdd(&opt,"tauscan",'x',&tauscan);
+
+  OptionAdd(&opt,"constant",'x',&life_dist);    /* irregularity distribution */
+  OptionAdd(&opt,"nocri",'x',&cri_flg);         /* remove cross-range interference */
+  OptionAdd(&opt,"iq",'x',&smp_flg);            /* output raw samples (iqdat) */
 
   arg=OptionProcess(1,argc,argv,&opt,rst_opterr);
 
@@ -238,87 +259,78 @@ int main(int argc,char *argv[])
     exit(0);
   }
 
-  /*fit file to recreate*/
-  char * filename = argv[argc-1];
-
   /*read the first radar's file*/
-  FILE * fitfp=fopen(filename,"r");
-  fprintf(stderr,"%s\n",filename);
-  if(fitfp==NULL) {
-    fprintf(stderr,"File %s not found.\n",filename);
+  if (arg==argc) fp=stdin;
+  else fp=fopen(argv[arg],"r");
+  if (fp==NULL) {
+    fprintf(stderr,"File not found.\n");
     exit(-1);
   }
 
   /*fill the parameter structure*/
-  struct RadarParm * prm;
   prm = RadarParmMake();
+  fit = FitMake();
+  prm2 = RadarParmMake();
+
+  cri_flg = !cri_flg;
 
   /*array with the irregularity decay time for each range gate*/
-  double * t_d_arr = malloc(nrang*sizeof(double));
-  for(i=0;i<nrang;i++)
+  double *t_d_arr = malloc(nrang*sizeof(double));
+  for (i=0;i<nrang;i++)
     t_d_arr[i] = 0;
 
   /*array with the irregularity growth time for each range gate*/
-  double * t_g_arr = malloc(nrang*sizeof(double));
-  for(i=0;i<nrang;i++)
+  double *t_g_arr = malloc(nrang*sizeof(double));
+  for (i=0;i<nrang;i++)
     t_g_arr[i] = 1.e-6;
 
   /*array with the irregularity lifetime for each range gate*/
-  double * t_c_arr = malloc(nrang*sizeof(double));
-  for(i=0;i<nrang;i++)
+  double *t_c_arr = malloc(nrang*sizeof(double));
+  for (i=0;i<nrang;i++)
     t_c_arr[i] = 1000;
 
   /*array with the irregularity doppler velocity for each range gate*/
-  double * v_dop_arr = malloc(nrang*sizeof(double));
-  for(i=0;i<nrang;i++)
+  double *v_dop_arr = malloc(nrang*sizeof(double));
+  for (i=0;i<nrang;i++)
     v_dop_arr[i] = 0;
 
   /*array with the irregularity doppler velocity for each range gate*/
-  double * velo_arr = malloc(nrang*sizeof(double));
-  for(i=0;i<nrang;i++)
+  double *velo_arr = malloc(nrang*sizeof(double));
+  for (i=0;i<nrang;i++)
     velo_arr[i] = 0;
 
   /*array with the ACF amplitude for each range gate*/
-  double * amp0_arr = malloc(nrang*sizeof(double));
-  for(i=0;i<nrang;i++)
+  double *amp0_arr = malloc(nrang*sizeof(double));
+  for (i=0;i<nrang;i++)
     amp0_arr[i] = 0;
 
   /*flags to tell which range gates contain scatter*/
-  int * qflg = malloc(nrang*sizeof(int));
-  for(i=0;i<nrang;i++)
+  int *qflg = malloc(nrang*sizeof(int));
+  for (i=0;i<nrang;i++)
     qflg[i] = 0;
 
   /*Creating the output array for ACFs*/
-  complex double ** acfs = malloc(nrang*sizeof(complex double *));
+  complex double **acfs = malloc(nrang*sizeof(complex double *));
 
 
-  do {
+  while (FitFread(fp,prm,fit) !=-1) {
 
-    rt = fscanf(fitfp,"%hd  %hd  %hd  %hd  %hd  %hd\n",&prm->time.yr,&prm->time.mo,&prm->time.dy,&prm->time.hr,&prm->time.mt,&prm->time.sc);
-    if (rt == 0) {
-      fprintf(stderr, "Error: unable to read all variables\n");
-      exit(-1);
-    }
-    fprintf(stderr,"%d  %d  %d  %d  %d  %d\n",prm->time.yr,prm->time.mo,prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc);
+    if (vb) fprintf(stderr,"%.4d-%.2d-%.2d %.2d:%.2d:%.2d\n",
+                    prm->time.yr,prm->time.mo,prm->time.dy,
+                    prm->time.hr,prm->time.mt,prm->time.sc);
 
-    rt = fscanf(fitfp,"%d  %lf  %hd  %lf  %d  %d  %lf  %lf  %lf  %d\n",&cpid,&freq,&prm->bmnum,&noise_lev,&nave,&lagfr,&dt,&smsep,&rngsep,&nrang);
-    if (rt == 0) {
-      fprintf(stderr, "Error: unable to read all variables\n");
-      exit(-1);
-    }
+    nrang = prm->nrang;
+    lagfr = prm->lagfr/prm->smsep;
+    smsep = prm->smsep*1.e-6;
+    dt = prm->mpinc*1.e-6;
+    freq = prm->tfreq*1.e3;
+    nave = prm->nave;
+    noise_lev = prm->noise.search;
 
-    lagfr /= smsep;
-    rngsep *= 1.e3;
-    smsep *= 1.e-6;
-    dt *= 1.e-6;
-    freq *= 1.e3;
-
-    double lambda = C/freq;
-    if(w != -9999.)
-      t_d = lambda/(w*2.*PI);
+    lambda = C/freq;
 
     /*oldscan*/
-    if(oldscan) {
+    if (oldscan) {
       cpid = 1;
       n_pul = 7;                            /*number of pulses*/
       n_lags = 18;                          /*number of lags in the ACFs*/
@@ -335,14 +347,14 @@ int main(int argc,char *argv[])
 
       /*Creating lag array*/
       tau = malloc(n_lags*sizeof(int));
-      for(i=0;i<n_lags;i++)
+      for (i=0;i<n_lags;i++)
         tau[i] = i;
       /*no lag 16*/
       tau[16] += 1;
       tau[17] += 1;
     }
     /*tauscan*/
-    else if(tauscan) {
+    else if (tauscan) {
       cpid = 503;
       n_pul = 13;                           /*number of pulses*/
       n_lags = 17;                          /*number of lags in the ACFs*/
@@ -365,10 +377,10 @@ int main(int argc,char *argv[])
 
       /*Creating lag array*/
       tau = malloc(n_lags*sizeof(int));
-      for(i=0;i<10;i++)
+      for (i=0;i<10;i++)
         tau[i] = i;
       /*no lag 10*/
-      for(i=10;i<18;i++)
+      for (i=10;i<18;i++)
         tau[i] = (i+1);
     }
     /*katscan (default)*/
@@ -389,10 +401,10 @@ int main(int argc,char *argv[])
       pulse_t[7] = 43;
       /*Creating lag array*/
       tau = malloc(n_lags*sizeof(int));
-      for(i=0;i<6;i++)
+      for (i=0;i<6;i++)
         tau[i] = i;
       /*no lag 6*/
-      for(i=6;i<22;i++)
+      for (i=6;i<22;i++)
         tau[i] = (i+1);
       /*no lag 23*/
       tau[22] = 24;
@@ -404,32 +416,28 @@ int main(int argc,char *argv[])
     n_samples = (pulse_t[n_pul-1]*taus+nrang+lagfr);      /*number of samples in 1 pulse sequence*/
 
     /*create a structure to store the raw samples from each pulse sequence*/
-    complex double * raw_samples = malloc(n_samples*nave*sizeof(complex double));
-    makeRadarParm2(prm, argv, argc, cpid, nave, lagfr, smsep, noise_lev, amp0, n_samples,
-                   dt, n_pul, n_lags, nrang, rngsep, freq, pulse_t,prm->time.yr,prm->time.mo,
-                   prm->time.dy,prm->time.hr,prm->time.mt,prm->time.sc,prm->bmnum);
+    complex double *raw_samples = malloc(n_samples*nave*sizeof(complex double));
+    makeRadarParm2(prm2, argv, argc, cpid, nave, smsep, amp0, n_samples,
+                   dt, n_pul, n_lags, pulse_t, prm);
 
     /**********************************************************
     ****FILL THESE ARRAYS WITH THE SIMULATION PARAMETERS*******
     **********************************************************/
-    for(i=0;i<nrang;i++) {
-      rt = fscanf(fitfp,"%*d  %d  %lf  %lf  %lf\n",&qflg[i],&v_dop,&amp0,&t_d);
-      if (rt == 0) {
-                fprintf(stderr, "Error: unable to read all variables\n");
-                exit(-1);
-      }
+    for (i=0;i<prm->nrang;i++) {
 
-      t_d = lambda/(t_d*2.*PI);
-      if(t_d > 999999.) t_d = 0.;
+      qflg[i] = fit->rng[i].qflg;
+
+      t_d = lambda/(fit->rng[i].w_l*2.*PI);
+      if (t_d > 999999.) t_d = 0.;
       t_d_arr[i] = t_d;
 
-      v_dop_arr[i] = v_dop;
+      v_dop_arr[i] = fit->rng[i].v;
 
-      amp0 = noise_lev*pow(10.,(amp0/10.));
+      amp0 = noise_lev*pow(10.,(fit->rng[i].p_0/10.));
       amp0_arr[i] = amp0;
 
       acfs[i] = malloc(n_lags*sizeof(complex double));
-      for(j=0;j<n_lags;j++)
+      for (j=0;j<n_lags;j++)
         acfs[i][j] = 0.+I*0.;
     }
 
@@ -438,22 +446,22 @@ int main(int argc,char *argv[])
              noise_flg, nave, nrang, lagfr, smsep, cpid, life_dist,
              n_pul, cri_flg, n_lags, pulse_t, tau, dt, raw_samples, acfs, decayflg);
 
-    if(!smp_flg) {
+    if (!smp_flg) {
       /*fill the rawdata structure*/
-      struct RawData * raw;
+      struct RawData *raw;
       raw = RawMake();
 
       raw->revision.major = 1;
       raw->revision.minor = 1;
       raw->thr=0.0;
-      int * slist = malloc(nrang*sizeof(int));
-      float * pwr0 = malloc(nrang*sizeof(float));
-      float * acfd = malloc(nrang*n_lags*2*sizeof(float));
-      float * xcfd = malloc(nrang*n_lags*2*sizeof(float));
-      for(i=0;i<nrang;i++) {
+      int *slist = malloc(nrang*sizeof(int));
+      float *pwr0 = malloc(nrang*sizeof(float));
+      float *acfd = malloc(nrang*n_lags*2*sizeof(float));
+      float *xcfd = malloc(nrang*n_lags*2*sizeof(float));
+      for (i=0;i<nrang;i++) {
         slist[i] = i;
         pwr0[i] = creal(acfs[i][0]);
-        for(j=0;j<n_lags;j++) {
+        for (j=0;j<n_lags;j++) {
           acfd[i*n_lags*2+j*2] = creal(acfs[i][j]);
           acfd[i*n_lags*2+j*2+1] = cimag(acfs[i][j]);
           xcfd[i*n_lags*2+j*2] = 0.;
@@ -464,7 +472,7 @@ int main(int argc,char *argv[])
       RawSetPwr(raw,nrang,pwr0,nrang,slist);
       RawSetACF(raw,nrang,n_lags,acfd,nrang,slist);
       RawSetXCF(raw,nrang,n_lags,xcfd,nrang,slist);
-      i=RawFwrite(stdout,prm,raw);
+      i=RawFwrite(stdout,prm2,raw);
       free(slist);
       free(pwr0);
       free(acfd);
@@ -474,7 +482,6 @@ int main(int argc,char *argv[])
       struct IQ *iq;
       iq=IQMake();
 
-      struct timeval tick;
       struct timespec seqtval[nave];
       int seqatten[nave];
       float seqnoise[nave];
@@ -486,25 +493,23 @@ int main(int argc,char *argv[])
       iq->smpnum = n_samples;
       iq->skpnum = 4;
 
-      gettimeofday(&tick,NULL);
-
-      int16 * samples = malloc(n_samples*nave*2*2*sizeof(int16));
-      for(i=0;i<nave;i++) {
+      int16 *samples = malloc(n_samples*nave*2*2*sizeof(int16));
+      for (i=0;i<nave;i++) {
         /*iq structure values*/
-        seqtval[i].tv_sec = tick.tv_sec + (int)(i*n_samples*smsep);
-        seqtval[i].tv_nsec = (tick.tv_usec + (i*n_samples*smsep-(int)(i*n_samples*smsep))*1e6)*1000;
+        seqtval[i].tv_sec = prm->time.sc + (int)(i*n_samples*smsep);
+        seqtval[i].tv_nsec = (prm->time.us + (i*n_samples*smsep-(int)(i*n_samples*smsep))*1e6)*1000;
         seqatten[i] = 0;
         seqnoise[i] = 0.;
         seqoff[i] = i*n_samples*2*2;
         seqsze[i] = n_samples*2*2;
   
         /*main array samples*/
-        for(j=0;j<n_samples;j++) {
+        for (j=0;j<n_samples;j++) {
           samples[i*n_samples*2*2+j*2] = (int16)(creal(raw_samples[i*n_samples+j]));
           samples[i*n_samples*2*2+j*2+1] = (int16)(cimag(raw_samples[i*n_samples+j]));
         }
         /*interferometer array samples*/
-        for(j=0;j<n_samples;j++) {
+        for (j=0;j<n_samples;j++) {
           samples[i*n_samples*2*2+j*2+n_samples] = 0;
           samples[i*n_samples*2*2+j*2+1+n_samples] = 0;
         }
@@ -516,9 +521,9 @@ int main(int argc,char *argv[])
       IQSetOffset(iq,nave,seqoff);
       IQSetSize(iq,nave,seqsze);
 
-      unsigned int * badtr = malloc(nave*n_pul*2*sizeof(int));
+      unsigned int *badtr = malloc(nave*n_pul*2*sizeof(int));
 
-      IQFwrite(stdout,prm,iq,badtr,samples);
+      IQFwrite(stdout,prm2,iq,badtr,samples);
       free(samples);
       free(badtr);
     }
@@ -526,13 +531,11 @@ int main(int argc,char *argv[])
     free(pulse_t);
     free(tau);
     free(raw_samples);
-    for(i=0;i<nrang;i++)
+    for (i=0;i<nrang;i++)
       free(acfs[i]);
-  } while(!feof(fitfp));
+  }
 
   /*free dynamically allocated memory*/
-  for(i=0;i<nrang;i++)
-    free(acfs[i]);
   free(acfs);
   free(qflg);
   free(t_d_arr);
@@ -541,7 +544,7 @@ int main(int argc,char *argv[])
   free(v_dop_arr);
   free(velo_arr);
   free(amp0_arr);
-  fclose(fitfp);
+  fclose(fp);
 
   return 0;
 }

--- a/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
+++ b/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
@@ -24,6 +24,8 @@ THE SOFTWARE.
  MODIFICATION HISTORY:
  Written by AJ Ribeiro 06/16/2011
  Based on code orginally written by Pasha Ponomarenko
+
+ E.G.Thomas 2022-08: modified to use FITACF files as input and follow RST conventions
 */
 
 #include <errno.h>

--- a/codebase/superdarn/src.lib/tk/sim_data.1.0/src/sim_data.c
+++ b/codebase/superdarn/src.lib/tk/sim_data.1.0/src/sim_data.c
@@ -1,6 +1,5 @@
  /*COPYRIGHT:
 Copyright (C) 2011 by Virginia Tech
-TODO: Whose the author?
 TODO: Disclaimer is different as well... Kevin S?
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -135,8 +134,7 @@ float gasdev(long *idum)
 
 void acf_27(double complex * aa, double complex * rr, int cpid)
 {
-  if(cpid == 1)
-  {
+  if (cpid == 1) {
     rr[0]=aa[0]*conj(aa[0]);
     rr[1]=aa[5]*conj(aa[6]);
     rr[2]=aa[3]*conj(aa[4]);
@@ -156,8 +154,7 @@ void acf_27(double complex * aa, double complex * rr, int cpid)
     rr[16]=aa[1]*conj(aa[5]);
     rr[17]=aa[1]*conj(aa[6]);
   }
-  if(cpid == 150)
-  {
+  if (cpid == 150) {
     rr[0]=aa[0]*conj(aa[0]);
     rr[1]=aa[6]*conj(aa[7]);
     rr[2]=aa[2]*conj(aa[3]);
@@ -182,8 +179,7 @@ void acf_27(double complex * aa, double complex * rr, int cpid)
     rr[21]=aa[0]*conj(aa[2]);
     rr[22]=aa[0]*conj(aa[3]);
   }
-  if(cpid == 503)
-  {
+  if (cpid == 503) {
     double complex * temp = malloc(17*sizeof(double complex));
     int i;
     rr[0]=aa[0]*conj(aa[0]);
@@ -203,7 +199,6 @@ void acf_27(double complex * aa, double complex * rr, int cpid)
     rr[14]=aa[0]*conj(aa[1]);
     rr[15]=aa[2]*conj(aa[6]);
     rr[16]=aa[1]*conj(aa[6]);
-
 
     temp[0]=aa[0]*conj(aa[0]);
     temp[1]=aa[11]*conj(aa[12]);
@@ -227,6 +222,129 @@ void acf_27(double complex * aa, double complex * rr, int cpid)
       rr[i] = (rr[i]+temp[i])/2.;
 
     free(temp);
+  }
+  if (cpid == 9100) {
+    rr[0]=aa[15]*conj(aa[15]);
+    rr[1]=aa[0]*conj(aa[1]);
+    rr[2]=aa[1]*conj(aa[2]);
+    rr[3]=aa[0]*conj(aa[2]);
+    rr[4]=aa[2]*conj(aa[3]);
+    rr[5]=aa[3]*conj(aa[4]);
+    rr[6]=aa[1]*conj(aa[3]);
+    rr[7]=aa[0]*conj(aa[3]);
+    rr[8]=aa[4]*conj(aa[5]);
+    rr[9]=aa[2]*conj(aa[4]);
+    rr[10]=aa[5]*conj(aa[6]);
+    rr[11]=aa[1]*conj(aa[4]);
+    rr[12]=aa[0]*conj(aa[4]);
+    rr[13]=aa[6]*conj(aa[7]);
+    rr[14]=aa[3]*conj(aa[5]);
+    rr[15]=aa[7]*conj(aa[8]);
+    rr[16]=aa[2]*conj(aa[5]);
+    rr[17]=aa[8]*conj(aa[9]);
+    rr[18]=aa[4]*conj(aa[6]);
+    rr[19]=aa[1]*conj(aa[5]);
+    rr[20]=aa[9]*conj(aa[10]);
+    rr[21]=aa[0]*conj(aa[5]);
+    rr[22]=aa[5]*conj(aa[7]);
+    rr[23]=aa[10]*conj(aa[11]);
+    rr[24]=aa[3]*conj(aa[6]);
+    rr[25]=aa[11]*conj(aa[12]);
+    rr[26]=aa[6]*conj(aa[8]);
+    rr[27]=aa[2]*conj(aa[6]);
+    rr[28]=aa[12]*conj(aa[13]);
+    rr[29]=aa[1]*conj(aa[6]);
+    rr[30]=aa[0]*conj(aa[6]);
+    rr[31]=aa[4]*conj(aa[7]);
+    rr[32]=aa[13]*conj(aa[14]);
+    rr[33]=aa[7]*conj(aa[9]);
+    rr[34]=aa[14]*conj(aa[15]);
+    rr[35]=aa[3]*conj(aa[7]);
+    rr[36]=aa[5]*conj(aa[8]);
+    rr[37]=aa[8]*conj(aa[10]);
+    rr[38]=aa[2]*conj(aa[7]);
+    rr[39]=aa[1]*conj(aa[7]);
+    rr[40]=aa[0]*conj(aa[7]);
+    rr[41]=aa[9]*conj(aa[11]);
+    rr[42]=aa[6]*conj(aa[9]);
+    rr[43]=aa[4]*conj(aa[8]);
+    rr[44]=aa[10]*conj(aa[12]);
+    rr[45]=aa[3]*conj(aa[8]);
+    rr[46]=aa[7]*conj(aa[10]);
+    rr[47]=aa[11]*conj(aa[13]);
+    rr[48]=aa[2]*conj(aa[8]);
+    rr[49]=aa[5]*conj(aa[9]);
+    rr[50]=aa[1]*conj(aa[8]);
+    rr[51]=aa[0]*conj(aa[8]);
+    rr[52]=aa[12]*conj(aa[14]);
+    rr[53]=aa[8]*conj(aa[11]);
+    rr[54]=aa[4]*conj(aa[9]);
+    rr[55]=aa[6]*conj(aa[10]);
+    rr[56]=aa[13]*conj(aa[15]);
+    rr[57]=aa[9]*conj(aa[12]);
+    rr[58]=aa[3]*conj(aa[9]);
+    rr[59]=aa[2]*conj(aa[9]);
+    rr[60]=aa[1]*conj(aa[9]);
+    rr[61]=aa[5]*conj(aa[10]);
+    rr[62]=aa[0]*conj(aa[9]);
+    rr[63]=aa[7]*conj(aa[11]);
+    rr[64]=aa[10]*conj(aa[13]);
+    rr[65]=aa[4]*conj(aa[10]);
+    rr[66]=aa[11]*conj(aa[14]);
+    rr[67]=aa[8]*conj(aa[12]);
+    rr[68]=aa[6]*conj(aa[11]);
+    rr[69]=aa[3]*conj(aa[10]);
+    rr[70]=aa[2]*conj(aa[10]);
+    rr[71]=aa[12]*conj(aa[15]);
+    rr[72]=aa[1]*conj(aa[10]);
+    rr[73]=aa[0]*conj(aa[10]);
+    rr[74]=aa[9]*conj(aa[13]);
+    rr[75]=aa[5]*conj(aa[11]);
+    rr[76]=aa[7]*conj(aa[12]);
+    rr[77]=aa[4]*conj(aa[11]);
+    rr[78]=aa[10]*conj(aa[14]);
+    rr[79]=aa[3]*conj(aa[11]);
+    rr[80]=aa[6]*conj(aa[12]);
+    rr[81]=aa[8]*conj(aa[13]);
+    rr[82]=aa[2]*conj(aa[11]);
+    rr[83]=aa[1]*conj(aa[11]);
+    rr[84]=aa[0]*conj(aa[11]);
+    rr[85]=aa[11]*conj(aa[15]);
+    rr[86]=aa[5]*conj(aa[12]);
+    rr[87]=aa[9]*conj(aa[14]);
+    rr[88]=aa[7]*conj(aa[13]);
+    rr[89]=aa[4]*conj(aa[12]);
+    rr[90]=aa[3]*conj(aa[12]);
+    rr[91]=aa[2]*conj(aa[12]);
+    rr[92]=aa[6]*conj(aa[13]);
+    rr[93]=aa[10]*conj(aa[15]);
+    rr[94]=aa[1]*conj(aa[12]);
+    rr[95]=aa[0]*conj(aa[12]);
+    rr[96]=aa[8]*conj(aa[14]);
+    rr[97]=aa[5]*conj(aa[13]);
+    rr[98]=aa[4]*conj(aa[13]);
+    rr[99]=aa[7]*conj(aa[14]);
+    rr[100]=aa[9]*conj(aa[15]);
+    rr[101]=aa[3]*conj(aa[13]);
+    rr[102]=aa[2]*conj(aa[13]);
+    rr[103]=aa[1]*conj(aa[13]);
+    rr[104]=aa[0]*conj(aa[13]);
+    rr[105]=aa[6]*conj(aa[14]);
+    rr[106]=aa[8]*conj(aa[15]);
+    rr[107]=aa[5]*conj(aa[14]);
+    rr[108]=aa[4]*conj(aa[14]);
+    rr[109]=aa[7]*conj(aa[15]);
+    rr[110]=aa[3]*conj(aa[14]);
+    rr[111]=aa[2]*conj(aa[14]);
+    rr[112]=aa[1]*conj(aa[14]);
+    rr[113]=aa[0]*conj(aa[14]);
+    rr[114]=aa[6]*conj(aa[15]);
+    rr[115]=aa[5]*conj(aa[15]);
+    rr[116]=aa[4]*conj(aa[15]);
+    rr[117]=aa[3]*conj(aa[15]);
+    rr[118]=aa[2]*conj(aa[15]);
+    rr[119]=aa[0]*conj(aa[15]);
+    rr[120]=aa[15]*conj(aa[15]);
   }
   return;
 }

--- a/codebase/superdarn/src.lib/tk/sim_data.1.0/src/sim_data.c
+++ b/codebase/superdarn/src.lib/tk/sim_data.1.0/src/sim_data.c
@@ -25,7 +25,7 @@ THE SOFTWARE.
  Based on code orginally written by Pasha Ponomarenko
  
  2020-11-12 Marina Schmidt Converted RST complex -> C library complex
-
+ E.G.Thomas 2022-08: added support for extended 16-pulse sequence
 
 */
 


### PR DESCRIPTION
This pull request adds support for the new `bmoff` parameter in the hardware files to the radar simulator (`make_sim`).  This pull request also makes major changes to `sim_real`, which (I think) was originally intended to take the contents of a `fitacf`-format file as input and then run the data simulator at each range where scatter was actually observed to produce an output `rawacf` (or `iqdat`) file.  I don't know if the intention was to use user-defined irregularity characteristics (like in `make_sim`) or the actual measured velocity/width/power values, so I've gone with the latter.  `sim_real` also seems to have used a custom plain-text file as input, whereas in this pull request I've modified it to read an actual `fitacf`-format file.