### PR TITLE
Fix custom color options in time_plot

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/doc/time_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/doc/time_plot.doc.xml
@@ -58,6 +58,8 @@
 </option>
 <option><on>-bgcol <ar>rrggbb</ar></on><od>set the background color to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
 </option>
+<option><on>-pbgcol <ar>rrggbb</ar></on><od>set the panel background color to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+</option>
 <option><on>-grdcol <ar>rrggbb</ar></on><od>set the color of grid to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
 </option>
 <option><on>-txtcol <ar>rrggbb</ar></on><od>set the color of text to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -711,16 +711,16 @@ int main(int argc,char *argv[]) {
   }
 
   bgcolor=PlotColor(0xff,0xff,0xff,0xff);
-  if (bgtxt !=NULL) sscanf(bgtxt,"%x",&bgcolor);
+  if (bgtxt !=NULL) bgcolor=PlotColorStringRGB(bgtxt);
 
   gscolor=PlotColor(0xa0,0xa0,0xa0,0xff);
-  if (gsctxt !=NULL) sscanf(gsctxt,"%x",&gscolor);
+  if (gsctxt !=NULL) gscolor=PlotColorStringRGB(gsctxt);
 
   grdcolor=PlotColor(0x00,0x00,0x00,0xff);
-  if (grdtxt !=NULL) sscanf(grdtxt,"%x",&grdcolor);
+  if (grdtxt !=NULL) grdcolor=PlotColorStringRGB(grdtxt);
 
   txtcolor=PlotColor(0x00,0x00,0x00,0xff);
-  if (txttxt !=NULL)  sscanf(txttxt,"%x",&txtcolor);
+  if (txttxt !=NULL) txtcolor=PlotColorStringRGB(txttxt);
 
   if (pkey_fname !=NULL) {
     if (pkey_path == NULL) pkey_path = getenv("COLOR_TABLE_PATH");

--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -407,6 +407,9 @@ int main(int argc,char *argv[]) {
   int hgt=HEIGHT;
   unsigned int bgcolor=0;
 
+  char *pbgtxt=NULL;
+  unsigned int pbgcolor=0;
+
   float width=0.5;
   char *fontname=NULL;
   char *tfontname=NULL;
@@ -523,6 +526,7 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"wdt",'i',&wdt); /* width */
   OptionAdd(&opt,"hgt",'i',&hgt); /* height */
   OptionAdd(&opt,"bgcol",'t',&bgtxt); /* background color */
+  OptionAdd(&opt,"pbgcol",'t',&pbgtxt); /* panel background color */
 
   OptionAdd(&opt,"grdcol",'t',&grdtxt); /* grid color */
   OptionAdd(&opt,"txtcol",'t',&txttxt); /* text color */
@@ -712,6 +716,9 @@ int main(int argc,char *argv[]) {
 
   bgcolor=PlotColor(0xff,0xff,0xff,0xff);
   if (bgtxt !=NULL) bgcolor=PlotColorStringRGB(bgtxt);
+
+  pbgcolor=PlotColor(0xff,0xff,0xff,0xff);
+  if (pbgtxt !=NULL) pbgcolor=PlotColorStringRGB(pbgtxt);
 
   gscolor=PlotColor(0xa0,0xa0,0xa0,0xff);
   if (gsctxt !=NULL) gscolor=PlotColorStringRGB(gsctxt);
@@ -1333,6 +1340,13 @@ int main(int argc,char *argv[]) {
   FrameBufferClear(nblk,0x0f,bgcolor);
 
   for (n=0;n<8;n++) if (blk[n] !=NULL) FrameBufferClear(blk[n],0x0f,bgcolor);
+
+  for (i=0;i<cnt;i++) {
+    PlotRectangle(plot,NULL,
+                  plt->xoff+(i % plt->xnum)*(plt->box_wdt+plt->lpad+plt->rpad),
+                  plt->yoff+(i / plt->xnum)*(plt->box_hgt+plt->tpad+plt->bpad),
+                  plt->box_wdt,plt->box_hgt,1,pbgcolor,0x0f,0,NULL);
+  }
 
   do {
 


### PR DESCRIPTION
Ok - extreme apologies to @ecbland, but this does seem like one last fundamental bug that's worth fixing in `time_plot` prior to the 5.0 release.

Basically, the command line options to control the background, ground scatter, grid, and text colors in `time_plot` are all broken and won't work on the `develop` / `release` branch.  This pull request replaces the incorrect `sscanf` calls with the `PlotColorStringRGB` function which converts the input hex value to something usable by the rest of the plotting code, consistent with all of the other plotting binaries.

(Note this bug appears to date all the way back to pre-4.0 versions of the RST)