### PR TITLE
Fix `fitacfclientgui` compilation on macOS

### DIFF
--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/makefile
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/makefile
@@ -9,7 +9,10 @@ INCLUDE=-I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn
 OBJS = fitacfclientgui.o
 SRC=hlpstr.h errstr.h fitacfclientgui.c
 
-LIBS=-lfitcnx.1 -lfit.1 -lcfit.1 -lrscan.1 -lradar.1 -lcnx.1 -ldmap.1 -lopt.1 -lrtime.1 -lrcnv.1 -lncurses -ltinfo
+LIBS=-lfitcnx.1 -lfit.1 -lcfit.1 -lrscan.1 -lradar.1 -lcnx.1 -ldmap.1 -lopt.1 -lrtime.1 -lrcnv.1 -lncurses
+ifneq ($(OSTYPE),darwin)
+LIBS += -ltinfo
+endif
 SLIB=-lz
 DSTPATH = $(BINPATH)
 OUTPUT = fitacfclientgui


### PR DESCRIPTION
@agrocott _https://github.com/SuperDARN/rst/issues/533#issuecomment-1303662216_

> ...does the script that produces the makefile not have access to the OSTYPE system variable, such that the makefile could be modified based on that?

Yes, I think this might work. I've modified the makefile to check `$OSTYPE` before adding `-ltinfo`. It works for me on linux. Would you mind testing on your mac?