### PR TITLE
Fixing FitSeek DLM bug

### DIFF
--- a/codebase/superdarn/src.dlm/fitdlm.1.7/fitdlm.c
+++ b/codebase/superdarn/src.dlm/fitdlm.1.7/fitdlm.c
@@ -331,7 +331,7 @@ static IDL_VPTR IDLFitSeek(int argc,IDL_VPTR *argv,char *argk) {
 
 
 
-  if (outargc>6) {
+  if (outargc>7) {
     /* decode index here */
     finx=malloc(sizeof(struct FitIndex));
     if (finx==NULL) {


### PR DESCRIPTION
This pull request fixes a typo in `fitdlm.c` causing `FitSeek` to throw a seg fault when trying to use the DLM with IDL (#525).  To test, try something like the following on this branch and on `develop`:

```
inp = FitOpen('your_filename_here.fitacf', /read)
s = FitSeek(inp, yr, mo, dy, hr, mt, sc)
ret = FitRead(inp, prm, fit)
```

As far as I can tell, this bug dates back to when the DLMs were first introduced in RST 3.2.