### PR TITLE
Real-time output file name fix

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/doc/rtcfit.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/doc/rtcfit.doc.xml
@@ -14,6 +14,8 @@
 </option>
 <option><on>-vb</on><od>verbose. Log information to the console.</od>
 </option>
+<option><on>-name <ar>stid</ar></on><od>specify the radar code <ar>stid</ar> to use for the output filename (the default value is taken from the radar parameter block but can sometimes become corrupted and set to tst).</od>
+</option>
 <option><on>-mp <ar>minpwr</ar></on><od>filter out data with values of lag-zero power less than <ar>minpwr</ar>.</od>
 </option>
 <option><on>-L <ar>logname</ar></on><od>log connections and information in the file <ar>logname</ar>. By default, connections are recorded in <code>log.rt</code>.</od>

--- a/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/rtcfit.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/rtcfit.c
@@ -115,6 +115,7 @@ int main(int argc,char *argv[]) {
   char *pidstr=NULL;
 
   char *envstr;
+  char *stcode=NULL;
 
   int sock;
 
@@ -189,6 +190,8 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"-version",'x',&version);
 
   OptionAdd(&opt,"vb",'x',&vb);
+
+  OptionAdd(&opt,"name",'t',&stcode);
 
   OptionAdd(&opt,"mp",'d',&minpwr);
 
@@ -313,8 +316,9 @@ int main(int argc,char *argv[]) {
          if (dstart==0) {
            dstart=now-(int) now % (24*3600); /* start of day */
            TimeEpochToYMDHMS(dstart,&yr,&mo,&dy,&hr,&mt,&sc);
+           if (stcode==NULL) stcode=RadarGetCode(network,cfit->stid,0);
            sprintf(dname,"%s/%.4d%.2d%.2d.%s.cfit",
-		       path,yr,mo,dy,RadarGetCode(network,cfit->stid,0));
+		           path,yr,mo,dy,stcode);
 	 }
 
 
@@ -325,9 +329,9 @@ int main(int argc,char *argv[]) {
          if ((now-dstart) >= 24*3600) { /* advance to the next day */
            dstart=now-(int) now % (24*3600); /* start of day */
            TimeEpochToYMDHMS(dstart,&yr,&mo,&dy,&hr,&mt,&sc);
+           if (stcode==NULL) stcode=RadarGetCode(network,cfit->stid,0);
            sprintf(dname,"%s/%.4d%.2d%.2d.%s.cfit",
-		       path,yr,mo,dy,
-                       RadarGetCode(network,cfit->stid,0));
+		           path,yr,mo,dy,stcode);
 	 }
 	 
          cnt++;

--- a/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/doc/rtgrid.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/doc/rtgrid.doc.xml
@@ -12,6 +12,8 @@
 </option>
 <option><on>--version</on><od>print the RST version number and exit.</od>
 </option>
+<option><on>-name <ar>stid</ar></on><od>specify the radar code <ar>stid</ar> to use for the output filename (the default value is taken from the radar parameter block but can sometimes become corrupted and set to tst).</od>
+</option>
 <option><on>-tl <ar>tlen</ar></on><od>ignore the scan flag and instead use a fixed length scan of  <ar>tlen</ar> seconds.</od>
 </option>
 <option><on>-i <ar>intt</ar></on><od>integrate the grid data into records of length <ar>intt</ar> seconds.</od>

--- a/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/rtgrid.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtgrid.1.22/rtgrid.c
@@ -299,6 +299,8 @@ int main(int argc,char *argv[]) {
 
   OptionAdd(&opt,"old",'x',&old); 
 
+  OptionAdd(&opt,"name",'t',&stcode);
+
   OptionAdd(&opt,"xtd",'x',&xtd);
   OptionAdd(&opt,"i",'i',&avlen);
   OptionAdd(&opt,"tl",'i',&tlen);
@@ -417,8 +419,13 @@ int main(int argc,char *argv[]) {
   else sprintf(logbuf,"Host:%s Port File:%s",host,port_fname);
   loginfo(logname,logbuf);
 
-  if (old) sprintf(logbuf,"Output file name:%s<stid>.grd",fname);
-  else sprintf(logbuf,"Output file name:%s<stid>.grdmap",fname);
+  if (stcode !=NULL) {
+    if (old) sprintf(logbuf,"Output file name:%s%s.grd",fname,stcode);
+    else sprintf(logbuf,"Output file name:%s%s.grdmap",fname,stcode);
+  } else {
+    if (old) sprintf(logbuf,"Output file name:%s<stid>.grd",fname);
+    else sprintf(logbuf,"Output file name:%s<stid>.grdmap",fname);
+  }
   loginfo(logname,logbuf);
   sprintf(logbuf,"Daily file path:%s",path);
   loginfo(logname,logbuf);
@@ -561,7 +568,7 @@ int main(int argc,char *argv[]) {
               exit(-1);
             }
             site=RadarYMDHMSGetSite(radar,yr,mo,dy,hr,mt,(int) sc);
-            stcode=RadarGetCode(network,out->stid,0);
+            if (stcode==NULL) stcode=RadarGetCode(network,out->stid,0);
 
             strcat(fname,stcode);
             if (channel==1) strcat(fname,".a");

--- a/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/doc/rtsnd.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/doc/rtsnd.doc.xml
@@ -12,6 +12,8 @@
 </option>
 <option><on>--version</on><od>print the RST version number and exit.</od>
 </option>
+<option><on>-name <ar>stid</ar></on><od>specify the radar code <ar>stid</ar> to use for the output filename (the default value is taken from the radar parameter block but can sometimes become corrupted and set to tst).</od>
+</option>
 <option><on>-noscan</on><od>ignore scan flag and process all data (usually sounding mode data is indicated by a scan flag of -2).</od>
 </option>
 <option><on>-cn <ar>channel</ar></on><od>process data from a specific channel number for stereo mode data.</od>

--- a/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/rtsnd.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/rtsnd.c
@@ -125,6 +125,7 @@ int main(int argc,char *argv[]) {
   char *pidstr=NULL;
 
   char *envstr;
+  char *stcode=NULL;
 
   int sock;
 
@@ -200,6 +201,8 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"-help",'x',&help);
   OptionAdd(&opt,"-option",'x',&option);
   OptionAdd(&opt,"-version",'x',&version);
+
+  OptionAdd(&opt,"name",'t',&stcode);
 
   OptionAdd(&opt,"noscan",'x',&noscan);
   OptionAdd(&opt,"cn",'t',&chnstr);
@@ -366,15 +369,17 @@ int main(int argc,char *argv[]) {
         if (hstart==0) {
           hstart=now-(int) now % (2*3600); /* start of 2-hour block */
           TimeEpochToYMDHMS(hstart,&yr,&mo,&dy,&hr,&mt,&sc);
+          if (stcode==NULL) stcode=RadarGetCode(network,snd->stid,0);
           sprintf(dname,"%s/%.4d%.2d%.2d.%.2d.%s.snd",
-                  path,yr,mo,dy,(hr/2)*2,RadarGetCode(network,snd->stid,0));
+                  path,yr,mo,dy,(hr/2)*2,stcode);
         }
 
         if ((now-hstart) >= 2*3600) { /* advance to the next 2-hour block */
           hstart=now-(int) now % (2*3600); /* start of 2-hour block */
           TimeEpochToYMDHMS(hstart,&yr,&mo,&dy,&hr,&mt,&sc);
+          if (stcode==NULL) stcode=RadarGetCode(network,snd->stid,0);
           sprintf(dname,"%s/%.4d%.2d%.2d.%.2d.%s.snd",
-                  path,yr,mo,dy,(hr/2)*2,RadarGetCode(network,snd->stid,0));
+                  path,yr,mo,dy,(hr/2)*2,stcode);
         }
 
         fp=fopen(dname,"a");


### PR DESCRIPTION
This pull request slightly modifies the behavior of `rtcfit`, `rtgrid`, and `rtsnd` by allowing the user to set the radar name used for the real-time output files via an optional `-name` command line option.

By default, the three-letter station name is taken from the radar parameter block of the real-time data stream.  However, sometimes that value can become corrupted / invalid, causing the `stid` to be set to zero and the files to be labeled as belonging to the `tst` radar.