### PR TITLE
Fix/rbposlib (and RadarEpochGetSite)

### DIFF
--- a/codebase/superdarn/src.idl/lib/legacy.1.6/rbposlib.pro
+++ b/codebase/superdarn/src.idl/lib/legacy.1.6/rbposlib.pro
@@ -121,7 +121,7 @@ function rbpos,range,height=height,beam=beam,lagfr=first_lag,smsep=smsp, $
   if (keyword_set(station)) then st_id = station else st_id = dp.p.st_id
 
   if (keyword_set(yr)) then year=yr else year=dp.p.year
-  if (keyword_set(yrs)) then yrsec=yrs else $
+  if (n_elements(yrs)) then yrsec=yrs else $
       yrsec=TimeYMDHMSToYrsec(dp.p.year,dp.p.month,dp.p.day,dp.p.hour, $
                                   dp.p.minut,dp.p.sec)
 

--- a/codebase/superdarn/src.idl/lib/legacy.1.6/rbposlib.pro
+++ b/codebase/superdarn/src.idl/lib/legacy.1.6/rbposlib.pro
@@ -126,8 +126,6 @@ function rbpos,range,height=height,beam=beam,lagfr=first_lag,smsep=smsp, $
                                   dp.p.minut,dp.p.sec)
 
   yr=year
-  s=TimeYrsecToYMDHMS(yr,mo,dy,hr,mt,sc,yrsec)
-
   rid=RadarGetRadar(network,st_id)
   s=TimeYrsecToYMDHMS(yr,mo,dy,hr,mt,sc,yrsec)
   site=RadarYMDHMSGetSite(rid,yr,mo,dy,hr,mt,sc)

--- a/codebase/superdarn/src.idl/lib/main.1.25/radar.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/radar.pro
@@ -430,7 +430,7 @@ function RadarEpochGetSite,radar,tval
   if (radar.st_time ne -1) && (tval lt radar.st_time) then return,0
   if (radar.ed_time ne -1) && (tval gt radar.ed_time) then return,0 
 
-  for s=0,radar.snum do begin
+  for s=0,radar.snum-1 do begin
     if  (radar.site[s].tval gt tval) then break
   endfor
 


### PR DESCRIPTION
1. Deleted duplicate call to TimeYrsecToYMDHMS in rbpos.
2. Fixed rbpos returning wrong position coords (due to error in tval loop in RadarEpochGetSite).

Before this PR is merged, we might want to understand why issue (2) seems to be user dependent... @ecbland does not seem to encounter this issue. I wonder if it's something to do with me using native IDL routines - maybe @ecbland is not?

The issue with the IDL version of RadarEpochGetSite, at least, seems to be that, for certain radars, rbpos is erroneously returning mag lat = -16.118233, mag lon = 72.000923 (which are basically the geomagnetic coordinates of geographic lat = 0, lon = 0). 

I have traced the issue to where the hardware file is read in and scanned for records within the current time:

`  for s=0,radar.snum do begin`
`    if  (radar.site[s].tval gt tval) then break`
`  endfor`
`return, radar.site[s-1]`

In, e.g. hdw.dat.lyr, there is a single entry, and so radar.snum=1. I think the problem is that the code is looping from zero to radar.snum, rather than radar.snum-1. Since radar.site[1].tval is unpopulated, it is zero, and so passes the check. Upon exiting the loop, "s" is incremented again, so then s=2. The final line returns the site info for s-1, i.e. radar.site[1], which is empty. So, the returned site lat and lon will be zero, which is what I am finding. Changing the loop to:

`for s=0,radar.snum-1 do begin `

seems to fix the problem.
