### PR TITLE
Fix flatten and expand functions

### DIFF
--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fit.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fit.c
@@ -154,23 +154,23 @@ void *FitFlatten(struct FitData *ptr,int nrang,size_t *size) {
 
   r=(struct FitData *) buf;
 
-  memcpy((int*)buf,ptr,sizeof(struct FitData));
+  memcpy(buf,ptr,sizeof(struct FitData));
   p=sizeof(struct FitData);
 
   if (ptr->rng !=NULL) {
-    memcpy((int*)buf+p,ptr->rng,nrang*sizeof(struct FitRange));
+    memcpy(buf+p,ptr->rng,nrang*sizeof(struct FitRange));
     r->rng=(void *) p;
     p+=nrang*sizeof(struct FitRange);
   }
 
   if (ptr->xrng !=NULL) {
-    memcpy((int*)buf+p,ptr->xrng,nrang*sizeof(struct FitRange));
+    memcpy(buf+p,ptr->xrng,nrang*sizeof(struct FitRange));
     r->xrng=(void *) p;
     p+=nrang*sizeof(struct FitRange);
   }
 
   if (ptr->elv !=NULL) {
-    memcpy((int*)buf+p,ptr->elv,nrang*sizeof(struct FitElv));
+    memcpy(buf+p,ptr->elv,nrang*sizeof(struct FitElv));
     r->elv=(void *) p;
     p+=nrang*sizeof(struct FitElv);
   }
@@ -190,19 +190,19 @@ int FitExpand(struct FitData *ptr,int nrang,void *buffer) {
   memcpy(ptr,buffer,sizeof(struct FitData));
 
   if (ptr->rng !=NULL) {
-    p=(int*)buffer+(size_t) ptr->rng;
+    p=buffer+(size_t) ptr->rng;
     ptr->rng=malloc(nrang*sizeof(struct FitRange));
     memcpy(ptr->rng,p,nrang*sizeof(struct FitRange));
   }
 
   if (ptr->xrng !=NULL) {
-    p=(int*)buffer+(size_t) ptr->xrng;
+    p=buffer+(size_t) ptr->xrng;
     ptr->xrng=malloc(nrang*sizeof(struct FitRange));
     memcpy(ptr->xrng,p,nrang*sizeof(struct FitRange));
   }
  
   if (ptr->elv !=NULL) {
-    p=(int*)buffer+(size_t) ptr->elv;
+    p=buffer+(size_t) ptr->elv;
     ptr->elv=malloc(nrang*sizeof(struct FitElv));
     memcpy(ptr->elv,p,nrang*sizeof(struct FitElv));
   }

--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fit.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fit.c
@@ -144,6 +144,7 @@ void *FitFlatten(struct FitData *ptr,int nrang,size_t *size) {
   if (size==NULL) return NULL;
 
   s=sizeof(struct FitData);
+  if (ptr->algorithm !=NULL) s+=strlen(ptr->algorithm)+1;
   if (ptr->rng !=NULL) s+=nrang*sizeof(struct FitRange);
   if (ptr->xrng !=NULL) s+=nrang*sizeof(struct FitRange);    
   if (ptr->elv !=NULL) s+=nrang*sizeof(struct FitElv);
@@ -156,6 +157,12 @@ void *FitFlatten(struct FitData *ptr,int nrang,size_t *size) {
 
   memcpy(buf,ptr,sizeof(struct FitData));
   p=sizeof(struct FitData);
+
+  if (ptr->algorithm !=NULL) {
+    strcpy(buf+p,ptr->algorithm);
+    r->algorithm=(void *) p;
+    p+=strlen(ptr->algorithm)+1;
+  }
 
   if (ptr->rng !=NULL) {
     memcpy(buf+p,ptr->rng,nrang*sizeof(struct FitRange));
@@ -183,11 +190,18 @@ int FitExpand(struct FitData *ptr,int nrang,void *buffer) {
   if (ptr==NULL) return -1;
   if (buffer==NULL) return -1;
 
+  if (ptr->algorithm !=NULL) free(ptr->algorithm);
   if (ptr->rng !=NULL) free(ptr->rng);
   if (ptr->xrng !=NULL) free(ptr->xrng);
   if (ptr->elv !=NULL) free(ptr->elv);
 
   memcpy(ptr,buffer,sizeof(struct FitData));
+
+  if (ptr->algorithm !=NULL) {
+    p=buffer+(size_t) ptr->algorithm;
+    ptr->algorithm=malloc(strlen(p)+1);
+    strcpy(ptr->algorithm,p);
+  }
 
   if (ptr->rng !=NULL) {
     p=buffer+(size_t) ptr->rng;

--- a/codebase/superdarn/src.lib/tk/iq.1.7/src/iq.c
+++ b/codebase/superdarn/src.lib/tk/iq.1.7/src/iq.c
@@ -203,37 +203,37 @@ void *IQFlatten(struct IQ *ptr,int nave,size_t *size) {
   p=sizeof(struct IQ);
 
   if (ptr->tval !=NULL) {
-    memcpy((int*)buf+p,ptr->tval,nave*sizeof(struct timespec));
+    memcpy(buf+p,ptr->tval,nave*sizeof(struct timespec));
     r->tval=(void *) p;
     p+=nave*sizeof(struct timespec);
   }
 
   if (ptr->atten !=NULL) {
-    memcpy((int*)buf+p,ptr->atten,nave*sizeof(int));
+    memcpy(buf+p,ptr->atten,nave*sizeof(int));
     r->atten=(void *) p;
     p+=nave*sizeof(int);
   }
 
   if (ptr->noise !=NULL) {
-    memcpy((int*)buf+p,ptr->noise,nave*sizeof(float));
+    memcpy(buf+p,ptr->noise,nave*sizeof(float));
     r->noise=(void *) p;
     p+=nave*sizeof(float);
   }
 
   if (ptr->offset !=NULL) {
-    memcpy((int*)buf+p,ptr->offset,nave*sizeof(int));
+    memcpy(buf+p,ptr->offset,nave*sizeof(int));
     r->offset=(void *) p;
     p+=nave*sizeof(int);
   }
 
   if (ptr->size !=NULL) {
-    memcpy((int*)buf+p,ptr->size,nave*sizeof(int));
+    memcpy(buf+p,ptr->size,nave*sizeof(int));
     r->size=(void *) p;
     p+=nave*sizeof(int);
   }
 
   if (ptr->badtr !=NULL) {
-    memcpy((int*)buf+p,ptr->badtr,nave*sizeof(int));
+    memcpy(buf+p,ptr->badtr,nave*sizeof(int));
     r->badtr=(void *) p;
     p+=nave*sizeof(int);
   }
@@ -256,32 +256,32 @@ int IQExpand(struct IQ *ptr,int nave,void *buffer) {
   if (ptr->badtr !=NULL) free(ptr->badtr);
   memcpy(ptr,buffer,sizeof(struct IQ));
   if (ptr->tval !=NULL) {
-    p=(int*)buffer+(size_t) ptr->tval;
+    p=buffer+(size_t) ptr->tval;
     ptr->tval=malloc(nave*sizeof(struct timespec));
     memcpy(ptr->tval,p,nave*sizeof(struct timespec));
   }
   if (ptr->atten !=NULL) {
-    p=(int*)buffer+(size_t) ptr->atten;
+    p=buffer+(size_t) ptr->atten;
     ptr->atten=malloc(nave*sizeof(int));
     memcpy(ptr->atten,p,nave*sizeof(int));
   }
   if (ptr->noise !=NULL) {
-    p=(int*)buffer+(size_t) ptr->noise;
+    p=buffer+(size_t) ptr->noise;
     ptr->noise=malloc(nave*sizeof(float));
     memcpy(ptr->noise,p,nave*sizeof(float));
   }
   if (ptr->offset !=NULL) {
-    p=(int*)buffer+(size_t) ptr->offset;
+    p=buffer+(size_t) ptr->offset;
     ptr->offset=malloc(nave*sizeof(int));
     memcpy(ptr->offset,p,nave*sizeof(int));
   }
   if (ptr->size !=NULL) {
-    p=(int*)buffer+(size_t) ptr->size;
+    p=buffer+(size_t) ptr->size;
     ptr->size=malloc(nave*sizeof(int));
     memcpy(ptr->size,p,nave*sizeof(int));
   }
   if (ptr->badtr !=NULL) {
-    p=(int*)buffer+(size_t) ptr->badtr;
+    p=buffer+(size_t) ptr->badtr;
     ptr->badtr=malloc(nave*sizeof(int));
     memcpy(ptr->badtr,p,nave*sizeof(int));
   }

--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -442,14 +442,14 @@ void *RadarParmFlatten(struct RadarParm *ptr,size_t *size) {
   }
 
   if (ptr->pulse !=NULL) {
-    memcpy((int*)buf+p,ptr->pulse,ptr->mppul*sizeof(int16));
+    memcpy(buf+p,ptr->pulse,ptr->mppul*sizeof(int16));
     r->pulse=(void *) p;
     p+=ptr->mppul*sizeof(int16);
   }
 
   for (n=0;n<2;n++) {
     if (ptr->lag[n]==NULL) continue;
-    memcpy((int*)buf+p,ptr->lag[n],lnum*sizeof(int16));
+    memcpy(buf+p,ptr->lag[n],lnum*sizeof(int16));
     r->lag[n]=(void *) p;
     p+=lnum*sizeof(int16);
   }
@@ -472,25 +472,25 @@ int RadarParmExpand(struct RadarParm *ptr,void *buffer) {
 
   memcpy(ptr,buffer,sizeof(struct RadarParm));
   if (ptr->origin.time !=NULL) {
-    p=(int*)buffer+(size_t) ptr->origin.time;
+    p=buffer+(size_t) ptr->origin.time;
     ptr->origin.time=malloc(strlen(p)+1);
     strcpy(ptr->origin.time,p);
   }
 
   if (ptr->origin.command !=NULL) {
-    p=(int*)buffer+(size_t) ptr->origin.command;
+    p=buffer+(size_t) ptr->origin.command;
     ptr->origin.command=malloc(strlen(p)+1);
     strcpy(ptr->origin.command,p);
   }
 
   if (ptr->combf !=NULL) {
-    p=(int*)buffer+(size_t) ptr->combf;
+    p=buffer+(size_t) ptr->combf;
     ptr->combf=malloc(strlen(p)+1);
     strcpy(ptr->combf,p);
   }
 
   if (ptr->pulse !=NULL) {
-    p=(int*)buffer+(size_t) ptr->pulse;
+    p=buffer+(size_t) ptr->pulse;
     ptr->pulse=malloc(ptr->mppul*sizeof(int16));
     memcpy(ptr->pulse,p,ptr->mppul*sizeof(int16));
   }
@@ -499,7 +499,7 @@ int RadarParmExpand(struct RadarParm *ptr,void *buffer) {
     if (ptr->lag[n]==NULL) continue;
     if (ptr->mplgexs !=0) lnum=ptr->mplgexs+1;
     else lnum=ptr->mplgs+1;
-    p=(int*)buffer+(size_t) ptr->lag[n];
+    p=buffer+(size_t) ptr->lag[n];
     ptr->lag[n]=malloc(lnum*sizeof(int16));
     memcpy(ptr->lag[n],p,lnum*sizeof(int16));
   }

--- a/codebase/superdarn/src.lib/tk/raw.1.22/src/raw.c
+++ b/codebase/superdarn/src.lib/tk/raw.1.22/src/raw.c
@@ -184,21 +184,21 @@ void *RawFlatten(struct RawData *ptr,int nrang,int mplgs,size_t *size) {
   p=sizeof(struct RawData);
 
   if (ptr->pwr0 !=NULL) {
-    memcpy((int *)buf+p,ptr->pwr0,nrang*sizeof(float));
+    memcpy(buf+p,ptr->pwr0,nrang*sizeof(float));
     r->pwr0=(void *) p;
     p+=nrang*sizeof(float);
   }
 
   for (n=0;n<2;n++) {
     if (ptr->acfd[n]==NULL) continue; 
-    memcpy((int *)buf+p,ptr->acfd[n],(nrang*mplgs)*sizeof(float));
+    memcpy(buf+p,ptr->acfd[n],(nrang*mplgs)*sizeof(float));
     r->acfd[n]=(void *) p;
     p+=(nrang*mplgs)*sizeof(float); 
   }
 
   for (n=0;n<2;n++) {
     if (ptr->xcfd[n]==NULL) continue; 
-    memcpy((int *)buf+p,ptr->xcfd[n],(nrang*mplgs)*sizeof(float));
+    memcpy(buf+p,ptr->xcfd[n],(nrang*mplgs)*sizeof(float));
     r->xcfd[n]=(void *) p;
     p+=(nrang*mplgs)*sizeof(float); 
   }
@@ -220,21 +220,21 @@ int RawExpand(struct RawData *ptr,int nrang,int mplgs,void *buffer) {
   memcpy(ptr,buffer,sizeof(struct RawData));
 
   if (ptr->pwr0 !=NULL) {
-    p=(int *)buffer+(size_t) ptr->pwr0;
+    p=buffer+(size_t) ptr->pwr0;
     ptr->pwr0=malloc(nrang*sizeof(float));
     memcpy(ptr->pwr0,p,nrang*sizeof(float));
   }
 
   for (n=0;n<2;n++) {
     if (ptr->acfd[n]==NULL) continue;
-    p=(int *)buffer+(size_t) ptr->acfd[n]; 
+    p=buffer+(size_t) ptr->acfd[n];
     ptr->acfd[n]=malloc((nrang*mplgs)*sizeof(float));
     memcpy(ptr->acfd[n],p,(nrang*mplgs)*sizeof(float));
   }
 
   for (n=0;n<2;n++) {
     if (ptr->xcfd[n]==NULL) continue;
-    p=(int *) buffer+(size_t) ptr->xcfd[n]; 
+    p=buffer+(size_t) ptr->xcfd[n];
     ptr->xcfd[n]=malloc((nrang*mplgs)*sizeof(float));
     memcpy(ptr->xcfd[n],p,(nrang*mplgs)*sizeof(float));
   }


### PR DESCRIPTION
This pull request reverts several changes previously made to the `IQ` / `Fit` / `Raw` / `RadarParm` `Flatten` and `Expand` functions which had attempted to address compilation warnings.  While these previous changes got rid of the compilation warnings, the functions no longer work properly - in some cases garbage values are passed back and forth, and in others they fail completely.  I've also gone ahead and added support for the new `algorithm` field to `FitFlatten` and `FitExpand` for completeness.

Note that these functions are (as far as I know) only used by control programs in the ROS to pass data to the various `write` functions, so the changes in this pull request are not so straightforward to test.  One could either take my word for it, write their own program to test, or I can provide some instructions offline for using the radar simulator.