### PR TITLE
Fixing bug in trim_iq

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/make_raw.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/make_raw.c
@@ -326,9 +326,9 @@ int main (int argc,char *argv[]) {
     badrng=ACFBadLagZero(&tprm,prm->mplgs,lag);
 
     if (chnnum > 0) {
-      rngoff = 2*chnnum;
+      rngoff = chnnum;
     } else {
-      rngoff = 2*iq->chnnum;
+      rngoff = iq->chnnum;
     }
 
     if (digital) {

--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
@@ -652,7 +652,7 @@ int main(int argc,char *argv[])
     int seqsze[nave];
 
     iq->seqnum = nave;
-    iq->chnnum = 1;
+    iq->chnnum = 2;
     iq->smpnum = n_samples;
     iq->skpnum = 4;
 

--- a/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
+++ b/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
@@ -491,7 +491,7 @@ int main(int argc,char *argv[])
       int seqsze[nave];
 
       iq->seqnum = nave;
-      iq->chnnum = 1;
+      iq->chnnum = 2;
       iq->smpnum = n_samples;
       iq->skpnum = 4;
 

--- a/codebase/superdarn/src.lib/tk/iq.1.7/src/iqwrite.c
+++ b/codebase/superdarn/src.lib/tk/iq.1.7/src/iqwrite.c
@@ -61,7 +61,7 @@ int IQEncode(struct DataMap *ptr,struct IQ *iq,
   tnum=iq->seqnum;
   bnum=iq->tbadtr*2;
 
- snum=iq->seqnum*iq->chnnum*iq->smpnum*2*2;   /*2 for main and back  2  to convert to 16 bit */  
+  snum=iq->seqnum*iq->chnnum*iq->smpnum*2;
 
   DataMapAddScalar(ptr,"iqdata.revision.major",DATAINT,
 		    &iq->revision.major);


### PR DESCRIPTION
This pull request modifies `IQEncode` to remove the extra multiplication by 2 causing a bug in `trim_iq` output data size (#565), and modifying `make_raw`, `make_sim`, and `sim_real` to correctly handle the IQ `chnnum` parameter.  This bug appears to have originated from the development of the Linux/QNX6 ROS, which is no longer part of the RST.