### PR TITLE
Modifying rtcfit, rtgrid, and rtsnd to sleep 5 seconds if a connection fails

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/rtcfit.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/rtcfit.c
@@ -342,20 +342,9 @@ int main(int argc,char *argv[]) {
     if (resetflg==1) loginfo(logfname,"Connection timed out.");
     if (resetflg==2) loginfo(logfname,"Connection reset by signal.");
     ConnexClose(sock);
+    sleep(5);
   } while(1);
 
   return 0;
 }
-   
-
- 
-
-
-
-
-
-
-
-
-
 

--- a/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/rtgrid.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/rtgrid.c
@@ -602,6 +602,7 @@ int main(int argc,char *argv[]) {
     if (resetflg==1) loginfo(logname,"Connection timed out.");
     if (resetflg==2) loginfo(logname,"Connection reset by signal.");
     ConnexClose(sock);
+    sleep(5);
   } while(1);
 
   return 0;

--- a/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/rtsnd.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/rtsnd.c
@@ -391,6 +391,7 @@ int main(int argc,char *argv[]) {
     if (resetflg==1) loginfo(logfname,"Connection timed out.");
     if (resetflg==2) loginfo(logfname,"Connection reset by signal.");
     ConnexClose(sock);
+    sleep(5);
   } while(1);
 
   return 0;


### PR DESCRIPTION
As the title / commit suggest, this pull request modifies `rtcfit`, `rtgrid`, and `rtsnd` to add a `sleep(5)` command if the connection to a real-time data stream fails, times out, or is reset.  This should both limit the number of attempted connections if a stream goes down, and also reduce the size of the rt* logs.

For example, currently `rtgrid` will try to connect >9 times per second if the connection fails, leading to a log file of >100 MB per day.