### PR TITLE
Fixing bug in IDL DLM RadarYMDHMSGetSite

### DIFF
--- a/codebase/superdarn/src.dlm/rposdlm.1.9/rposdlm.c
+++ b/codebase/superdarn/src.dlm/rposdlm.1.9/rposdlm.c
@@ -659,7 +659,7 @@ static IDL_VPTR IDLRadarYMDHMSGetSite(int argc,IDL_VPTR *argv) {
 
   isite=IDLRadarMakeSite(&vsite);
 
-  isite->tval=iradar->site[s].status;
+  isite->status=iradar->site[s].status;
   isite->tval=iradar->site[s].tval;
   isite->geolat=iradar->site[s].geolat;
   isite->geolon=iradar->site[s].geolon;


### PR DESCRIPTION
This pull request fixes a bug in the IDL DLM implementation of `RadarYMDHMSGetSite` which prevents the correct `status` value being returned from the `hdw` file.

Currently, the `status` field returned by `RadarYMDHMSGetSite` will always be zero, whereas on this branch the correct value will be returned (ie `1` for active or `-1` for inactive).  As far as I can tell this bug has been present since the new `hdw` file format was introduced in RST 4.7.  Oops.