### PR TITLE
Fixing likely typo in dmap.c

### DIFF
--- a/codebase/general/src.lib/dmap.1.25/src/dmap.c
+++ b/codebase/general/src.lib/dmap.1.25/src/dmap.c
@@ -1229,8 +1229,8 @@ struct DataMap *DataMapDecodeBuffer(unsigned char *buf,int size) {
     case DATAINT:
       a->data.vptr=malloc(sizeof(int32)*n);
       if (a->data.vptr==NULL) {
-        break;
         e=1;
+        break;
       }
       for (x=0;x<n;x++) {
         ConvertToInt(buf+off,&a->data.iptr[x]);


### PR DESCRIPTION
This pull request fixes a likely typo in `dmap.c` where a break occurs before an error flag can be set, which is inconsistent with the surrounding code.