### PR TITLE
Fix Usask copyright information

### DIFF
--- a/codebase/general/src.bin/dat/datdump/datdump.c
+++ b/codebase/general/src.bin/dat/datdump/datdump.c
@@ -1,13 +1,13 @@
 /* 
- Copyright (C) 2021 SuperDARN Canada, University of Saskatchewan
+ Copyright (c) 2021 University of Saskatchewan
  Author: Marina Schmidt
+ 
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
  Copied code from dmapdump but modified to print dat file information.
 
- Modification:
 
  This file is part of the Radar Software Toolkit (RST).
- 
+
  RST is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
@@ -20,6 +20,8 @@
  
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ 
+ Modifications:
  
 */
 

--- a/codebase/general/src.bin/dat/datdump/doc/datdump.doc.xml
+++ b/codebase/general/src.bin/dat/datdump/doc/datdump.doc.xml
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <?ignore
-(C) Copyright 2021 SuperDARN Canada, University of Saskatchewan
+Copyright (c) 2021 University of Saskatchewan
 Author: Marina Schmidt 
+
 This file is part of the Radar Software Toolkit (RST).
+
 RST is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see https://www.gnu.org/licenses/.
+
 Modifications:
+
 ?>
 <binary>
 <project>general</project>

--- a/codebase/general/src.bin/dat/datdump/makefile
+++ b/codebase/general/src.bin/dat/datdump/makefile
@@ -1,7 +1,5 @@
-# Copyright  (C) SuperDARN Canada, University of Saskatchewan
+# Copyright (c) University of Saskatchewan
 # Author: Marina Schmidt 
-#
-# Modification:
 #
 #
 # This file is part of the Radar Software Toolkit (RST).
@@ -19,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # 
+# Modifications:
+#
+
 include $(MAKECFG).$(SYSTEM)
 
 INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn 

--- a/codebase/general/src.lib/dat/include/dat.h
+++ b/codebase/general/src.lib/dat/include/dat.h
@@ -1,12 +1,10 @@
 /* 
- Copyright (C) 2021 SuperDARN Canada, University of Saskatchewan
+ Copyright (C) 2021 University of Saskatchewan
  Author: Marina Schmidt
+ 
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
  Copied code from raw.h in cmpraw modified for dat files
 
- Modified
-
- Disclaimer:
  
  This file is part of the Radar Software Toolkit (RST).
  
@@ -23,6 +21,7 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+ Modifications:
  
 */
 

--- a/codebase/general/src.lib/dat/include/datread.h
+++ b/codebase/general/src.lib/dat/include/datread.h
@@ -1,12 +1,11 @@
 /* 
- Copyright (C) 2021 SuperDARN Canada, University of Saskatchewan
+ Copyright (c) 2021 University of Saskatchewan
  Author: Marina Schmidt
+ 
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
  Copied code from raw_read.c in cmpraw modified for dat files
 
- Modified
 
- Disclaimer:
  This file is part of the Radar Software Toolkit (RST).
  
  RST is free software: you can redistribute it and/or modify
@@ -22,6 +21,7 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+ Modifications:
  
 */
 

--- a/codebase/general/src.lib/dat/src/dat_versions.h
+++ b/codebase/general/src.lib/dat/src/dat_versions.h
@@ -1,28 +1,27 @@
 /* 
- Copyright (C) 2021 SuperDARN Canada, University of Saskatchewan
+ Copyright (c) 2021 University of Saskatchewan
  Author: Marina Schmidt
+ 
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
  Copied code from raw_versions.c in cmpraw modified for dat files
 
- Modified
 
-Disclaimer:
+ This file is part of the Radar Software Toolkit (RST).
 
-This file is part of the Radar Software Toolkit (RST).
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+ Modifications:
  
 */
 

--- a/codebase/general/src.lib/dat/src/datclose.c
+++ b/codebase/general/src.lib/dat/src/datclose.c
@@ -1,28 +1,27 @@
 /* 
- Copyright (C) 2021 SuperDARN Canada, University of Saskatchewan
+ Copyright (c) 2021 University of Saskatchewan
  Author: Marina Schmidt
+ 
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
  Copied code from raw_close.c in cmpraw modified for dat files
 
- Modified
 
-Disclaimer:
+ This file is part of the Radar Software Toolkit (RST).
 
-This file is part of the Radar Software Toolkit (RST).
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+ Modifications:
  
 */
 

--- a/codebase/general/src.lib/dat/src/datopen.c
+++ b/codebase/general/src.lib/dat/src/datopen.c
@@ -1,28 +1,27 @@
 /* 
- Copyright (C) 2021 SuperDARN Canada, University of Saskatchewan
+ Copyright (c) 2021 University of Saskatchewan
  Author: Marina Schmidt
+ 
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
  Copied code from raw_close.c in cmpraw modified for dat files
 
- Modified
 
-Disclaimer:
+ This file is part of the Radar Software Toolkit (RST).
 
-This file is part of the Radar Software Toolkit (RST).
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+ Modifications:
  
 */
 

--- a/codebase/general/src.lib/dat/src/datread.c
+++ b/codebase/general/src.lib/dat/src/datread.c
@@ -1,13 +1,26 @@
 /* 
- Copyright (C) 2021 SuperDARN Canada, University of Saskatchewan
+ Copyright (c) 2021 University of Saskatchewan
  Author: Marina Schmidt
+ 
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
  Copied code from raw_read.c in cmpraw modified for dat files
 
- Modified
+ This file is part of the Radar Software Toolkit (RST).
 
-Disclaimer:
-
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+  
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  
+ Modifications:
  
 */
 

--- a/codebase/general/src.lib/dat/src/datreadcurrent.c
+++ b/codebase/general/src.lib/dat/src/datreadcurrent.c
@@ -1,28 +1,27 @@
 /* 
- Copyright (C) 2021 SuperDARN Canada, University of Saskatchewan
+ Copyright (c) 2021 University of Saskatchewan
  Author: Marina Schmidt
+ 
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
  Copied code from raw_close.c in cmpraw modified for dat files
 
- Modified
 
-Disclaimer:
+ This file is part of the Radar Software Toolkit (RST).
 
-This file is part of the Radar Software Toolkit (RST).
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ 
+ Modifications:
  
 */
 

--- a/codebase/general/src.lib/dat/src/dattodmap.c
+++ b/codebase/general/src.lib/dat/src/dattodmap.c
@@ -1,24 +1,26 @@
-/* Copyright (C)  2021 SuperDARN Canada, University of Saskatchwan 
- * Author: Marina Schmidt
- *
- * Modifications:
- *      2022-03-01 Marina Schmidt (USASK), switching intt to int 16  
- * Disclaimer:
- * 
- * This file is part of the Radar Software Toolkit (RST).
- * 
- * RST is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+/* 
+ Copyright (c) 2021 University of Saskatchwan 
+ Author: Marina Schmidt
+
+
+ This file is part of the Radar Software Toolkit (RST).
+
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+  
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  
+ Modifications:
+     2022-03-01 Marina Schmidt (USASK), switching intt to int 16 
+ 
  */ 
 
 #include <stdio.h>

--- a/codebase/general/src.lib/dat/src/makefile
+++ b/codebase/general/src.lib/dat/src/makefile
@@ -1,9 +1,6 @@
-# Copyright (C) 2021 SuperDARN Canada, University of Saskatchewan
+# Copyright (c) 2021 University of Saskatchewan
 # Author: Marina Schmidt
 #
-# Modified
-#
-# Disclaimer:
 #
 # This file is part of the Radar Software Toolkit (RST).
 # 
@@ -20,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+# Modifications:
+# 
+
 include $(MAKECFG).$(SYSTEM)
 
 INCLUDE= -g -I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn

--- a/codebase/superdarn/src.bin/tk/tool/make_lmfit2/make_lmfit2.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_lmfit2/make_lmfit2.c
@@ -1,31 +1,28 @@
 /* make_fit.c
    ==========
 
-//TODO Add copyright notice
+ Copyright (c) 2016 University of Saskatchewan
+ Adapted by: Ashton Reimer
+ From code by: Keith Kotyk and R.J. Barnes
 
-Adapted by: Ashton Reimer
-From code by: Keith Kotyk and R.J. Barnes
 
-ISAS
-August 2016
+ This file is part of the Radar Software Toolkit (RST).
 
-This file is part of the Radar Software Toolkit (RST).
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
-
-Modifications:
-    2022-06-06 Emma Bland (UNIS) Replaced -new command line option with -old
+ Modifications:
+     2022-06-06 Emma Bland (UNIS) Replaced -new command line option with -old
 */
 
 #include <stdio.h>

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/include/fit_structures.h
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/include/fit_structures.h
@@ -1,31 +1,29 @@
-/*Copyright (C) 2016  SuperDARN Canada
-
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
-
 /*
-Structures used in ACF fitting
+ Structures used in ACF fitting
 
-Keith Kotyk
-ISAS
-July 2015
+ Copyright (c) 2016 University of Saskatchewan
+ Author: Keith Kotyk
 
-Modifications:
-  E.G.Thomas 2021-08: added support for bmoff parameter
+
+ This file is part of the Radar Software Toolkit (RST).
+ 
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ Modifications:
+     E.G.Thomas 2021-08: added support for bmoff parameter
 */
-
-
-
 
 
 

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/include/fitacftoplevel.h
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/include/fitacftoplevel.h
@@ -1,26 +1,30 @@
-/*Copyright (C) 2016  SuperDARN Canada
-
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
-
 /*
-FITACF main routine
+ FITACF main routine
 
-Keith Kotyk
-ISAS
-July 2015
+ Copyright (c) 2016 University of Saskatchewan
+ Author: Keith Kotyk
+
+
+ This file is part of the Radar Software Toolkit (RST).
+
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ Modifications: 
+
 
 */
+
 
 #ifndef _FITACFTOPLEVEL_H
 #define _FITACFTOPLEVEL_H

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/include/leastsquares.h
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/include/leastsquares.h
@@ -1,24 +1,30 @@
-/*Copyright (C) 2016  SuperDARN Canada
+/*
+ Least squares fitting header
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ Copyright (c) 2016 University of Saskatchewan
+ Author: Keith Kotyk
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
+ This file is part of the Radar Software Toolkit (RST).
 
-/*Least squares fitting header
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-Keith Kotyk
-ISAS
-June 16, 2015
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ Modifications: 
+
+
 */
+
 
 #ifndef _LEASTSQUARES_H
 #define _LEASTSQUARES_H

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.c
@@ -1,31 +1,34 @@
-/*Copyright (C) 2015  SuperDARN Canada, University of Saskatchewan
-
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-author(s): Keith Kotyk
-modifications: 
-    2020-03-11 Marina Schmidt (SuperDARN Canada) removed all defined constants 
-                              and include rmath.h
-    2020-08-12 Marina Schmidt (SuperDARN Canada) removed map function for better decoupling abilities
-    2020-10-29 Marina Schmidt (SuperDARN Canada) & Emma Bland (UNIS) Changed default elevation calculation to elevation_v2()
-    2021-06-01 Emma Bland (UNIS) Consolidated elevation angle calculations into a single function
-    E.G.Thomas 2021-08: added support for bmoff parameter
-*/
-
 /*
-ACF determinations from fitted parameters
+ ACF determinations from fitted parameters
+
+ Copyright (c) 2015 University of Saskatchewan
+ author: Keith Kotyk
+
+
+ This file is part of the Radar Software Toolkit (RST).
+
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ Modifications: 
+     2020-03-11 Marina Schmidt (University of Saskatchewan) removed all defined constants and include rmath.h
+     2020-08-12 Marina Schmidt (University of Saskatchewan) removed map function for better decoupling abilities
+     2020-10-29 Marina Schmidt (University of Saskatchewan) & Emma Bland (UNIS) 
+                Changed default elevation calculation to elevation_v2()
+     2021-06-01 Emma Bland (UNIS) Consolidated elevation angle calculations into a single function
+     E.G.Thomas 2021-08: added support for bmoff parameter
 */
+
 
 #include "llist.h"
 #include "rtypes.h"

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.h
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/determinations.h
@@ -1,30 +1,31 @@
-/*Copyright (C) 2015  SuperDARN Canada, University of Saskatchewan
-
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-author(s): Keith Kotyk
-modifications: 
-    2020-03-11 Marina Schmidt (SuperDARN Canada) removed all defined constants 
-                              and include rmath.h
-    2020-09-01 Marina Schmidt (SuperDARN Canada) removed map function for better decoupling abilities
-    2020-10-29 Marina Schmidt (SuperDARN Canada) & Emma Bland (UNIS) Changed default elevation calculation to elevation_v2()
-    2021-06-01 Emma Bland (UNIS) Consolidated elevation angle calculations into a single function
-*/
-
 /*
-ACF determination functions
+ ACF determination functions
+
+ Copyright (c) 2015 University of Saskatchewan
+ author: Keith Kotyk
+
+ This file is part of the Radar Software Toolkit (RST).
+
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ Modifications: 
+     2020-03-11 Marina Schmidt (University of Saskatchewan) removed all defined constants and include rmath.h
+     2020-09-01 Marina Schmidt (University of Saskatchewan) removed map function for better decoupling abilities
+     2020-10-29 Marina Schmidt (University of Saskatchewan) & Emma Bland (UNIS) Changed default elevation calculation to elevation_v2()
+     2021-06-01 Emma Bland (UNIS) Consolidated elevation angle calculations into a single function
 */
+
 
 
 

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/fitacftoplevel.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/fitacftoplevel.c
@@ -1,27 +1,31 @@
-/*Copyright (C) 2016  SuperDARN Canada
-
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
 /*
-FITACF main routine
+ FITACF main routine
 
-Keith Kotyk
-ISAS
-July 2015
+ Copyright (c) 2016 University of Saskatchewan
+ Author: Keith Kotyk
 
-Modifications:
-  E.G.Thomas 2021-08: added support for bmoff parameter and multi-channel tdiff values
+
+ This file is part of the Radar Software Toolkit (RST).
+
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ Modifications:
+     E.G.Thomas 2021-08: added support for bmoff parameter and multi-channel tdiff values
+  
 */
+
+
 
 #include "rtypes.h"
 #include "llist.h"

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/fitting.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/fitting.c
@@ -1,26 +1,30 @@
-/*Copyright (C) 2016  SuperDARN Canada
-
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
-
 /*
-ACF least square fitting wrapper functions
+ ACF least square fitting wrapper functions
 
-Keith Kotyk
-ISAS
-July 2015
+ Copyright (c) 2016 University of Saskatchewan
+ Author: Keith Kotyk
+
+
+ This file is part of the Radar Software Toolkit (RST).
+
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ Modifications:
+
 
 */
+
 
 #include "rtypes.h"
 #include <math.h>

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/fitting.h
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/fitting.h
@@ -1,27 +1,30 @@
-/*Copyright (C) 2015  SuperDARN Canada, University of Saskatchewan
-author: Keith Kotyk
-
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-Modifications:
-    2020-09-01 Marina Schmidt (SuperDARN Canada) removed map function for better decoupling abilities
-
-*/
-
 /*
-ACF least square fitting wrapper functions
+ ACF least square fitting wrapper functions
+
+ Copyright (c) 2015 University of Saskatchewan
+ author: Keith Kotyk
+
+
+ This file is part of the Radar Software Toolkit (RST).
+
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ Modifications:
+     2020-09-01 Marina Schmidt (University of Saskatchewan) removed map function for better decoupling abilities
+
 */
+
 
 #ifndef _ACFFIT_H
 #define _ACFFIT_H

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/leastsquares.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/leastsquares.c
@@ -1,29 +1,34 @@
-/*Copyright (C) 2016  SuperDARN Canada
+/*
+ Least squares fitting
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ Functions follow the naming scheme and procedures used in
+ NUMERICAL RECIPES IN C: THE ART OF SCIENTIFIC COMPUTING
+ pages 661-663
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
+ Copyright (c) 2016 University of Saskatchewan
+ Author: Keith Kotyk
 
-/*Least squares fitting
+ This file is part of the Radar Software Toolkit (RST).
 
-Keith Kotyk
-ISAS
-June 16, 2015
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-Functions follow the naming scheme and procedures used in
-NUMERICAL RECIPES IN C: THE ART OF SCIENTIFIC COMPUTING
-pages 661-663
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ Modifications:
+
 
 */
+
 
 #include "leastsquares.h"
 #include "rtypes.h"

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.c
@@ -1,28 +1,29 @@
-/*Copyright (C) 2016  SuperDARN Canada, University of Saskatchewan
-
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
-
 /*
-ACF Processing main functions
+ ACF Processing main functions
 
-Author(s): Keith Kotyk July 2015
+ Copyright (c) 2016  University of Saskatchewan
+ author: Keith Kotyk
 
-Modifications: 
-    2020-03-11 Marina Schmidt (SuperDARN Canada) removed all defined 
-                              constants and included rmath.h 
-    2021-05-26 Pasha Ponomarenko (SuperDARN Canada) check that the search noise
-               is nonzero before using it to replace the skynoise when min_pwr < 1
+
+ This file is part of the Radar Software Toolkit (RST).
+
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ Modifications: 
+     2020-03-11 Marina Schmidt (University of Saskatchewan) removed all defined constants and included rmath.h 
+     2021-05-26 Pasha Ponomarenko (University of Saskatchewan) check that the search noise
+                is nonzero before using it to replace the skynoise when min_pwr < 1
 
 */
 

--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.h
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/preprocessing.h
@@ -1,26 +1,29 @@
-/*Copyright (C) 2016  SuperDARN Canada
-
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
-
 /*
-ACF Processing main functions
+ ACF Processing main functions
 
-Keith Kotyk
-ISAS
-July 2015
+ Copyright (c) 2016 University of Saskatchewan
+ Author: Keith Kotyk
+
+
+ This file is part of the Radar Software Toolkit (RST).
+ 
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ Modifications:
 
 */
+
 
 #ifndef _ACFPROC_H
 #define _ACFPROC_H

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/include/lmfit2toplevel.h
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/include/lmfit2toplevel.h
@@ -1,28 +1,27 @@
 /*
-LMFIT2 main routine
+ LMFIT2 main routine
 
-Adapted by: Ashton Reimer
-From code by: Keith Kotyk
+ Copyright (c) 2016 University of Saskatchewan
+ Adapted by: Ashton Reimer
+ From code by: Keith Kotyk
 
-ISAS
-August 2016
 
-This file is part of the Radar Software Toolkit (RST).
+ This file is part of the Radar Software Toolkit (RST).
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-Modifications:
+ Modifications:
 
 */
 

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/include/lmfit_leastsquares.h
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/include/lmfit_leastsquares.h
@@ -1,30 +1,28 @@
-/*Non-Linear Least squares fitting using Levenburg-Marquardt 
-Algorithm implements in C (cmpfit)
+/*
+ Non-Linear Least squares fitting using Levenburg-Marquardt 
+ Algorithm implements in C (cmpfit)
 
-/TODO Add copyright notice
+ Copyright (c) 2016 University of Saskatchewan
+ Adapted by: Ashton Reimer
+ From code by: Keith Kotyk
 
-Adapted by: Ashton Reimer
-From code by: Keith Kotyk
 
-ISAS
-August 2016
+ This file is part of the Radar Software Toolkit (RST).
 
-This file is part of the Radar Software Toolkit (RST).
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
-
-Modifications:
+ Modifications:
 
 */
 

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/include/lmfit_structures.h
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/include/lmfit_structures.h
@@ -1,30 +1,28 @@
 /*
-Structures used in ACF fitting
+ Structures used in ACF fitting
 
-//TODO Add copyright notice
+ Copyright (c) 2016 University of Saskatchewan
 
-Adapted by: Ashton Reimer
-From code by: Keith Kotyk
+ Adapted by: Ashton Reimer
+ From code by: Keith Kotyk
 
-ISAS
-August 2016
 
-This file is part of the Radar Software Toolkit (RST).
+ This file is part of the Radar Software Toolkit (RST).
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-Modifications:
+ Modifications:
 
 
 */

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/error_estimates.c
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/error_estimates.c
@@ -1,26 +1,25 @@
 /* selfclutter.c
    ==============
-Author: A.S.Reimer
 
-Copyright (c) 2014 The Institute for Space and Atmospheric Study at 
-the University of Saskatchewan
+ Copyright (c) 2014 University of Saskatchewan
+ Author: A.S.Reimer
  
-This file is part of the Radar Software Toolkit (RST).
+ This file is part of the Radar Software Toolkit (RST).
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-Modifications:
+ Modifications:
 
 */
 

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/error_estimates.h
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/error_estimates.h
@@ -1,24 +1,25 @@
 /* error_estimates.h
    ==========
 
-//TODO Add copyright notice
+ Copyright (c) 2016 University of Saskatchewan
+ Author: Ashton Reimer
 
-This file is part of the Radar Software Toolkit (RST).
+ This file is part of the Radar Software Toolkit (RST).
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-Modifications:
+ Modifications:
 
 
 */

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit2toplevel.c
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit2toplevel.c
@@ -1,29 +1,28 @@
 /*
-LMFIT2 main routine
+ LMFIT2 main routine
 
-Adapted by: Ashton Reimer
-From code by: Keith Kotyk
+ Copyright (c) 2016 University of Saskatchewan
+ Adapted by: Ashton Reimer
+ From code by: Keith Kotyk
 
-ISAS
-August 2016
 
-This file is part of the Radar Software Toolkit (RST).
+ This file is part of the Radar Software Toolkit (RST).
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-Modifications:
-    2022-06-06 Emma Bland (UNIS): Updated fit_prms->tdiff to match new hardware file format
+ Modifications:
+     2022-06-06 Emma Bland (UNIS): Updated fit_prms->tdiff to match new hardware file format
 
 */
 

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_determinations.c
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_determinations.c
@@ -1,28 +1,27 @@
 /*
-ACF determinations from fitted parameters
+ ACF determinations from fitted parameters
 
-Adapted by: Ashton Reimer
-From code by: Keith Kotyk
+ Copyright (c) 2016 University of Saskatchewan
+ Adapted by: Ashton Reimer
+ From code by: Keith Kotyk
 
-ISAS
-August 2016
 
-This file is part of the Radar Software Toolkit (RST).
+ This file is part of the Radar Software Toolkit (RST).
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-Modifications:
+ Modifications:
 
 
 */

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_determinations.h
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_determinations.h
@@ -1,28 +1,26 @@
 /*
-ACF determination functions
+ ACF determination functions
 
-//TODO Add copyright notice
+ Copyright (c) 2015 University of Saskatchewan
+ Author: Keith Kotyk
 
-Keith Kotyk
-ISAS
-July 2015
 
-This file is part of the Radar Software Toolkit (RST).
+ This file is part of the Radar Software Toolkit (RST).
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-Modifications:
+ Modifications:
 
 
 */

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_fitting.c
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_fitting.c
@@ -1,30 +1,27 @@
 /*
-LMFIT2 least square fitting wrapper functions
+ LMFIT2 least square fitting wrapper functions
 
-//TODO Add copyright notice
+ Copyright (c) 2016 University of Saskatchewan
+ Adapted by: Ashton Reimer
+ From code by: Keith Kotyk
 
-Adapted by: Ashton Reimer
-From code by: Keith Kotyk
 
-ISAS
-August 2016
+ This file is part of the Radar Software Toolkit (RST).
 
-This file is part of the Radar Software Toolkit (RST).
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
-
-Modifications:
+ Modifications:
 
 
 */

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_fitting.h
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_fitting.h
@@ -1,30 +1,27 @@
 /*
-LMFIT2 least square fitting wrapper functions
+ LMFIT2 least square fitting wrapper functions
 
-//TODO Add copyright notice
+ Copyright (c) 2016 University of Saskatchewan
+ Adapted by: Ashton Reimer
+ From code by: Keith Kotyk
 
-Adapted by: Ashton Reimer
-From code by: Keith Kotyk
 
-ISAS
-August 2016
+ This file is part of the Radar Software Toolkit (RST).
 
-This file is part of the Radar Software Toolkit (RST).
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
-
-Modifications:
+ Modifications:
 
 
 */

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_leastsquares.c
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_leastsquares.c
@@ -1,30 +1,28 @@
-/*Non-Linear Least squares fitting using Levenburg-Marquardt 
-Algorithm implements in C (cmpfit)
+/*
+ Non-Linear Least squares fitting using Levenburg-Marquardt 
+ Algorithm implements in C (cmpfit)
 
-//TODO Add copyright notice
+ Copyright (c) 2016 University of Saskatchewan
+ Adapted by: Ashton Reimer
+ From code by: Keith Kotyk
 
-Adapted by: Ashton Reimer
-From code by: Keith Kotyk
 
-ISAS
-August 2016
+ This file is part of the Radar Software Toolkit (RST).
 
-This file is part of the Radar Software Toolkit (RST).
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
-
-Modifications:
+ Modifications:
 
 
 */

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_preprocessing.c
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_preprocessing.c
@@ -1,30 +1,27 @@
 /*
-ACF Processing main functions
+ ACF Processing main functions
 
-//TODO Add copyright notice
+ Copyright (c) 2016 University of Saskatchewan
+ Adapted by: Ashton Reimer
+ From code by: Keith Kotyk
 
-Adapted by: Ashton Reimer
-From code by: Keith Kotyk
 
-ISAS
-August 2016
+ This file is part of the Radar Software Toolkit (RST).
 
-This file is part of the Radar Software Toolkit (RST).
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
-
-Modifications:
+ Modifications:
 
 
 */

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_preprocessing.h
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/lmfit_preprocessing.h
@@ -1,30 +1,27 @@
 /*
-ACF Processing main functions
+ ACF Processing main functions
 
-//TODO Add copyright notice
+ Copyright (c) 2016 University of Saskatchewan
+ Adapted by: Ashton Reimer
+ From code by: Keith Kotyk
 
-Adapted by: Ashton Reimer
-From code by: Keith Kotyk
 
-ISAS
-August 2016
+ This file is part of the Radar Software Toolkit (RST).
 
-This file is part of the Radar Software Toolkit (RST).
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
-
-Modifications:
+ Modifications:
 
 
 */

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/selfclutter.c
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/selfclutter.c
@@ -1,29 +1,26 @@
 /* selfclutter.c
    ==============
 
-//TODO Add copyright notice
+ Copyright (c) 2016 University of Saskatchewan
+ Author: Ashton Reimer
 
-Ashton Reimer
 
-ISAS
-Last Update: August 2016
+ This file is part of the Radar Software Toolkit (RST).
 
-This file is part of the Radar Software Toolkit (RST).
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
-
-Modifications:
+ Modifications:
 
 
 */

--- a/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/selfclutter.h
+++ b/codebase/superdarn/src.lib/tk/lmfit_v2.0/src/selfclutter.h
@@ -1,27 +1,26 @@
 /* selfclutter.h
    =====
 
-//TODO Add copyright notice
+ Copyright (c) 2016 University of Saskatchewan
+ Author: A.S. Reimer
 
-   Author: A.S. Reimer
 
+ This file is part of the Radar Software Toolkit (RST).
 
-This file is part of the Radar Software Toolkit (RST).
+ RST is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-RST is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
-
-Modifications:
+ Modifications:
 
  
 */


### PR DESCRIPTION
This PR corrects some copyright notices in `lmfit2`, `fitacf3` and `datdump` that I noticed while working on #514. 

I have removed references to "SuperDARN Canada" and "ISAS", and replaced with "University of Saskatchewan". The changes have been approved by Kathryn.