### PR TITLE
Updating gitignore so fitacfversion.h and lib subdirectories aren't ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,22 +2,24 @@
 *.so
 *.o
 *~
-bin/
-build/bin/
-build/include/
-build/lib/
-dlm/
-/doc/
-/idl/
-/include/
-lib/
-log/
+
+bin
+/build/include
+/build/lib
+/dlm
+/doc
+/idl
+/include
+/lib
+/log
 
 codebase/general/src.lib/stdkey.1.5/src/make_palette
 
 *errstr.h
 *hlpstr.h
 *version.h
+!fitacfversion.h
+
 site/
 docs/xml
 docs/latex/


### PR DESCRIPTION
As the title indicates, this pull request makes a few small changes to the `.gitignore` file so that the `lib/` filter doesn't exclude codebase subdirectories with actual source code (eg, `codebase/analysis/src.idl/lib`) and so the `*version.h` filter doesn't exclude the `fitacfversion.h` file in the `fitacf.2.5` library.

This will primarily help with copying future RST releases to the `rst-archive` repository - in the past I had to go back and manually add the missing lib directories and fitacfversion files because the `.gitignore` excluded them (eg https://github.com/SuperDARN/rst-archive/commit/d70471dd4f8a293cd0ce18b3cd60ffd0ae28ce0e and https://github.com/SuperDARN/rst-archive/commit/9b659d77d262ad9596fd4797a61999996e10b2e7).  Note that no behavior should change in this repository.