### PR TITLE
Fixing typo in FitSetAlgorithm of fit.c

### DIFF
--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fit.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fit.c
@@ -67,7 +67,7 @@ int FitSetAlgorithm(struct FitData *ptr,char *str) {
     return 0;
   }
 
-  if (ptr->algorithm==NULL) tmp=malloc(strlen(str+1));
+  if (ptr->algorithm==NULL) tmp=malloc(strlen(str)+1);
   else tmp=realloc(ptr->algorithm,strlen(str)+1);
 
   if (tmp==NULL) return -1;


### PR DESCRIPTION
This pull request fixes a small typo in the new `FitSetAlgorithm` function of the `fit` library, where the string length is not correctly calculated for a malloc.  This bug was identified using valgrind, eg

```
==27264==  Address 0x5d881d6 is 0 bytes after a block of size 6 alloc'd
==27264==    at 0x4C31B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27264==    by 0x112138: FitSetAlgorithm (fit.c:70)
```

I'm not sure if there are any easy tests - hopefully it is a clear typo whose fix can be approved for the release branch.
