### PR TITLE
Add placeholder command line option for `lmfit2` in `make_fit`

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_fit/doc/make_fit.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit/doc/make_fit.doc.xml
@@ -13,6 +13,7 @@
 <option><on><ar>rawacfname</ar></on><od>filename of the <code>rawacf</code> format file. If this is omitted the file is read from standard input.</od></option>
 <option><on>-fitacf3</on><od>Uses FitACF 3.0 fitting algorithm</od></option>
 <option><on>-fitacf2</on><od>Uses FitACF 2.5 fitting algorithm</od></option>
+<option><on>-lmfit2</on><od>Uses LMFit 2.0 fitting algorithm (Not yet implemented: use make_lmfit2 binary)</od></option>
 <option><on>-lmfit1</on><od>Uses LMFit 1.0 fitting algorithm</od></option>
 <option><on>-fitex2</on><od>Uses FitEx 2.0 fitting algorithm</od></option>
 <option><on>-fitex1</on><od>Uses FitEx 1.0 fitting algorithm</od></option>

--- a/codebase/superdarn/src.bin/tk/tool/make_fit/make_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit/make_fit.c
@@ -163,6 +163,7 @@ int main(int argc,char *argv[]) {
 
   int fitacf3 = 0;
   int fitacf2 = 0;
+  int lmfit2 = 0;
   int lmfit1 = 0;
   int fitex2 = 0;
   int fitex1 = 0;
@@ -180,6 +181,7 @@ int main(int argc,char *argv[]) {
 
   OptionAdd(&opt,"fitacf3",'x',&fitacf3);
   OptionAdd(&opt,"fitacf2",'x',&fitacf2);
+  OptionAdd(&opt,"lmfit2",'x',&lmfit2);
   OptionAdd(&opt,"lmfit1",'x',&lmfit1);
   OptionAdd(&opt,"fitex2",'x',&fitex2);
   OptionAdd(&opt,"fitex1",'x',&fitex1);
@@ -217,6 +219,13 @@ int main(int argc,char *argv[]) {
 
   if (old_elev == 1) {
     elv_version = 1;
+  }
+
+  // If lmfit2 fitting algorithm is provided, direct user to the separate binary
+  if (lmfit2) {
+    fprintf(stderr,"The lmfit2 fitting algorithm must be called using the separate binary, make_lmfit2\n");
+    OptionFree(&opt);
+    exit(-1);
   }
 
   // Check that a valid fitting algorithm has been provided

--- a/docs/user_guide/make_fit.md
+++ b/docs/user_guide/make_fit.md
@@ -18,9 +18,16 @@ The fitting algorithms available for processing SuperDARN data are:
 | :----------| :-----------|
 | `fitacf3`  | Suitable for all scientific applications. Fitted data may appear 'noisy' for some radars due to operational problems (remove with [`fit_speck_removal`](despecking.md)).<br>**Released:** 2017 <br>**References:** (1) [FitACF 3.0 White Paper](https://superdarn.github.io/dawg/files/sup_material/FITACF3_white_paper.pdf), (2) [SuperDARN noise estimation](https://doi.org/10.1002/essoar.10510616.1)|
 | `fitacf2`  | Suitable for all scientific applications. Generally results in fewer fitted ACFs compared to `fitacf3`. <br>**Released:** 2006<br>**Reference:** [Annales Geophysicae, 24, 115–128, 2006](https://doi.org/10.5194/angeo-24-115-2006) |
+| `lmfit2`   | Suitable for scientific applications of fit-level data. Levenburg-Marquardt fitting of SuperDARN auto-correlation functions (ACFs). With no ad hoc assumptions/conditions. No elevation angles. **Call using separate binary,** `make_lmfit2` <br>**Released:** 2018<br>**Reference:** [Radio Science, 53, 93-111, 2018](10.1002/2017RS006450) |
 | `lmfit1`   | Suitable for scientific applications of fit-level data. A model complex ACF (single component, exponential decay) is fitted to the observed one using the Levenberg-Marquardt algorithm. No elevation angles. <br>**Released:** c.a. 2012<br>**Reference:** [Radio Science, 48, 274–282, 2013](doi:10.1002/rds.20031) |
 | `fitex2` | Intended for use with the `tauscan` multipulse sequence. Phase fitting performed with 120 phase variation models. <br>**Released:** c.a. 2012<br>**Reference:** [Radio Science, 48, 274–282, 2013](doi:10.1002/rds.20031) |
-| `fitex1` | Original `fitex` algorithm. Not thoroughly tested. No elevation angles.|
+| `fitex1` | Original `fitex` algorithm. Not thoroughly tested. No elevation angles. |
+
+<br>
+
+!!! Warning
+    The `lmfit2` algorithm must be called using the separate binary, `make_lmfit2`.
+
 
 ## Basic syntax
 ```


### PR DESCRIPTION
As discussed in #522, this PR adds a command line option `-lmfit2` to `make_fit`. This option will print a help message directing users to the `make_lmfit2` binary. I also updated the readthedocs page to include a short description of lmfit2 alongside the other fitting algorithms. 

Test:
```
$ make_fit -lmfit2 20180520.0801.00.lyr.rawacf > /dev/null
The lmfit2 fitting algorithm must be called using the separate binary, make_lmfit2
```