### PR TITLE
Updating fov_plot documentation to include description of the alpha component

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/doc/fov_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/doc/fov_plot.doc.xml
@@ -93,37 +93,37 @@
 </option>
 <option><on>-lnewdt <ar>lnewdt</ar></on><od>set the line width to <ar>lnewdt</ar>.</od>
 </option>
-<option><on>-bgcol <ar>rrggbb</ar></on><od>set the background color to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-bgcol <ar>aarrggbb</ar></on><od>set the background color to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-txtcol <ar>rrggbb</ar></on><od>set the color of the text to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-txtcol <ar>aarrggbb</ar></on><od>set the color of the text to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-grdcol <ar>rrggbb</ar></on><od>set the color of the grid to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-grdcol <ar>aarrggbb</ar></on><od>set the color of the grid to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-cstcol <ar>rrggbb</ar></on><od>set the color of the coastline to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-cstcol <ar>aarrggbb</ar></on><od>set the color of the coastline to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-bndcol <ar>rrggbb</ar></on><od>set the color of the state boundaries to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-bndcol <ar>aarrggbb</ar></on><od>set the color of the state boundaries to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-lndcol <ar>rrggbb</ar></on><od>set the color of the land to <ar>rrggbb</ar>, specified as the  hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-lndcol <ar>aarrggbb</ar></on><od>set the color of the land to <ar>aarrggbb</ar>, specified as the  hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-seacol <ar>rrggbb</ar></on><od>set the color of the sea to <ar>rrggbb</ar>, specified as the  hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-seacol <ar>aarrggbb</ar></on><od>set the color of the sea to <ar>aarrggbb</ar>, specified as the  hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-trmcol <ar>rrggbb</ar></on><od>set the color of the terminator outline to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-trmcol <ar>aarrggbb</ar></on><od>set the color of the terminator outline to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-ftrmcol <ar>rrggbb</ar></on><od>set the color of the filled terminator to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-ftrmcol <ar>aarrggbb</ar></on><od>set the color of the filled terminator to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-tmkcol <ar>rrggbb</ar></on><od>set the color of the time clock-dial to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-tmkcol <ar>aarrggbb</ar></on><od>set the color of the time clock-dial to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-fovcol <ar>rrggbb</ar></on><od>set the color of the field of view outline to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-fovcol <ar>aarrggbb</ar></on><od>set the color of the field of view outline to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-ffovcol <ar>rrggbb</ar></on><od>set the color of the filled field of view to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-ffovcol <ar>aarrggbb</ar></on><od>set the color of the filled field of view to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-ofovcol <ar>rrggbb</ar></on><od>set the color of the field of view outline of other radars to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-ofovcol <ar>aarrggbb</ar></on><od>set the color of the field of view outline of other radars to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-fofovcol <ar>rrggbb</ar></on><od>set the color of the filled field of view of other radars to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-fofovcol <ar>aarrggbb</ar></on><od>set the color of the filled field of view of other radars to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-cfovcol <ar>rrggbb</ar></on><od>set the color of the field of view outline of radars under construction to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-cfovcol <ar>aarrggbb</ar></on><od>set the color of the field of view outline of radars under construction to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
-<option><on>-fcfovcol <ar>rrggbb</ar></on><od>set the color of the filled field of view of radars under construction to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color.</od>
+<option><on>-fcfovcol <ar>aarrggbb</ar></on><od>set the color of the filled field of view of radars under construction to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color.</od>
 </option>
 <option><on>-d <ar>yyyymmdd</ar></on><od>plot for the date <ar>yyyymmdd</ar>.</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
@@ -50,13 +50,13 @@
 </option>
 <option><on>-n <ar>xnum</ar></on><od>set the number of I&Q samples plotted to <ar>xnum</ar>.</od>
 </option>
-<option><on>-xmaj <ar>xmajor</ar></on><od>set the number of X-axis major tick marks to <ar>xmajor</ar>.</od>
+<option><on>-xmaj <ar>xmajor</ar></on><od>set the X-axis major tick mark interval to <ar>xmajor</ar>.</od>
 </option>
-<option><on>-xmin <ar>xminor</ar></on><od>set the number of X-axis minor tick marks to <ar>xminor</ar>.</od>
+<option><on>-xmin <ar>xminor</ar></on><od>set the X-axis minor tick mark interval to <ar>xminor</ar>.</od>
 </option>
-<option><on>-ymaj <ar>ymajor</ar></on><od>set the number of Y-axis major tick marks to <ar>ymajor</ar>.</od>
+<option><on>-ymaj <ar>ymajor</ar></on><od>set the Y-axis major tick mark interval to <ar>ymajor</ar>.</od>
 </option>
-<option><on>-ymin <ar>yminor</ar></on><od>set the number of Y-axis minor tick marks to <ar>yminor</ar>.</od>
+<option><on>-ymin <ar>yminor</ar></on><od>set the Y-axis minor tick mark interval to <ar>yminor</ar>.</od>
 </option>
 <option><on><ar>name</ar></on><od>the filename of the <code>iqdat</code> format file to plot.</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/iqplot.1.6/doc/iqplot.doc.xml
@@ -40,9 +40,9 @@
 </option>
 <option><on>-int</on><od>plot I&Q samples from the interferometer array instead of the main array.</od>
 </option>
-<option><on>-rcol <ar>rrggbb</ar></on><od>set the color of the real (I) component to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color [default is teal].</od>
+<option><on>-rcol <ar>aarrggbb</ar></on><od>set the color of the real (I) component to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color [default is teal].</od>
 </option>
-<option><on>-icol <ar>rrggbb</ar></on><od>set the color of the imaginary (Q) component to <ar>rrggbb</ar>, specified as the hexadecimal value for the 24-bit red,green and blue component color [default is red].</od>
+<option><on>-icol <ar>aarrggbb</ar></on><od>set the color of the imaginary (Q) component to <ar>aarrggbb</ar>, specified as the hexadecimal value for the 32-bit alpha,red,green and blue component color [default is red].</od>
 </option>
 <option><on>-m <ar>ymax</ar></on><od>set the extent of the Y-axis to +/-<ar>ymax</ar> when plotting I&Q components.</od>
 </option>


### PR DESCRIPTION
One minor XML documentation update, this time to `fov_plot` to correctly describe the input format for the hex `aarrggbb` values (previously the documentation was missing any mention of the alpha component and would mislead users).  No functionality has changed.

Sorry @ecbland - this really is the last one, I promise!