### PR TITLE
Fixing typo in make_raw and fitacfclientgui documentation

### DIFF
--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/doc/fitacfclientgui.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/doc/fitacfclientgui.doc.xml
@@ -21,7 +21,7 @@
 </option>
 <option><on>-w</on><od>plot spectral width.</od>
 </option>
-<option><on>-w</on><od>plot elevation angle.</od>
+<option><on>-e</on><od>plot elevation angle.</od>
 </option>
 <option><on>-pmin <ar>pmin</ar></on><od>set the minimum value of the power scale to <ar>pmin</ar>.</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/doc/make_raw.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/doc/make_raw.doc.xml
@@ -18,7 +18,7 @@
 </option>
 <option><on>-skip <ar>skpval</ar></on><od>set the number of samples to skip at the start of each sequence to <ar>skpval</ar>. The default value is taken from the IQ structure of the input <code>iqdat</code> format file.</od>
 </option>
-<option><on>-chnnum <ar>chnnum</ar></on><od>set the number of receiver channels to <ar>chnnum</ar>. The default value si taken from the IQ structure of the input <code>iqdat</code> format file.</od>
+<option><on>-chnnum <ar>chnnum</ar></on><od>set the number of receiver channels to <ar>chnnum</ar>. The default value is taken from the IQ structure of the input <code>iqdat</code> format file.</od>
 </option>
 <option><on><ar>iqdatname</ar></on><od>filename of the <code>iqdat</code> format file. If this is omitted the file is read from standard input.</od>
 </option>


### PR DESCRIPTION
This pull request fixes a small typo in the `make_raw` documentation (changing `si` to `is`).