### PR TITLE
time_plot fix for large number of range gates (> 150)

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -1656,6 +1656,7 @@ int main(int argc,char *argv[]) {
   if (ymajor==0) {
     if (kmflg) ymajor=(erang-frang)/ytick;
     else if ((geoflg) || (magflg)) ymajor=(latmax-latmin)/ytick;
+    else if ((erng-srng)>150) ymajor=(erng-srng)/ytick;
     else ymajor=15;
   }
   if (yminor==0) yminor=5;

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -91,7 +91,7 @@ Modifications:
 
 #define HEIGHT 640
 #define WIDTH  540
-#define MAX_RANGE 300
+#define MAX_RANGE 600
 
 struct OptionData opt;
 struct OptionFile *optf=NULL;


### PR DESCRIPTION
This pull request makes two small changes to `time_plot` to better support radar operating modes when more than 150 range gates were used:

1. the maximum number of ranges has been increased from 300 to 600, and 
2. the range gate ytick intervals have been changed from a fixed value of 15 to be dynamically calculated based on the requested start and end ranges