### PR TITLE
Update AACGM_v2 error message

### DIFF
--- a/codebase/analysis/src.lib/aacgm_v2/aacgm.1.0/src/aacgmlib_v2.c
+++ b/codebase/analysis/src.lib/aacgm_v2/aacgm.1.0/src/aacgmlib_v2.c
@@ -1020,7 +1020,7 @@ int AACGM_v2_Convert(double in_lat, double in_lon, double height,
 
   /* height > 2000 km not allowed for coefficients */
   if (height > MAXALT && !(code & (TRACE|ALLOWTRACE|BADIDEA))) {
-    fprintf(stderr, "ERROR: coefficients are not valid for altitudes "
+    fprintf(stderr, "AACGM-v2 ERROR: coefficients are not valid for altitudes "
                     "above %d km: %lf.\n", MAXALT, height);
     fprintf(stderr, "       You must either use field-line tracing "
                     "(TRACE or ALLOWTRACE) or\n"


### PR DESCRIPTION
Following up from [#548](https://github.com/SuperDARN/rst/issues/548#issuecomment-1336007263), this PR is just a small modification to the "altitude exceeds 2000km" error message from `aacgm_v2`, since it wasn't immediately obvious where the error was coming from. 

Most error messages in the `aacgm_v2` code are written as `AACGM-v2 ERROR: [error message]`, so I followed that style.