### PR TITLE
Improve log messages in rt routines

### DIFF
--- a/codebase/general/src.bin/tcpip/rtmultiplex.1.32/connect.c
+++ b/codebase/general/src.bin/tcpip/rtmultiplex.1.32/connect.c
@@ -50,7 +50,7 @@ extern int msgmax;
 void closesock(int i) {
   if ((i<msgmax) && (client[i].sock !=-1)) {
     char logbuf[256];
-    sprintf(logbuf,"%s : Close Connection.",client[i].host);
+    sprintf(logbuf,"%s : Close Connection (%d/%d).",client[i].host,i,CLIENT_MAX);
     loginfo(logfname,logbuf);
     close(client[i].sock);
     client[i].sock=-1;
@@ -61,6 +61,7 @@ void closesock(int i) {
 int opensock(int sock,fd_set *fdset) {
   int i,status;
   char logbuf[256];
+  char hostbuf[256];
   int temp;
   socklen_t clength;
 
@@ -72,9 +73,13 @@ int opensock(int sock,fd_set *fdset) {
   if (i>=CLIENT_MAX) { 
     /* dequeue the request here */
 
-    loginfo(logfname,"Too many clients attached - refusing connection.");
+    clength=sizeof(caddr);
+    temp=accept(sock,(struct sockaddr *) &caddr,&clength);
 
-    temp=accept(sock,0,0);
+    sprintf(hostbuf,"[%s]",inet_ntoa(caddr.sin_addr));
+    sprintf(logbuf,"%s : Too many clients attached - refusing connection.",hostbuf);
+    loginfo(logfname,logbuf);
+
     if (temp !=-1) close(temp);
     return -1;
   }
@@ -103,7 +108,7 @@ int opensock(int sock,fd_set *fdset) {
     return -1;
   } 
 
-  sprintf(logbuf,"%s : Open Connection.",client[i].host);
+  sprintf(logbuf,"%s : Open Connection (%d/%d).",client[i].host,i,CLIENT_MAX);
   loginfo(logfname,logbuf);
 
   if (i==msgmax) msgmax++;

--- a/codebase/general/src.bin/tcpip/rtmultiplex.1.32/loginfo.c
+++ b/codebase/general/src.bin/tcpip/rtmultiplex.1.32/loginfo.c
@@ -1,6 +1,7 @@
 /* loginfo.c
    =========
    Author: R.J.Barnes
+
  Copyright (c) 2012 The Johns Hopkins University/Applied Physics Laboratory
 
 This file is part of the Radar Software Toolkit (RST).
@@ -34,7 +35,6 @@ Modifications:
 void loginfo(char *fname,char *str) {
   FILE *fp;
   char *date;
-  char pid[128];
   char logpath[1024];
   time_t ltime;
   struct tm *time_of_day;
@@ -44,13 +44,9 @@ void loginfo(char *fname,char *str) {
 
   date=asctime(time_of_day);  
 
-  date[strlen(date)-1]=':';
+  date[strlen(date)-1]=0;
   
-  sprintf(pid,"(%d):",getpid());
-  fprintf(stderr,"%s",date);
-  fprintf(stderr,"%s",pid);
-  fprintf(stderr,"%s",str);
-  fprintf(stderr,"\n");
+  fprintf(stderr,"%s : (%d) : %s\n",date,getpid(),str);
 
   sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
           time_of_day->tm_year,time_of_day->tm_mon+1,
@@ -62,19 +58,7 @@ void loginfo(char *fname,char *str) {
     return;
   }
 
-  fprintf(fp,"%s",date);
-  fprintf(fp,"%s",pid);
-  fprintf(fp,"%s",str);
-  fprintf(fp,"\n");
+  fprintf(fp,"%s : (%d) : %s\n",date,getpid(),str);
   fclose(fp);
 }
-
-
-
-
-
-
-
-
-
 

--- a/codebase/general/src.bin/tcpip/rtmultiplex.1.32/socket.c
+++ b/codebase/general/src.bin/tcpip/rtmultiplex.1.32/socket.c
@@ -70,15 +70,19 @@ void logtime(char *fname,int nbytes) {
   int mask=S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
   int fid,s;
   time_t tval;
-  
- 
-  tval=time(NULL);
+  struct tm *time_of_day;
+  char *date;
+
+  time(&tval);
+  time_of_day=localtime(&tval);
+  date=asctime(time_of_day);
+  date[strlen(date)-1]=0;
 
   fid=open(fname,O_WRONLY | O_TRUNC | O_CREAT,mask);
 
   if (fid !=0) {
-    sprintf(txt,"%d %d\n",(int) tval,nbytes);
-    s=write(fid,txt,strlen(txt)+1);
+    sprintf(txt,"%s : %d",date,nbytes);
+    s=write(fid,txt,strlen(txt));
     if (s == -1)
     {
         fprintf(stderr, "Error: Write was not Successful\n");

--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfserver.1.17/connect.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfserver.1.17/connect.c
@@ -53,7 +53,7 @@ extern char logfname[256];
 void close_sock(int i) {
   if ((i<msgmax) && (client[i].sock !=-1)) {
     char logbuf[256];
-    sprintf(logbuf,"%s : Close Connection.",client[i].host);
+    sprintf(logbuf,"%s : Close Connection (%d/%d).",client[i].host,i,CLIENT_MAX);
     loginfo(logfname,logbuf);
     close(client[i].sock);
     client[i].sock=-1;
@@ -64,6 +64,7 @@ void close_sock(int i) {
 int open_sock(int sock,fd_set *fdset) {
   int i,status;
   char logbuf[256];
+  char hostbuf[256];
   int temp;
   socklen_t clength;
 
@@ -74,9 +75,13 @@ int open_sock(int sock,fd_set *fdset) {
   if (i>=CLIENT_MAX) { 
     /* dequeue the request here */
 
-    loginfo(logfname,"Too many clients attached - refusing connection.");
+    clength=sizeof(caddr);
+    temp=accept(sock,(struct sockaddr *) &caddr,&clength);
 
-    temp=accept(sock,0,0);
+    sprintf(hostbuf,"[%s]",inet_ntoa(caddr.sin_addr));
+    sprintf(logbuf,"%s : Too many clients attached - refusing connection.",hostbuf);
+    loginfo(logfname,logbuf);
+
     if (temp !=-1) close(temp);
     return -1;
   }
@@ -105,7 +110,7 @@ int open_sock(int sock,fd_set *fdset) {
     return -1;
   } 
 
-  sprintf(logbuf,"%s : Open Connection.",client[i].host);
+  sprintf(logbuf,"%s : Open Connection (%d/%d).",client[i].host,i,CLIENT_MAX);
   loginfo(logfname,logbuf);
 
   if (i==msgmax) msgmax++;

--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfserver.1.17/fitacfserver.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfserver.1.17/fitacfserver.c
@@ -406,28 +406,4 @@ int main(int argc,char *argv[]) {
   } while(status==0);
   return 0;
 }
-   
-
- 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfserver.1.17/loginfo.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfserver.1.17/loginfo.c
@@ -30,6 +30,7 @@ Modifications:
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 
 void loginfo(char *fname,char *str) {
@@ -44,11 +45,9 @@ void loginfo(char *fname,char *str) {
 
   date=asctime(time_of_day);  
 
-  date[strlen(date)-1]=':';
+  date[strlen(date)-1]=0;
   
-  fprintf(stderr,"%s",date);
-  fprintf(stderr,"%s",str);
-  fprintf(stderr,"\n");
+  fprintf(stderr,"%s : (%d) : %s\n",date,getpid(),str);
 
    sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
           time_of_day->tm_year,time_of_day->tm_mon+1,
@@ -59,18 +58,7 @@ void loginfo(char *fname,char *str) {
     fprintf(stderr,"WARNING:Log failed.\n");
     return;
   }
-  fprintf(fp,"%s",date);
-  fprintf(fp,"%s",str);
-  fprintf(fp,"\n");
+  fprintf(fp,"%s : (%d) : %s\n",date,getpid(),str);
   fclose(fp);
 }
-
-
-
-
-
-
-
-
-
 

--- a/codebase/superdarn/src.bin/tk/tcpip/rtfitacftofit.1.19/connect.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/rtfitacftofit.1.19/connect.c
@@ -53,7 +53,7 @@ extern int msgmax;
 void closesock(int i) {
   if ((i<msgmax) && (client[i].sock !=-1)) {
     char logbuf[256];
-    sprintf(logbuf,"%s : Close Connection.",client[i].host);
+    sprintf(logbuf,"%s : Close Connection (%d/%d).",client[i].host,i,CLIENT_MAX);
     loginfo(logfname,logbuf);
     close(client[i].sock);
     client[i].sock=-1;
@@ -64,6 +64,7 @@ void closesock(int i) {
 int opensock(int sock,fd_set *fdset) {
   int i,status;
   char logbuf[256];
+  char hostbuf[256];
   int temp;
   socklen_t clength;
 
@@ -74,9 +75,13 @@ int opensock(int sock,fd_set *fdset) {
   if (i>=CLIENT_MAX) { 
     /* dequeue the request here */
 
-    loginfo(logfname,"Too many clients attached - refusing connection.");
+    clength=sizeof(caddr);
+    temp=accept(sock,(struct sockaddr *) &caddr,&clength);
 
-    temp=accept(sock,0,0);
+    sprintf(hostbuf,"[%s]",inet_ntoa(caddr.sin_addr));
+    sprintf(logbuf,"%s : Too many clients attached - refusing connection.",hostbuf);
+    loginfo(logfname,logbuf);
+
     if (temp !=-1) close(temp);
     return -1;
   }
@@ -105,7 +110,7 @@ int opensock(int sock,fd_set *fdset) {
     return -1;
   } 
 
-  sprintf(logbuf,"%s : Open Connection.",client[i].host);
+  sprintf(logbuf,"%s : Open Connection (%d/%d).",client[i].host,i,CLIENT_MAX);
   loginfo(logfname,logbuf);
 
   if (i==msgmax) msgmax++;

--- a/codebase/superdarn/src.bin/tk/tcpip/rtfitacftofit.1.19/loginfo.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/rtfitacftofit.1.19/loginfo.c
@@ -44,11 +44,9 @@ void loginfo(char *fname,char *str) {
 
   date=asctime(time_of_day);  
 
-  date[strlen(date)-1]=':';
+  date[strlen(date)-1]=0;
   
-  fprintf(stderr,"%s",date);
-  fprintf(stderr,"%s",str);
-  fprintf(stderr,"\n");
+  fprintf(stderr,"%s : %s\n",date,str);
 
   sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
           time_of_day->tm_year,time_of_day->tm_mon+1,
@@ -60,18 +58,7 @@ void loginfo(char *fname,char *str) {
     return;
   }
 
-  fprintf(fp,"%s",date);
-  fprintf(fp,"%s",str);
-  fprintf(fp,"\n");
+  fprintf(fp,"%s : %s\n",date,str);
   fclose(fp);
 }
-
-
-
-
-
-
-
-
-
 

--- a/codebase/superdarn/src.bin/tk/tcpip/rtfittofitacf.1.20/connect.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/rtfittofitacf.1.20/connect.c
@@ -53,7 +53,7 @@ extern int msgmax;
 void closesock(int i) {
   if ((i<msgmax) && (client[i].sock !=-1)) {
     char logbuf[256];
-    sprintf(logbuf,"%s : Close Connection.",client[i].host);
+    sprintf(logbuf,"%s : Close Connection (%d/%d).",client[i].host,i,CLIENT_MAX);
     loginfo(logfname,logbuf);
     close(client[i].sock);
     client[i].sock=-1;
@@ -64,6 +64,7 @@ void closesock(int i) {
 int opensock(int sock,fd_set *fdset) {
   int i,status;
   char logbuf[256];
+  char hostbuf[256];
   int temp;
   socklen_t clength;
   struct sockaddr_in caddr;
@@ -73,9 +74,13 @@ int opensock(int sock,fd_set *fdset) {
   if (i>=CLIENT_MAX) { 
     /* dequeue the request here */
 
-    loginfo(logfname,"Too many clients attached - refusing connection.");
+    clength=sizeof(caddr);
+    temp=accept(sock,(struct sockaddr *) &caddr,&clength);
 
-    temp=accept(sock,0,0);
+    sprintf(hostbuf,"[%s]",inet_ntoa(caddr.sin_addr));
+    sprintf(logbuf,"%s : Too many clients attached - refusing connection.",hostbuf);
+    loginfo(logfname,logbuf);
+
     if (temp !=-1) close(temp);
     return -1;
   }
@@ -104,7 +109,7 @@ int opensock(int sock,fd_set *fdset) {
     return -1;
   } 
 
-  sprintf(logbuf,"%s : Open Connection.",client[i].host);
+  sprintf(logbuf,"%s : Open Connection (%d/%d).",client[i].host,i,CLIENT_MAX);
   loginfo(logfname,logbuf);
 
   if (i==msgmax) msgmax++;

--- a/codebase/superdarn/src.bin/tk/tcpip/rtfittofitacf.1.20/loginfo.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/rtfittofitacf.1.20/loginfo.c
@@ -44,11 +44,9 @@ void loginfo(char *fname,char *str) {
 
   date=asctime(time_of_day);  
 
-  date[strlen(date)-1]=':';
+  date[strlen(date)-1]=0;
   
-  fprintf(stderr,"%s",date);
-  fprintf(stderr,"%s",str);
-  fprintf(stderr,"\n");
+  fprintf(stderr,"%s : %s\n",date,str);
 
   sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
           time_of_day->tm_year,time_of_day->tm_mon+1,
@@ -60,9 +58,7 @@ void loginfo(char *fname,char *str) {
     return;
   }
 
-  fprintf(fp,"%s",date);
-  fprintf(fp,"%s",str);
-  fprintf(fp,"\n");
+  fprintf(fp,"%s : %s\n",date,str);
   fclose(fp);
 }
 

--- a/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/loginfo.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/loginfo.c
@@ -45,12 +45,10 @@ void loginfo(char *fname,char *str) {
 
   date=asctime(time_of_day);  
 
-  date[strlen(date)-1]=':';
+  date[strlen(date)-1]=0;
   
   if (dotflag==1) fprintf(stderr,"\n");
-  fprintf(stderr,"%s",date);
-  fprintf(stderr,"%s",str);
-  fprintf(stderr,"\n");
+  fprintf(stderr,"%s : %s\n",date,str);
   dotflag=0;
   sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
           time_of_day->tm_year,time_of_day->tm_mon+1,
@@ -60,18 +58,7 @@ void loginfo(char *fname,char *str) {
     fprintf(stderr,"WARNING:Log failed.\n");
     return;
   }
-  fprintf(fp,"%s",date);
-  fprintf(fp,"%s",str);
-  fprintf(fp,"\n");
+  fprintf(fp,"%s : %s\n",date,str);
   fclose(fp);
 }
-
-
-
-
-
-
-
-
-
 

--- a/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/loginfo.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/loginfo.c
@@ -46,30 +46,17 @@ void loginfo(char *fname,char *str) {
 
   date=asctime(time_of_day);  
 
-  date[strlen(date)-1]=':';
+  date[strlen(date)-1]=0;
   
   if (dotflag==1) fprintf(stderr,"\n");
-  fprintf(stderr,"%s",date);
-  fprintf(stderr,"%s",str);
-  fprintf(stderr,"\n");
+  fprintf(stderr,"%s : %s\n",date,str);
   dotflag=0;
 
   sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
           time_of_day->tm_year,time_of_day->tm_mon+1,
           time_of_day->tm_mday);
   fp=fopen(logpath,"a");
-  fprintf(fp,"%s",date);
-  fprintf(fp,"%s",str);
-  fprintf(fp,"\n");
+  fprintf(fp,"%s : %s\n",date,str);
   fclose(fp);
 }
-
-
-
-
-
-
-
-
-
 

--- a/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/rtgrid.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/rtgrid.c
@@ -528,10 +528,10 @@ int main(int argc,char *argv[]) {
         TimeEpochToYMDHMS(src[inx]->st_time,
           &yr,&mo,&dy,&hr,&mt,&sc);
         if (dataflg==1) sprintf(logbuf,
-          "%d:%d:%d:Processing scan %d (data received)",
+          "%02d:%02d:%02d : Processing scan %d (data received)",
           hr,mt,(int) sc,num);
         else sprintf(logbuf,
-          "%d:%d:%d:Processing scan %d (no data received)",
+          "%02d:%02d:%02d : Processing scan %d (no data received)",
           hr,mt,(int) sc,num);
         dataflg=0;
         loginfo(logname,logbuf);

--- a/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/loginfo.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/loginfo.c
@@ -45,12 +45,10 @@ void loginfo(char *fname,char *str) {
 
   date=asctime(time_of_day);
 
-  date[strlen(date)-1]=':';
+  date[strlen(date)-1]=0;
 
   if (dotflag==1) fprintf(stderr,"\n");
-  fprintf(stderr,"%s",date);
-  fprintf(stderr,"%s",str);
-  fprintf(stderr,"\n");
+  fprintf(stderr,"%s : %s\n",date,str);
   dotflag=0;
   sprintf(logpath,"%s.%.4d%.2d%.2d",fname,1900+
           time_of_day->tm_year,time_of_day->tm_mon+1,
@@ -60,8 +58,6 @@ void loginfo(char *fname,char *str) {
     fprintf(stderr,"WARNING:Log failed.\n");
     return;
   }
-  fprintf(fp,"%s",date);
-  fprintf(fp,"%s",str);
-  fprintf(fp,"\n");
+  fprintf(fp,"%s : %s\n",date,str);
   fclose(fp);
 }


### PR DESCRIPTION
This pull request cleans up the logging messages printed / recorded by several of the real-time server routines:

- rtmultiplex
- rtfitacftofit
- rtfittofitacf
- fitacfserver

and client routines:

- rtgrid
- rtsnd
- rtcfit

Generally the spacing is fixed up, and for the server-style routines there is new information about how many client connections are currently active, and also the host information of clients trying to connect once too many are already attached.

For example, log output from `rtmultiplex` might look something like this once too many connections are reached (note that I've reduced the default `CLIENT_MAX` limit of 64 down to 2 for demonstration purposes):

```
Thu Nov 17 16:02:41 2022 : (24727) : [XXX.X.X.X] : Open Connection (0/2).
Thu Nov 17 16:02:47 2022 : (24727) : [XXX.X.X.X] : Open Connection (1/2).
Thu Nov 17 16:02:53 2022 : (24727) : [XXX.X.X.X] : Too many clients attached - refusing connection.
Thu Nov 17 16:03:08 2022 : (24727) : [XXX.X.X.X] : Close Connection (0/2).
Thu Nov 17 16:03:08 2022 : (24727) : [XXX.X.X.X] : Close Connection (1/2).
```