### PR TITLE
Modifying field_plot to add new -minbeam and -maxbeam options for FOV outlines

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/doc/field_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/doc/field_plot.doc.xml
@@ -126,6 +126,12 @@
 </option>
 <option><on>-ffan</on><od>plot the filled radar field of view.</od>
 </option>
+<option><on>-minbeam <ar>minbeam</ar></on><od>set the minimum beam number to draw for the radar field of view outline to <ar>minbeam</ar>.</od>
+</option>
+<option><on>-maxbeam <ar>maxbeam</ar></on><od>set the maximum number of beams to draw for the radar field of view outline to <ar>maxbeam</ar>.</od>
+</option>
+<option><on>-lst</on><od>use local solar time rather than local time.</od>
+</option>
 <option><on>-tmtick <ar>tick</ar></on><od>set the grid interval for the time clock-dial to <ar>tick</ar> hours.</od>
 </option>
 <option><on>-lst</on><od>use local solar time rather than local time.</od>
@@ -331,7 +337,7 @@
 <example>
 <command>field_plot -wdt 540 -hgt 540 -mag -st 1:00 -lat 90 -lon 0 -tmk -time -latmin 55 -rotate -grd -fcoast -coast -keyp -ffov -fov -r 0 -fan -p</command>
 <description>
-Generate rPlot xml plots of power data from the file "<code>20021219.han.fit</code>". Store the plots in files named "<code>xxxx</code>.xml", starting at 01:00UTC. Use magnetic coordinates, rotated so that magnetic local noon is at the top of the plot.Plot filled coastlines, terminator, a clockdial representing time, and the time.</description>
+Generate rPlot xml plots of power data from the file "<code>20021219.han.fit</code>". Store the plots in files named "<code>xxxx</code>.xml", starting at 01:00UTC. Use magnetic coordinates, rotated so that magnetic local noon is at the top of the plot.Plot filled coastlines, terminator, a clockdial representing time, and the time.
 </description>
 </example>
 <example type="rplot">example2</example>

--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
@@ -660,6 +660,9 @@ int main(int argc,char *argv[]) {
   unsigned char cfitflg=0,fitflg=0;
   unsigned char sndflg=0;
 
+  int minbeam=0;
+  int maxbeam=-1;
+
   char *chnstr=NULL;
 
   char *dname=NULL,*iname=NULL;
@@ -880,6 +883,9 @@ int main(int argc,char *argv[]) {
 
   OptionAdd(&opt,"fan",'x',&fanflg);
   OptionAdd(&opt,"ffan",'x',&ffanflg);
+
+  OptionAdd(&opt,"minbeam",'i',&minbeam);
+  OptionAdd(&opt,"maxbeam",'i',&maxbeam);
 
   OptionAdd(&opt,"gscol",'t',&gscol_txt);
 
@@ -1740,8 +1746,10 @@ int main(int argc,char *argv[]) {
                                    wbox-2*pad,hbox-2*pad,vsf,tfunc,marg,find_color,
                                    &vkey,gscol,gsflg,0.5,vecr);
 
+        if (maxbeam==-1) maxbeam=site->maxbeam;
+
         if (fanflg) plot_outline(plot,&scn->bm[c],&geol.bm[n],0,
-                                 magflg,site->maxbeam,xbox+pad,ybox+pad,
+                                 magflg,minbeam,maxbeam,xbox+pad,ybox+pad,
                                  wbox-2*pad,hbox-2*pad,tfunc,marg,fancol);
       }
 

--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/plot_outline.c
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/plot_outline.c
@@ -47,10 +47,11 @@ Modifications:
 
 
 void plot_outline(struct Plot *plot,struct RadarBeam *sbm,
-		  struct GeoLocBeam *gbm,float latmin,int magflg,int maxbeam,
-               float xoff,float yoff,float wdt,float hgt,
-               int (*trnf)(int,void *,int,void *,void *data),void *data,
-               unsigned int color) {
+                  struct GeoLocBeam *gbm,float latmin,int magflg,
+                  int minbeam,int maxbeam,
+                  float xoff,float yoff,float wdt,float hgt,
+                  int (*trnf)(int,void *,int,void *,void *data),
+                  void *data,unsigned int color) {
 
   float ax=0,ay=0,bx=0,by=0;
   int s=0;
@@ -59,7 +60,7 @@ void plot_outline(struct Plot *plot,struct RadarBeam *sbm,
 
   nrang=sbm->nrang;
 
-  if (gbm->bm==0) {
+  if (gbm->bm==minbeam) {
     for (rng=0;rng<nrang;rng++) {
       if (magflg) {
          map[0]=gbm->mlat[0][rng];

--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/plot_outline.h
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/plot_outline.h
@@ -29,14 +29,15 @@ Modifications:
 
 
 void plot_outline(struct Plot *plot,struct RadarBeam *sbm,
-		  struct GeoLocBeam *gbm,float latmin,int magflg,int maxbeam,
-               float xoff,float yoff,float wdt,float hgt,
-               int (*trnf)(int,void *,int,void *,void *data),void *data,
-	       unsigned int color);
+                  struct GeoLocBeam *gbm,float latmin,int magflg,
+                  int minbeam, int maxbeam,
+                  float xoff,float yoff,float wdt,float hgt,
+                  int (*trnf)(int,void *,int,void *,void *data),
+                  void *data,unsigned int color);
 
 void plot_filled(struct Plot *plot,struct RadarBeam *sbm,
-               struct GeoLocBeam *gbm,float latmin,int magflg,
-               float xoff,float yoff,float wdt,float hgt,
-               int (*trnf)(int,void *,int,void *,void *data),void *data,
-	       unsigned int color);
+                 struct GeoLocBeam *gbm,float latmin,int magflg,
+                 float xoff,float yoff,float wdt,float hgt,
+                 int (*trnf)(int,void *,int,void *,void *data),void *data,
+                 unsigned int color);
 


### PR DESCRIPTION
This pull request adds two new options to `field_plot` allowing the user to manually set the start / end beam numbers with `field_plot` for radars where the data in a given scan may not match the maximum beam number listed in the hardware file (eg MSI-style radars which have up to 24 beams but may typically use fewer).  If neither option is set then `field_plot` will behave as normal (ie drawing the outline starting at beam 0 up to the maximum number of beams in the hardware file).

For example, here is what normalscan data from CVW looks like by default:

![image](https://user-images.githubusercontent.com/1869073/205955311-2415f9b1-abee-4209-8edc-4043f528bafa.png)

and this is using the new `-minbeam 4 -maxbeam 24` options:

![image](https://user-images.githubusercontent.com/1869073/205955218-7c376f66-3eae-4f37-b1cb-e52ff505eba4.png)

Likewise for CVE, first the default:

![image](https://user-images.githubusercontent.com/1869073/205955463-347e47cd-21ee-4a7f-be00-8a5aaa47fd1c.png)

and then using `-maxbeam 20`:

![image](https://user-images.githubusercontent.com/1869073/205955562-3c1ea392-8193-4aaf-942b-4496cc31cfc1.png)

(sorry @ecbland, I promise this is really the last one!)