### PR TITLE
Modifying fitacfclientgui to add elevation angle support and keyboard toggle

### DIFF
--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/doc/fitacfclientgui.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/doc/fitacfclientgui.doc.xml
@@ -21,6 +21,8 @@
 </option>
 <option><on>-w</on><od>plot spectral width.</od>
 </option>
+<option><on>-w</on><od>plot elevation angle.</od>
+</option>
 <option><on>-pmin <ar>pmin</ar></on><od>set the minimum value of the power scale to <ar>pmin</ar>.</od>
 </option>
 <option><on>-pmax <ar>pmax</ar></on><od>set the maximum value of the power scale to <ar>pmax</ar>.</od>
@@ -33,12 +35,16 @@
 </option>
 <option><on>-wmax <ar>wmax</ar></on><od>set the maximum value of the spectral width scale to <ar>wmax</ar>.</od>
 </option>
+<option><on>-emin <ar>emin</ar></on><od>set the minimum value of the elevation angle scale to <ar>emin</ar>.</od>
+</option>
+<option><on>-emax <ar>emax</ar></on><od>set the maximum value of the elevation angle scale to <ar>emax</ar>.</od>
+</option>
 <option><on><ar>host</ar></on><od>hostname or IP address of the system to connect to.</od>
 </option>
 <option><on><ar>port</ar></on><od>port number to connect to on the system.</od></option>
 <synopsis><p>Graphical client program for <code>fitacf</code> TCP/IP data streams.</p></synopsis>
 <description><p>Graphical client program for <code>fitacf</code> TCP/IP data streams.</p>
-<p>The program dumps an ASCII representation of the <code>fitacf</code> data stream to standard output.</p>
+<p>The program dumps an ASCII representation of the <code>fitacf</code> data stream to standard output. When color mode is enabled, users can toggle between power, velocity, spectral width, and elevation angle by pressing 'p', 'v', w', or 'e', respectively. Press any other key to exit the program.</p>
 </description>
 
 <example>

--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/fitacfclientgui.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/fitacfclientgui.c
@@ -77,7 +77,7 @@ int main(int argc,char *argv[]) {
 
   unsigned char pwrflg=0;
   double pmin=0;
-  double pmax=40;
+  double pmax=30;
 
   unsigned char velflg=0;
   double vmin=-500;

--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/fitacfclientgui.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/fitacfclientgui.c
@@ -288,7 +288,9 @@ int main(int argc,char *argv[]) {
 
       /* Draw beam and gate labels */
       move(12, 0);
-      printw("B\\G 0         10        20        30        40        50        60        70\n");
+      printw("B\\G 0         ");
+      for (i=1;i*10<nrng;i++) printw("%d        ",i*10);
+      printw("\n");
 
       if (colorflg) {
         if (prm->bmnum < min_beam) min_beam = prm->bmnum;


### PR DESCRIPTION
This pull request makes a few small changes to the new `fitacfclientgui` to add support for plotting elevation angles when in color mode, and also support for toggling between different parameters by pressing the `p` (power), `v` (velocity), `w` (width), or `e` (elevation) keys; pressing any other key will still cleanly exit the program.