### PR TITLE
More updates to readthedocs

### DIFF
--- a/docs/references/general/cfit.md
+++ b/docs/references/general/cfit.md
@@ -7,17 +7,12 @@ Disclaimer: License under GNU v3.0, the file is found in the root directory unde
 
 # Compressed FitACF (cFit) data format
 
-A description of the compressed FitACF data format "cFit."
+The cFit format is a compressed format for storing a limited sub-set of data from the output of the FitACF algorithm.  The format does not store all of the radar operation parameters or the full set of derived values of the algorithm. Instead it stores sufficient parameters to characterize the operation of the radar, as well as the power, velocity, and spectral width parameters. The advantage of cFit files is that they are considerably smaller than fit or fitacf files. Typically a cFit file is a few megabytes in length, whereas a fit file can be over 100 megabytes.
 
-## Introduction
-
-The cFit format is a compressed format for storing a limited sub-set of data from the output of the FitACF algorithm.  The format does not store all of the radar operation parameters or the full set of derived values of the algorithm, instead it stores sufficient parameters to characterize the operation of the radar and the power, spectral width, and velocity, and the derived errors, from the analysis.
-
-The advantage of cFit files is that they are considerably smaller and more convenient to work with than full fit or fitacf files.  Typically a cFit file is a few megabytes in length, whereas a fit file can be over 100 megabytes.
 
 ## The Format
 
-A cFit file is divided up into blocks or records, each record has the same format but can have varying length depending on the scatter observed by the radar.  Each record is dvidided up in to a header and a data section.  The structure of a record is given below:
+A cFit file is divided into blocks or records. Each record has the same format but can have varying length depending on the amount of scatter observed by the radar. Each record is divided into a header and a data section. The structure of a record is given below:
 
 | Byte Offset | Size (Bytes) | Type | Content |
 | :---        |  :----:      | :--- | :---   |
@@ -42,7 +37,7 @@ A cFit file is divided up into blocks or records, each record has the same forma
 | 47     | m  | m bytes              | Range table    |
 | 47+m   | n  | n bytes              | Data table     |
 
-The remainder of the block consists of the data values for the stored ranges.  The range table indicates which range a data value corresponds to.  For example, if the first entry in the range table contains a value of 23, that indicates that the first set of data values in the data table came from range 23.
+The remainder of the block consists of the data values for the stored ranges.  The range table indicates which range gate a data value corresponds to.  For example, if the first entry in the range table contains a value of 23, that indicates that the first set of data values in the data table came from range gate 23.
 
 Each entry in the data table has the same format shown below:
 

--- a/docs/references/general/dat.md
+++ b/docs/references/general/dat.md
@@ -12,7 +12,7 @@ They can be converted to the RAWACF file format using RST's `dattorawacf` comman
 
 ## Naming Conventions
 
-The naming convention for DAT files is:
+The community standard for naming DAT files is:
 
 > YYYYMMDDHH.<1-letter radar abbreviation>.dat
 
@@ -28,27 +28,25 @@ The naming convention for DAT files is:
 | w                           | sto                   | Stokkseyri     |
 | e                           | pyk                   | Pykkvibaer     |
 | f                           | han                   | Hankasalmi     |
-| d                           | san                   | Sanae          |
+| d                           | san                   | SANAE          |
 | j                           | sys                   | Syowa South    |
 | n                           | sye                   | Syowa East     |
 | r                           | tig                   | TIGER          |
-| p                           | ker                   | Keruelen       |
+| p                           | ker                   | Kerguelen       |
 | c                           | ksr                   | King Salmon    |
 | u                           | unw                   | Unwin          |
 | i                           | wal                   | Wallops Island |
 
 
 DAT files usually contain 2 hours of data. If the radar restarted or changed to a different control program during a 2-hour interval, a new DAT file is created. When this occurs, a letter is appended to the filename after the 1-letter radar abbreviation.
-!!! Warning
-    Do not confuse the letters in DAT-format filenames with the letters representing channels in RAWACF-format filenames. 
 
 > YYYYMMDDHH.<1-letter radar abbreviation>[a-z].dat
 
-## Fields
-
-Each record in a DAT file contains a set of scalar and vector fields. 
-
-### Scalars
+!!! Warning
+    Do not confuse the letters in DAT-format filenames with the letters representing channels in RAWACF-format filenames. 
+    
+    
+## Scalar Fields
 
 | Field name             | Units     | Data Type | Description                                                                                                                                                                                      |
 | :----------            | :-----:   | :-------: | :---                                                                                                                                                                                             |
@@ -91,7 +89,7 @@ Each record in a DAT file contains a set of scalar and vector fields.
 | *tfreq*                | *kHz*     | short     | Transmitted frequency                                                                                                                                                                            |
 | *mxpwr*                | *None*      | int       | Maximum power                                                                                                                                                                                    |
 | *lvmax*                | *None*    | int       | Maximum noise level allowed                                                                                                                                                                      |
-| usr_resL1              | *None*    | int       | User defined variable            
+| usr_resL1              | *None*    | int       | User defined variable
 | usr_resL2              | *None*    | int       | User defined variable                                                                                                                                                                          |
 | cp                     | *None*     | short     | Control program number                                                                                                                                                                           |
 | usr_resS1              | *None*    | short     | User defined variable                                                                                                                                                                            |
@@ -100,10 +98,9 @@ Each record in a DAT file contains a set of scalar and vector fields.
 | *combf*                | *None*    | string    | Comment buffer, usually contains the control program name                                                                                                                                        |
 
 
-### Vectors 
+## Vector Fields
 
-!!! Note
-    *slist* contains the range gates with lag zero power above the threshold level.
+*slist* contains the range gates with lag zero power above the threshold level.
 
 | Field name  | Units    | Dimensionality | Data Type   | Description                                                                 |
 | :---------- | :-----:  | :-------:      | :---:       | :---                                                                        |
@@ -112,3 +109,4 @@ Each record in a DAT file contains a set of scalar and vector fields.
 | *pwr0*      | *None*     | *[nrang]*      | float       | Lag zero power, estimated from voltage samples (not fitted)  |
 | *acfd*      | *None*   | *[2][mplgs][0-nrang]*    | float       | Calculated ACFs                                                             |
 | *xcfd*      | *None*   | *[2][mplgs][0-nrang]*    | float       | Calculated XCFs                                                             |
+

--- a/docs/references/general/dmap_data.md
+++ b/docs/references/general/dmap_data.md
@@ -13,11 +13,11 @@ A description of the DataMap self-describing format
 
 ## Introduction
 
-The DataMap format was developed as a self-describing format to replace the existing SuperDARN binary formats.  Althought many self-describing formats already existed, none was suitable for use in the operational environment of the radar sites.  The format was designed to be the simplest possible implementation of a self-describing format that placed the minimum number of restrictions on the user and developer.  Although DataMap was originally developed as a simple file format, the same encoding method can also be applied to any stream of data.  In fact, the DataMap format is currently used to encode the real-time data stream from the radar sites.
+The DataMap format was developed as a self-describing format to replace the existing SuperDARN binary formats.  Although many self-describing formats already existed, none was suitable for use in the operational environment of the radar sites.  The format was designed to be the simplest possible implementation of a self-describing format that placed the minimum number of restrictions on the user and developer.  Although DataMap was originally developed as a simple file format, the same encoding method can also be applied to any stream of data.  In fact, the DataMap format is currently used to encode the real-time data stream from the radar sites.
 
 ## The Format
 
-DataMap files or streams are comprised of blocks or records.  Each block represents a single packet of information.  A block is comprised of two types of variables that store the data, scalars and arrays.  A scalar variable contains a signle discrete value while an array variable contains multiple values with multiple dimensions.  There is no restriction on the contents of a block, and different blocks can contain different scalars and arrays, although in most cases the same scalars and arrays will appear in each block.
+DataMap files or streams are comprised of blocks or records.  Each block represents a single packet of information.  A block is comprised of two types of variables that store the data, scalars and arrays.  A scalar variable contains a single discrete value while an array variable contains multiple values with multiple dimensions.  There is no restriction on the contents of a block, and different blocks can contain different scalars and arrays, although in most cases the same scalars and arrays will appear in each block.
 
 ### Block Format
 
@@ -61,13 +61,13 @@ Scalar data consists of single discrete values.  To store a scalar value, the Da
 
 ### Array Data
 
-An array is defined by the number of dimensions it posesses and the ranges of those dimensions.  The simplest form of an array is a vector, which consists of a one-dimensional array:
+An array is defined by the number of dimensions it possesses and the ranges of those dimensions.  The simplest form of an array is a vector, which consists of a one-dimensional array:
 
 
 |v=(10.0 5.0 3.0) | A one-dimensional array |
 |v=(10.0 5.0 6.0) <br>    3.0 4.0 2.0 | A two-dimensional array |
 
-Every dimension in an array has a range or extent which represents that maximum value an index along that dimension can have.  Array ranges start at zero and can never have a negative value.  For the two examples above, the range for the one-dimensional array is 3 and for the two dimensional array the ranges are 3 and 2.  Arrays are exactly analogous to arrays in a programming langugage.
+Every dimension in an array has a range or extent which represents that maximum value an index along that dimension can have. Array ranges start at zero and can never have a negative value. For the two examples above, the range for the one-dimensional array is 3 and for the two-dimensional array the ranges are 3 and 2. Arrays are exactly analogous to arrays in a programming language.
 
 An array variable has a name, type, dimension, a set of ranges and the data values contained in the array:
 
@@ -81,7 +81,7 @@ An array variable has a name, type, dimension, a set of ranges and the data valu
 | x+8+4*N | y | multiple              | Array values |
 
 
-The array values stored so that the first dimension is the fastest varying.  For a simple two dimension array with the range of the first dimension being 3 and the second being 2 the array data is ordered as follows:
+The array values stored so that the first dimension is the fastest varying.  For a simple two-dimension array with the range of the first dimension being 3 and the second being 2 the array data is ordered as follows:
 
 
 | v(x,y) | Index into Array Values |
@@ -100,5 +100,5 @@ The array values stored so that the first dimension is the fastest varying.  For
 
 ## History (from RFC)
 
-- 2004/06/22 Iniital Revision, RJB
+- 2004/06/22 Initial Revision, RJB
 

--- a/docs/references/general/filename.md
+++ b/docs/references/general/filename.md
@@ -5,7 +5,7 @@ Disclaimer: License under GNU v3.0, the file is found in the root directory unde
 
 -->
 
-This information is sourced from the RFC: 0002 previously in the RST RFC documentation that was written by R.J. Barnes.  For the filenaming convention, it is expected the Data Standards Working Group documentation will make information presented here obsolete.
+This information is sourced from the RFC: 0002 previously in the RST RFC documentation that was written by R.J. Barnes.
 
 # Filename Format Definition
 
@@ -28,7 +28,7 @@ The original specification (from 1990s) for SuperDARN filenames was as follows:
 *ttt* | A three letter filetype (fit, inx, dat, smr, etc.)
 ```
 
-In 1999, the two digit year specification was replaced by a full four digit year to deal with the millenium:
+In 1999, the two digit year specification was replaced by a full four digit year to deal with the millennium:
 ```
 *yyyymmddhhi[c].ttt*
 ```
@@ -41,7 +41,7 @@ A typical set of filenames would look like:
 2002111412g.dat
 ```
 
-Due to the increase in the number of radars, the single letter radar indentifier can no longer be used.  Consequently, the file format must be changed and this opportunity was used to make the filename format easier to understand.
+Due to the increase in the number of radars, the single letter radar identifier can no longer be used.  Consequently, the file format must be changed and this opportunity was used to make the filename format easier to understand.
 
 ## "Proposed" Filename Format
 (Proposed as this appears to have been widely adapted in post 7/1/2006)
@@ -70,7 +70,7 @@ A typical set of filenames in the new format would look like:
 
 ### Concatenated Files
 
-Often the user will need to concatenate together multiple files when working on longer periods of data.  The RST software allow the user to pick any arbitrary name for the concatenated files, but for convenience it is recommnded that the following format is used:
+Often the user will need to concatenate together multiple files when working on longer periods of data.  The RST software allow the user to pick any arbitrary name for the concatenated files, but for convenience it is recommended that the following format is used:
 ```
 *yyyymmdd.hhMM.ss.iii.ttt[ttt].C*
 *yyyy*    | Four digit year (eg 2004)
@@ -136,5 +136,5 @@ A typical set of filenames in this format would look like:
 
 ## History (from RFC)
 
--2004/06/01 Iniital Revision, RJB
+-2004/06/01 Initial Revision, RJB
 -2004/06/08 Extended definitions to deal with whole day, hemispheric or global files

--- a/docs/references/general/fitacf.md
+++ b/docs/references/general/fitacf.md
@@ -81,11 +81,6 @@ The field [a-d] is used to separate data sampled at different frequencies into s
 | *tdiff*                 | **us**           | ***float***  | Value of time differential used when calculating elevation angles                 |
  
 
-!!! Note
-    The original intended usage of the `channel` parameter was to identify the data from the two separate frequency channels of the stereo radars (e.g. Hankasalmi). However, this parameter has sometimes been used for non-stereo radars when data from two different frequencies have been recorded in a single file.
-
-
-
 ## Vector Fields
 
 !!! Note

--- a/docs/references/general/grid.md
+++ b/docs/references/general/grid.md
@@ -25,6 +25,9 @@ When the gridded data from multiple radars have been combined, the files are nam
 
 *In both cases, the grid files contain 24-hours of data.*
 
+!!! Note
+    Combined grid files should contain data from a single hemisphere only.
+
 
 ## Scalar Fields
 

--- a/docs/references/general/grid.md
+++ b/docs/references/general/grid.md
@@ -19,9 +19,9 @@ The community standard for naming GRID files containing data from only one radar
 
 When the gridded data from multiple radars have been combined, the files are named as:
 
-> YYYYMMDD.north.grid
+> YYYYMMDD.north.grd
 
-> YYYYMMDD.south.grid
+> YYYYMMDD.south.grd
 
 *In both cases, the grid files contain 24-hours of data.*
 

--- a/docs/references/general/grid.md
+++ b/docs/references/general/grid.md
@@ -3,44 +3,30 @@ author(s): Marina Schmidt
 
 Disclaimer: License under GNU v3.0, the file is found in the root directory under LICENSE 
 
+Modifications:
+    2022-11-28 Emma Bland (UNIS) Updated file format description
+
 -->
 # GRID files 
 
-GRID files are post-processed data produced from FITACF files.
+GRID files are post-processed data produced from FITACF files, in which the fitted data products are placed on a magnetic latitude/longitude grid of equal-area cells spanning 1 degree of magnetic latitude. They may contain data from one radar or from multiple radars. For more information, see the [`make_grid` tutorial](../../user_guide/make_grid.md).
 
-## Naming Conventions
+## Naming Convention
 
-### Single radar GRID files
+The community standard for naming GRID files containing data from only one radar is:
 
-Currently the common naming convention for a single radar GRID file is:
+> YYYYMMDD.<3-letter abbreviation>.grd
 
-> YYYYMMDD.HH.mm.ss.<3-letter abbreviation>.grid
+When the gridded data from multiple radars have been combined, the files are named as:
 
-Some radars provide separate data files for each channel. In this case, the channel is specified after the 3-letter station ID:
+> YYYYMMDD.north.grid
 
-> YYYYMMDD.HH.mm.ss.<3-letter abbreviation>.[a-d].grid
+> YYYYMMDD.south.grid
 
-See [fitacf](fitacf.md) documentation for more information on this naming convention. 
+*In both cases, the grid files contain 24-hours of data.*
 
-If a GRID file is produced for 24-hours using the `-c` option in `make_grid` (see [`make_grid` tutorial](../../user_guide/make_grid.md)) or by combining individual GRID files with `combine_grid`, then the common naming convention is:
 
-> YYYYYMMDD.<3-letter abbreviation>.grid
-
-### Combined GRID files for each hemisphere
-
-After GRID files are produced for separate radars, they may then be combined with other radars' GRID files for eventual processing into convection map files.
-See [combine_grid](../../user_guide/make_grid.md) for instructions on how to combine multiple GRID files.
-
-For further Map Potential processing, separate GRID files should be produced for the Northern and Southern Hemispheres. One naming convention for 24-hr GRID files could be:
-
-> YYYYMMDD.north.grid  
-> YYYYMMDD.south.grid  
-
-## Fields
-
-GRID files contain a record that contains scalar and vector fields. 
-
-### Scalars
+## Scalar Fields
 
 The following times refer to the start and end of the integration period.
 
@@ -61,15 +47,15 @@ The following times refer to the start and end of the integration period.
 | *end.second*    | *s*        | ***short***  | End Seconds |
 
 
-### Vectors 
+## Vector Fields
 
-!!! Note
-    Let the number of radars in a given GRID record be defined as *numstid*, and let the number of gridded velocity vectors in a given record be defined as *numv*. 
+In the table below, *numstid* is the number of radars included in that grid record, and *numv* is the total number of gridded velocity vectors.
+
 
 | Field name  | Units           | Dimensionality | Data Type   | Description                                                                 |
 | :---------- | :-----:         | :-------:      | :---:       | :---                                                                        |
-| *stid*      |  **None**       |  *[numstid]*     | ***short*** | A list of of numeric station IDs that provided data for the record |
-| *channel*   |  **None**       |  *[numstid]*     | ***short*** | A list of channel numbers associated to the station id the record |
+| *stid*      |  **None**       |  *[numstid]*     | ***short*** | A list of numeric station IDs that provided data for the record |
+| *channel*   |  **None**       |  *[numstid]*     | ***short*** | A list of channel numbers associated with the station id |
 | *nvec*      | **None** | *[numstid]*  | ***short*** | Number of velocity vectors for each station|
 | *freq*      | *kHz* | *[numstid]* | ***float*** | Transmitted frequency for each radar |
 | *major.revision* | **None** | *[numstid]* | ***short*** | Major `make_grid` version number                    |
@@ -90,7 +76,7 @@ The following times refer to the start and end of the integration period.
 | *vector.mlon*     | *degrees* | *[numv]* | ***float*** | Magnetic Longitude |
 | *vector.kvect*    | *degrees* | *[numv]*   | ***float*** | Magnetic Azimuth |
 | *vector.stid*     | **None**  | *[numv]*   | ***short*** | Station identifier |
-| *vector.channel*  | **None**  | *[numv]*   | ***short*** | Channel number |  
+| *vector.channel*  | **None**  | *[numv]*   | ***short*** | Channel number |
 | *vector.index*    | **None**  | *[numv]*   | ***int***   | Grid cell index |
 | *vector.vel.median* | *m/s* | *[numv]*   | ***float*** | Weighted mean velocity magnitude |
 | *vector.vel.sd*     | *m/s*   | *[numv]*   | ***float*** | Velocity standard deviation |
@@ -99,6 +85,4 @@ The following times refer to the start and end of the integration period.
 | *vector.wdt.median* | *m/s* | *[numv]*   | ***float*** | Weighted mean spectral width|
 | *vector.wdt.sd      | *m/s* | *[numv]*   | ***float*** | Standard deviation of spectral width|
 
-## File structure
 
-GRID files typically contain up to 24 hours of data. Individual records in a GRID file contain a record for each integration time period (default 120 seconds) from one or more radars.

--- a/docs/references/general/iqdat.md
+++ b/docs/references/general/iqdat.md
@@ -16,7 +16,7 @@ The community standard for naming IQDAT files is:
 
 > YYYYMMDD.HH.mm.ss.<3-letter radar code>.[a-d].iqdat
 
-The field [a-d] is used to separate data sampled at different frequencies into separate files. This field may not be used if all the available data are provided in a single file.
+The field [a-d] is used when the data have been separated into multiple files based on a particular operating parameter (e.g. frequency, beam pattern, control program). This field may not be used if all the available data are provided in a single file.
 
 
 ## Fields

--- a/docs/references/general/iqdat.md
+++ b/docs/references/general/iqdat.md
@@ -1,27 +1,23 @@
 <!--
 (C) copyright 2020 VT SuperDARN, Virginia Polytechnic Institute & State University
 author: Kevin Sterne
+
+Modifications:
+    2022-11-28 Emma Bland (UNIS) Updated file format description
 -->
 
 # IQDat files
 
 IQDat files are a level-zero type data product that reflect the ADC voltages sampled at the radar site.
 
-## Naming Convenctions
+## Naming Convention
 
-Currently the common naming convention for IQDat files is:
+The community standard for naming IQDAT files is:
 
-> YYYYMMDD.HH.mm.ss.<3-letter abbreviation>.iqdat
+> YYYYMMDD.HH.mm.ss.<3-letter radar code>.[a-d].iqdat
 
-SuperDARN radars routinely change operating frequency. Some operating modes use multiple frequencies, either at the same time, or by alternating between frequencies. As a result, some files from some radars include all records for all frequencies in the same file and other radars separate out the individual frequencies into separate files, designated by a channel letter in the file name:
+The field [a-d] is used to separate data sampled at different frequencies into separate files. This field may not be used if all the available data are provided in a single file.
 
-> YYYYMMDD.HH.mm.ss.<3-letter abbreviation>.[a-d].iqdat
-
-For example, on 2019-02-01 the King Salmon radar (KSR) was operating simultaneously on two channels as seen from the file names `20190201.0401.00.ksr.a.iqdat` and `20190201.0401.00.ksr.b.iqdat`.
-Each file contains data from a different frequency channel. 
-
-!!! Note
-        Sometimes modes like `twofsound` will write data into a single file. In this case the two frequencies are marked as two separate channels, denoted using the `channel` parameter. However, it is important to note that some SuperDARN radars have stereo capability (transmitting and receiving on 2 frequencies simultaneously), which was the original intended usage of the `channel` parameter.
 
 ## Fields
 
@@ -55,7 +51,7 @@ IQDat files are composed of records that contain scalar and vector fields.
 | *stat.lopwr*            | **None** | short     | Low power status word          |
 | *noise.search*          | **None** | float     | Calculated noise from clear frequency search.  |
 | *noise.mean*            | **None** | float     | Average noise across frequency band.  |
-| *channel*               | **None** | short     | Channel number, used to denote different Tx/Rx channels on Stereo radars, and to denote changes in radar operating parameters between scans, eg. alternating between 2 frequency bands scan-to-scan    |
+| *channel*               | **None** | short     | Channel number, used to denote different Tx/Rx channels on Stereo radars, and to denote changes in radar operating parameters between scans, e.g. alternating between 2 frequency bands scan-to-scan    |
 | *bmnum*                 | **None** | short     | Beam number, zero based indexing      |
 | *bmazm*                 | *degrees* | float    | Beam azimuth                   |
 | *scan*                  | **None** | short     | Scan flag.                     |

--- a/docs/references/general/map.md
+++ b/docs/references/general/map.md
@@ -1,39 +1,28 @@
 <!-- 
 copyright (C) 2020 VT SuperDARN, Virginia Polytechnic Institute & State University 
 author: Kevin Sterne
+
+Modifications:
+    2022-11-28 Emma Bland (UNIS) Updated file format description
+    
 -->
 
 # Map files 
 
-Map files are post-processed data produced from grid files.
+Map files are post-processed data produced from grid files. They include all the information included in the original grid file, plus the additional information related to the convection mapping. Map files are generated using a multi-step process described in the [`map_grid` tutorial](../../user_guide/make_grid.md).
 
-## Naming Conventions
+## Naming Convention
 
-### Map files for each hemisphere
+Separate map files should be created for each hemisphere. The community standard for naming these files is:
 
-Map files are processed by starting with the combined (or single radar) [grid file](grid.md) as an input to `map_grd`.
+> YYYYMMDD.north.map
 
-From here, additional processsing occurs by adding additional data sources (Heppner-Maynard Boundary, IMF) and statistical convection models (TS18) before having a spherical harmonic fitting performed.
+> YYYYMMDD.south.map
 
-If a map file contains only a small time amount of data, it may be named:
+## Scalar Fields
 
-> YYYYMMDD.HH.MM.ss.hhhhh.map
+Start and end times refer to the start and end of the integration period (usually 2 minutes).
 
-where `hhhhh` is the hemisphere (north or south).
-
-If a map file is produced with 24-hours of data then the common naming convenction is:
-
-> YYYYMMDD.hhhhh.map
-
-where the hour, minute, and second fields are dropped.
-
-## Fields
-
-Each record of a map file contains scalar and vector fields. 
-
-### Scalars
-
-The following times refer to the start and end of the integration period.
 
 | Field name       | Units      | Data Type    | Description                                  |
 | :----------      | :-----:    | :-------:    | :---                                           |
@@ -66,7 +55,7 @@ The following times refer to the start and end of the integration period.
 | *model.angle*   | **None**   | ***string***  | Statistical clock angle of B |
 | *model.level*   | **None**   | ***string***  | Statistical model level |
 | *model.tilt*    | **None**   | ***string***  | Calculated tilt angle |
-| *model.name*    | **None**   | ***string***  | Name of the statical model used (TS18, CS10, RG96, etc.) |
+| *model.name*    | **None**   | ***string***  | Name of the statistical model used (TS18, CS10, RG96, etc.) |
 | *hemisphere*    | **None**   | ***short***   | Hemisphere flag (north=1) |
 | *noigrf*        | **None**   | ***short***   | Flag for no-IGRF model present |
 | *fit.order*     | **None**   | ***short***   | Order of spherical harmonic fit |
@@ -84,25 +73,29 @@ The following times refer to the start and end of the integration period.
 | *pot.max*       | *V*        | ***double***  | Maximum polar-cap potential     |
 | *pot.max.err*   | *V*        | ***double***  | Maximum polar-cap potential error |
 | *pot.min*       | *V*        | ***double***  | Minimum polar-cap potential     |
-| *pot.min.err*   | *V*        | ***double***  | Minimum polar-cap potentail error |
+| *pot.min.err*   | *V*        | ***double***  | Minimum polar-cap potential error |
  
 
 
-### Arrays 
+## Vector fields 
 
-The array components of the map file format are listed below. The map format is a superset of the grid formt so it contains the same arrays.
+In the table below, the following values describe the dimensionality of the map file fields: 
 
-!!! Note
- - Let the number of radars in a given map record be defined as *numstid*
- - Let the number of gridded velocity vectors in a given record be defined as *numv*
- - Let the number of values for the spherical harmonic analysis be defined as *numft*
- - Let the number of vectors output by the model used be defined as *nummd*
- - Let the number of the Heppner-Maynard boundary outputs be defined as *numbd*
+- *numstid*: the number of radars included in that grid record
+- *numv*: the total number of gridded velocity vectors
+- *numft*: the number of values used in the spherical harmonic analysis
+- *nummd*: the number of vectors output by the statistical convection model
+- *numbd*: the number of points in the Heppner-Maynard boundary
+
+
+A map file will not necessarily contain a complete set of all the variables listed below. The processing is divided into stages and new fields are added to the file as appropriate. For example, the `boundary.mlat` and `boundary.mlon` fields are added by `map_addhmb`, and the `model.mlat`, `model.mlon`, `model.kvect`, and `model.vel.median` are added by `map_addmodel`.
+
+
 
 | Field name  | Units           | Dimensionality | Data Type   | Description                                                                 |
 | :---------- | :-----:         | :-------:      | :---:       | :---                                                                        |
-| *stid*      |  **None**       |  *[numstid]*     | ***short*** | A list of of numeric station IDs that provided data for the record |
-| *channel*   |  **None**       |  *[numstid]*     | ***short*** | A list of channel numbers associated to the station id the record |
+| *stid*      |  **None**       |  *[numstid]*     | ***short*** | A list of numeric station IDs that provided data for the record |
+| *channel*   |  **None**       |  *[numstid]*     | ***short*** | A list of channel numbers associated with the station id |
 | *nvec*      | **None** | *[numstid]*  | ***short*** | Number of velocity vectors for each station |
 | *freq*      | *kHz* | *[numstid]* | ***float*** | Transmitted frequency for each radar |
 | *major.revision* | **None** | *[numstid]* | ***short*** | Major `make_grid` version number |
@@ -123,7 +116,7 @@ The array components of the map file format are listed below. The map format is 
 | *vector.mlon*     | *degrees* | *[numv]* | ***float*** | Magnetic Longitude |
 | *vector.kvect*    | *degrees* | *[numv]*   | ***float*** | Magnetic Azimuth |
 | *vector.stid*     | **None**  | *[numv]*   | ***short*** | Station identifier |
-| *vector.channel*  | **None**  | *[numv]*   | ***short*** | Channel number |  
+| *vector.channel*  | **None**  | *[numv]*   | ***short*** | Channel number |
 | *vector.index*    | **None**  | *[numv]*   | ***int***   | Grid cell index |
 | *vector.vel.median* | *m/s* | *[numv]*   | ***float*** | Weighted mean velocity magnitude |
 | *vector.vel.sd*     | *m/s* | *[numv]*   | ***float*** | Velocity standard deviation |
@@ -134,7 +127,7 @@ The array components of the map file format are listed below. The map format is 
 | *N*               | **None** | *[numft]* | ***double*** | L value of the expansion between 0 and Lmax |
 | *N+1*             | **None** | *[numft]* | ***double*** | M value of the expansion between -L and +L, negative values indicating the sin(M*phi) term |
 | *N+2*             | **None** | *[numft]* | ***double*** | Value of the coefficient  |
-| *N+3*             | **None** | *[numft]* | ***double*** | Stimate of the 1-sigma error of the coefficient |
+| *N+3*             | **None** | *[numft]* | ***double*** | Estimate of the 1-sigma error of the coefficient |
 | *model.mlat*      | *degrees* | [nummd] | ***float*** | Magnetic Latitudes of the model vectors |
 | *model.mlon*      | *degrees* | [nummd] | ***float*** | Magnetic Longitudes of the model vectors |
 | *model.kvect*     | *degrees* | [nummd] | ***float*** | Magnetic Azimuths of the model vectors |
@@ -142,8 +135,3 @@ The array components of the map file format are listed below. The map format is 
 | *boundary.mlat*   | *degrees* | [numbd] | ***float*** | Magnetic Latitudes of the lower latitude boundary |
 | *boundary.mlon*   | *degrees* | [numbd] | ***float*** | Magnetic Longitudes of the lower latitude boundary |
 
-A map file does not necessarily contain a complete set of all the variables listed above. The processing is dvidied up into stages with variables added to the file as needed.  If the statistical model has been calculated the file will contain the arrays `model.mlat`, `model.mlon`, `model.kvect`, and `model.vel.median`.  If the loer boundary ha been found then the file will contain the arrays `boundary.mlat` and `boundary.mlon`.  If the spherical harmonic analysis has been performed, then the file will contain the arrays `N`, `N+1`, `N+2`, and `N+3`.
-
-## File structure
-
-Map files typically contain up to 24 hours of data. Individual records in a map file contain a record for each integration time period (default 120 seconds) from one or more radars depending on the input grid file.

--- a/docs/references/general/radar_id.md
+++ b/docs/references/general/radar_id.md
@@ -17,14 +17,14 @@ As the number of radars increased, the use of a single letter as a radar identif
 
 SupeDARN radars have always been identified by two methods.  Within the software, each radar is identified by a unique station identifier number (site ID).  These numbers are difficult to remember and are very confusing to a normal human operator; consequently each radar is also assigned a single character station ID code.
 
-When the number of radars was compartively small, this approach worked well with each radar receiving an appropriate ID letter such as "g" for Goose Bay and "k" for Kapuskasing.  However as the number of radars has increased the number of available letters has decreased and the codes have become less logical and harder to remember.  Before the number of radars exceeded 26, the radar identifier was changed to be a short text string that is easy to remember.
+When the number of radars was comparatively small, this approach worked well with each radar receiving an appropriate ID letter such as "g" for Goose Bay and "k" for Kapuskasing.  However as the number of radars has increased the number of available letters has decreased and the codes have become less logical and harder to remember.  Before the number of radars exceeded 26, the radar identifier was changed to be a short text string that is easy to remember.
 
 ## Format for the Radar Identifier
 
 The summary for format in files after July 1, 2006 is:
 
 - The radar identifier (single character) was changed to a short three letter text string for all existing radars
-- Software should be capable of handling arbitary length strings, for future expansion.  Though the standard for now is 3 characters.
+- Software should be capable of handling arbitrary length strings, for future expansion.  Though the standard for now is 3 characters.
 - The three letter identifier uses lower case characters
 - Software should treat the identifier as case sensitive
 
@@ -62,5 +62,5 @@ An alias map for radars that transitioned from the single character to the three
 
 ## History (from RFC)
 
-- 2004/06/02 Iniital Revision, RJB
+- 2004/06/02 Initial Revision, RJB
 

--- a/docs/references/general/radar_table.md
+++ b/docs/references/general/radar_table.md
@@ -48,5 +48,5 @@ An entry in the table looks like this:
 
 ## History (from RFC)
 
-- 2004/06/14 Iniital Revision, RJB
+- 2004/06/14 Initial Revision, RJB
 

--- a/docs/references/general/rawacf.md
+++ b/docs/references/general/rawacf.md
@@ -77,8 +77,6 @@ The field [a-d] is used when the data have been separated into multiple files ba
 | *rawacf.revision.minor* | *None*   | int       | Minor version number of the RAWACF algorithm                                            |
 | *thr*                   | *None*   | float     | Threshold factor                                                                        |
 
-!!! Note
-    The original intended usage of the `channel` parameter was to identify the data from the two separate frequency channels of the stereo radars (e.g. Hankasalmi). However, this parameter has sometimes been used for non-stereo radars when data from two different frequencies have been recorded in a single file.
 
 ## Vector Fields
 

--- a/docs/references/general/rawacf.md
+++ b/docs/references/general/rawacf.md
@@ -19,7 +19,7 @@ The community standard for naming RAWACF files is:
 
 > YYYYMMDD.HH.mm.ss.<3-letter radar code>.[a-d].rawacf
 
-The field [a-d] is used to separate data sampled at different frequencies into separate files. This field may not be used if all the available data are provided in a single file.
+The field [a-d] is used when the data have been separated into multiple files based on a particular operating parameter (e.g. frequency, beam pattern, control program). This field may not be used if all the available data are provided in a single file.
 
 
 ## Scalar Fields

--- a/docs/references/general/rawacf.md
+++ b/docs/references/general/rawacf.md
@@ -3,6 +3,9 @@ author(s): Marina Schmidt
 
 Disclaimer: License under GNU v3.0, the file is found in the root directory under LICENSE 
 
+Modifications:
+    2022-11-28 Emma Bland (UNIS) Updated file format description
+
 -->
 # RAWACF files 
 
@@ -10,27 +13,17 @@ RAWACF files are raw files produced at radar sites.
 
 Sometimes they are post-processed from IQDAT files or converted from the older-format dat files (see `dattorawacf`).
 
-## Naming Conventions
+## Naming Convention
 
-Currently the common naming convention for RAWACF files is:
+The community standard for naming RAWACF files is:
 
-> YYYYMMDD.HH.mm.ss.<3-letter abbreviation>.rawacf
+> YYYYMMDD.HH.mm.ss.<3-letter radar code>.[a-d].rawacf
 
-SuperDARN radars routinely change operating frequency. Some operating modes use multiple frequencies, either at the same time, or by alternating between frequencies. As a result, some files from some radars include all records for all frequencies in the same file and other radars separate out the individual frequencies into separate files, designated by a channel letter in the file name:
+The field [a-d] is used to separate data sampled at different frequencies into separate files. This field may not be used if all the available data are provided in a single file.
 
-> YYYYMMDD.HH.mm.ss.<3-letter abbreviation>.[a-d].rawacf
 
-For example, on 2019-02-01 the King Salmon radar (KSR) was operating simultaneously on two channels as seen from the file names `20190201.0401.00.ksr.a.rawacf` and `20190201.0401.00.ksr.b.rawacf`.
-Each file contains data from a different frequency channel. 
+## Scalar Fields
 
-!!! Note
-        Sometimes modes like `twofsound` will write data into a single file. In this case the two frequencies are marked as two separate channels, denoted using the `channel` parameter. However, it is important to note that some SuperDARN radars have stereo capability (transmitting and receiving on 2 frequencies simultaneously), which was the original intended usage of the `channel` parameter.
-
-## Fields
-
-RAWACF files contain a record that contains scalar and vector fields. 
-
-### Scalars
 
 | Field name              | Units    | Data Type | Description                                                                             |
 | :----------             | :-----:  | :-------: | :---                                                                                    |
@@ -84,11 +77,10 @@ RAWACF files contain a record that contains scalar and vector fields.
 | *rawacf.revision.minor* | *None*   | int       | Minor version number of the RAWACF algorithm                                            |
 | *thr*                   | *None*   | float     | Threshold factor                                                                        |
 
-
-### Vectors 
-
 !!! Note
-    *slist* contains the range gates that obtained data points during the integration period of the beam. 
+    The original intended usage of the `channel` parameter was to identify the data from the two separate frequency channels of the stereo radars (e.g. Hankasalmi). However, this parameter has sometimes been used for non-stereo radars when data from two different frequencies have been recorded in a single file.
+
+## Vector Fields
 
 | Field name  | Units    | Dimensionality | Data Type   | Description                                                                 |
 | :---------- | :-----:  | :-------:      | :---:       | :---                                                                        |
@@ -99,12 +91,4 @@ RAWACF files contain a record that contains scalar and vector fields.
 | *acfd*      | *None*   | *[2][mplgs][0-nrang]*    | float       | Calculated ACFs                                                             |
 | *xcfd*      | *None*   | *[2][mplgs][0-nrang]*    | float       | Calculated XCFs                                                             |
 
-## File structure
 
-RAWACF files contain typically 2 hours of data. Individual records in the RAWACF file contain the raw data for a single integration period (usually 3s or 7s, but depends on operating mode of the radar). 
-In the standard operational mode (common mode) where each beam is scanned sequentially, the beam number `bmnum` will increase or decrease by 1 after each integration period. Other control programs may involve different beam sequences, including sampling the beams in a different order, or sampling a subset of the available beams.
-A "scan" is a beam sequence which gets repeated. In the common mode (*normal scan*), one scan is completed when each beam has been sampled sequentially from 0 to `bmnum-1` (or `bmnum-1` to 0). Radars with more than 16 beams *may* sample a subset of beams rather than their full field of view in order to maintain a 1min scan time. 
-Scans usually begin on whole-minute boundaries and last for either 1min or 2min. Custom control programs which define different scan lengths may also exist. The `scan` flag is used to indicate the beginning of each scan pattern. A value of 1 or -1 indicates the beginning of the scan, and then the value changes to 0 for the rest of the scan. When the `scan` value changes from 0 back to 1 this indicates the end of the scan. 
-
-!!! Note 
-    Different *control programs* in general have different beam patterns; `cp` will indicate the *control program* numerical value, and `combf` sometimes contains the *control program's* command/name. 

--- a/docs/user_guide/linux_install.md
+++ b/docs/user_guide/linux_install.md
@@ -259,8 +259,7 @@ Error: curses.h not found
    This runs a script to find all of the source codes and compile them into binaries.
    A log of this compilation is stored in `$RSTPATH/log`.
 
-### Compiling Old Documentation
-**Warning documentation may be outdated**
+### Compiling HTML Documentation
 
 To compile the html documentation, run `make.doc` from the command line. You may need
 to modify the `URLBASE` environment variable in `$RSTPATH/.profile/rst.bash` for the

--- a/docs/user_guide/mac_install.md
+++ b/docs/user_guide/mac_install.md
@@ -140,8 +140,7 @@ Error: curses.h not found
    This runs a script to find all of the source codes and compile them into binaries.
    A log of this compilation is stored in `$RSTPATH/log`.
 
-### Compiling Old Documentation
-**Warning: documentation may be outdated**
+### Compiling HTML Documentation
 
 To compile the html documentation, run `make.doc` from the command line. You may need
 to modify the `URLBASE` environment variable in `$RSTPATH/.profile/rst.bash` for the

--- a/docs/user_guide/make_grid.md
+++ b/docs/user_guide/make_grid.md
@@ -54,6 +54,10 @@ make_grid -cn b 20180101.C0.cly.fitacf > 20180101.cly.2.grid
     ```
 
 ## Combine data from multiple radars
+
+!!! Warning
+    Do not combine data from both hemispheres into a single grid file. This will create problems later when determining the convection pattern.
+
 First, generate grid files for each `fitacf` file you want to include. For example,
 
 ```


### PR DESCRIPTION
This PR is similar to #537. I have updated/simplified the descriptions of the `iqdat`, `rawacf`, `grid` and `map` file formats. I also fixed some typos in the documentation of the historical file formats. 