### PR TITLE
Fixing typo in IDL AACGM DLM

### DIFF
--- a/codebase/analysis/src.dlm/aacgmdlm.2.0/aacgmdlm.c
+++ b/codebase/analysis/src.dlm/aacgmdlm.2.0/aacgmdlm.c
@@ -237,7 +237,7 @@ static IDL_VPTR IDLAACGM_v2_GetDateTime(int argc,IDL_VPTR *argv,char *argk) {
 
     int s=0;
     int yr,mo,dy,hr,mt,sc,dayno;
-    IDL_VPTR outargv[0];
+    IDL_VPTR outargv[7];
 
     static IDL_VPTR month;
     static IDL_VPTR day;


### PR DESCRIPTION
This pull request fixes a small typo in the IDL DLM implementation of `AACGM_v2_GetDateTime` that causes the following compilation warning:

```
aacgmdlm.c: In function ‘IDLAACGM_v2_GetDateTime’:
aacgmdlm.c:240:14: warning: ISO C forbids zero-size array ‘outargv’ [-Wpedantic]
   240 |     IDL_VPTR outargv[0];
       |              ^~~~~~~
 aacgmdlm.c:272:5: warning: array subscript 0 is outside array bounds of ‘IDL_VARIABLE *[0]’ {aka ‘IDL_VARIABLE *[]’}     [-Warray-bounds]
   272 |     IDL_StoreScalar(outargv[0],IDL_TYP_LONG,(IDL_ALLTYPES *) &yr);
       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 aacgmdlm.c:240:14: note: while referencing ‘outargv’
   240 |     IDL_VPTR outargv[0];
       |              ^~~~~~~
```

On this branch, the code compiles cleanly without any warnings.