### PR TITLE
Update rbposlib.pro

### DIFF
--- a/codebase/superdarn/src.idl/lib/legacy.1.6/rbposlib.pro
+++ b/codebase/superdarn/src.idl/lib/legacy.1.6/rbposlib.pro
@@ -121,7 +121,7 @@ function rbpos,range,height=height,beam=beam,lagfr=first_lag,smsep=smsp, $
   if (keyword_set(station)) then st_id = station else st_id = dp.p.st_id
 
   if (keyword_set(yr)) then year=yr else year=dp.p.year
-  if (keyword_set(yrs)) then yrsec=yrs else $
+  if (n_elements(yrs)) then yrsec=yrs else $
       yrsec=TimeYMDHMSToYrsec(dp.p.year,dp.p.month,dp.p.day,dp.p.hour, $
                                   dp.p.minut,dp.p.sec)
 


### PR DESCRIPTION
I was testing the IDL routines, and happened to test it on a file time 2002010100, i.e. yrs(year seconds)=0, upon which the code failed. It tests if the "yrs" keyword is set, using the "keyword_set" function. This is unadvisable ("keyword_set" is best used when the keyword is binary) since it evaluates FALSE if the keyword has a (valid) value of zero. In this case, the time being 0:0:0 on Jan 1st, yrs=0, and "keyword_set(yrs)" was FALSE. I have replaced "keyword_set" with "n_elements" which returns 1 (TRUE) for any value (including zero). It evaluates 0 if the variable is undefined (i.e. unset).