### PR TITLE
Updates to fitacfclientgui

### DIFF
--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/doc/fitacfclientgui.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/doc/fitacfclientgui.doc.xml
@@ -15,6 +15,8 @@
 </option>
 <option><on>-color</on><od>display the data stream in color according to the selected parameter (default is power).</od>
 </option>
+<option><on>-gs</on><od>color ground scatter white (velocity only).</od>
+</option>
 <option><on>-p</on><od>plot power.</od>
 </option>
 <option><on>-v</on><od>plot velocity.</od>
@@ -44,7 +46,7 @@
 <option><on><ar>port</ar></on><od>port number to connect to on the system.</od></option>
 <synopsis><p>Graphical client program for <code>fitacf</code> TCP/IP data streams.</p></synopsis>
 <description><p>Graphical client program for <code>fitacf</code> TCP/IP data streams.</p>
-<p>The program dumps an ASCII representation of the <code>fitacf</code> data stream to standard output. When color mode is enabled, users can toggle between power, velocity, spectral width, and elevation angle by pressing 'p', 'v', w', or 'e', respectively. Press any other key to exit the program.</p>
+<p>The program dumps an ASCII representation of the <code>fitacf</code> data stream to standard output. When color mode is enabled, users can toggle between power, velocity, spectral width, and elevation angle by pressing 'p', 'v', w', or 'e', respectively. The 'g' key toggles the ground scatter flag, while the up/down arrow keys adjust the color scale maximum and right/left arrow keys cycle through parameters. Press any other key to exit the program.</p>
 </description>
 
 <example>

--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/doc/fitacfclientgui.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/doc/fitacfclientgui.doc.xml
@@ -13,8 +13,6 @@
 </option>
 <option><on>-nrange <ar>nrng</ar></on><od>set the maximum number of range gates to display to <ar>nrng</ar> (default is 75).</od>
 </option>
-<option><on>-color</on><od>display the data stream in color according to the selected parameter (default is power).</od>
-</option>
 <option><on>-gs</on><od>color ground scatter white (velocity only).</od>
 </option>
 <option><on>-p</on><od>plot power.</od>

--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/fitacfclientgui.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/fitacfclientgui.c
@@ -81,7 +81,7 @@ int main(int argc,char *argv[]) {
   int min_beam=100;
   int max_beam=-100;
 
-  unsigned char colorflg=0;
+  unsigned char colorflg=1;
   unsigned char gflg=0;
   unsigned char menu=1;
   double nlevels=5;
@@ -123,7 +123,6 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"-version",'x',&version);
   OptionAdd(&opt,"nrange",'i',&nrng);
 
-  OptionAdd(&opt,"color",'x',&colorflg);
   OptionAdd(&opt,"gs",'x',&gflg);
   OptionAdd(&opt,"p",'x',&pwrflg);
   OptionAdd(&opt,"pmin",'d',&pmin);
@@ -191,14 +190,11 @@ int main(int argc,char *argv[]) {
   /* Hide the cursor */
   curs_set(0);
 
+  /* Check for color support */
+  if (has_colors() == FALSE) colorflg = 0;
+
   /* Initialize colors */
   if (colorflg) {
-    if (has_colors() == FALSE) {
-      endwin();
-      fprintf(stderr,"No color support!\n");
-      exit(1);
-    }
-
     start_color();
     init_pair(1, COLOR_MAGENTA, COLOR_BLACK);
     init_pair(2, COLOR_BLUE, COLOR_BLACK);
@@ -547,6 +543,9 @@ int main(int argc,char *argv[]) {
   } while(1);
 
   endwin();
+
+  RadarParmFree(prm);
+  FitFree(fit);
 
   return 0;
 }

--- a/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/fitacfclientgui.c
+++ b/codebase/superdarn/src.bin/tk/tcpip/fitacfclientgui.1.0/fitacfclientgui.c
@@ -378,7 +378,7 @@ int main(int argc,char *argv[]) {
       clrtoeol();
       printw("rsep  = %3d  noise.search = %g\n", prm->rsep,prm->noise.search);
       clrtoeol();
-      printw("scan  = %3d  noise.mean   = %g\n", prm->scan,prm->noise.mean);
+      printw("scan  = %3d  noise.sky    = %g\n", prm->scan,fit->noise.skynoise);
       clrtoeol();
       printw("mppul = %3d  mpinc = %d\n", prm->mppul,prm->mpinc);
       clrtoeol();


### PR DESCRIPTION
This pull request implements major updates to `fitacfclientgui` ~~when using the `-color` option~~, including:

- an on-screen menu explaining keyboard controls
- use of a data buffer allowing all beams to update when plotting options change
- a new ground scatter flag option (which can also be toggled with the `g` key)
- up/down arrow control of the color scale maximum

As an example using the Iceland East real-time data stream,

<img width="536" alt="iceland_realtime" src="https://github.com/SuperDARN/rst/assets/1869073/40b033d3-e156-402a-9f96-ea72fe702b69">

For testing, if you don't have access to a real-time data stream you can simulate one using `fitacfserver` (eg https://github.com/SuperDARN/rst/pull/273).
