### PR TITLE
Adding title metadata to .zenodo.json file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,4 +1,6 @@
 {
+    "title": "SuperDARN Radar Software Toolkit (RST) 5.0",
+
     "creators":[
         {
             "name": "SuperDARN Data Analysis Working Group"


### PR DESCRIPTION
This pull request makes one small change to the `.zenodo.json` file to clean up the title for upcoming and future releases. 
 By default, the RST title on Zenodo would appear as something like

>  SuperDARN/rst: rst v5.0

while with this fix it will match previous releases without requiring any manual edits on the Zenodo website, eg

https://zenodo.org/search?page=1&size=20&q=conceptrecid:%22801458%22&sort=-version&all_versions=True