### PR TITLE
Elevation statistics tool

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/find_elvstat.1.0/doc/find_elvstat.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/find_elvstat.1.0/doc/find_elvstat.doc.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<binary>
+<project>superdarn</project>
+<name>find_elvstat</name>
+<location>src.bin/tk/tool/find_elvstat</location>
+
+<syntax>find_elvstat --help</syntax>
+<syntax>find_elvstat [<ar>options</ar>] <ar>fitacfname</ar></syntax>
+<syntax>find_elvstat -old [<ar>options</ar>] <ar>fitname</ar></syntax>
+<syntax>find_elvstat -cfit [<ar>options</ar>] <ar>cfitname</ar></syntax>
+<syntax>find_elvstat -c [<ar>options</ar>] <ar>fitacfnames...</ar></syntax>
+<syntax>find_elvstat -c -old [<ar>options</ar>] <ar>fitnames...</ar></syntax>
+<syntax>find_elvstat -c -cfit [<ar>options</ar>] <ar>cfitnames...</ar></syntax>
+
+<option><on>--help</on><od>print the help message and exit.</od>
+</option>
+<option><on>--version</on><od>print the RST version number and exit.</od>
+</option>
+<option><on>-vb</on><od>verbose. Log information to the console.</od>
+</option>
+<option><on>-sd <ar>yyyymmdd</ar></on><od>start from the date <ar>yyyymmdd</ar>.</od>
+</option>
+<option><on>-st <ar>hr:mn</ar></on><od>start from the time <ar>hr:mn</ar>.</od>
+</option>
+<option><on>-ed <ar>yyyymmdd</ar></on><od>stop at the date <ar>yyyymmdd</ar>.</od>
+</option>
+<option><on>-et <ar>hr:mn</ar></on><od>stop at the time <ar>hr:mn</ar>.</od>
+</option>
+<option><on>-ex <ar>hr:mn</ar></on><od>use the interval whose extent is <ar>hr:mn</ar>.</od>
+</option>
+<option><on>-cn <ar>channel</ar></on><od>process data from channel <ar>channel</ar> for stereo mode data.</od>
+</option>
+<option><on>-cn_fix <ar>channel</ar></on><od>manually set <ar>channel</ar> to be processed.</od>
+</option>
+<option><on>-ns</on><od>exclude data with scan flags less than zero.</od>
+</option>
+<option><on><ar>fitacfname</ar></on><od>filename of the <code>fitacf</code> format file.</od>
+</option>
+<option><on>-old</on><od>the input file is in the <code>fit</code> format.</od>
+</option>
+<option><on><ar>fitname</ar></on><od>filename of the <code>fit</code> format file.</od>
+</option>
+<option><on>-cfit</on><od>the input file is in the <code>cfit</code> format.</od>
+</option>
+<option><on><ar>cfitfname</ar></on><od>filename of the <code>cfit</code> format file.</od>
+</option>
+<option><on>-c</on><od>concatenate multiple input files (from the same radar site).</od>
+</option>
+<option><on><ar>fitnames</ar></on><od>filenames of the <code>fit</code> format files.</od>
+</option>
+<option><on><ar>fitacfnames</ar></on><od>filenames of the <code>fitacf</code> format files.</od>
+</option>
+<option><on><ar>cfitnames</ar></on><od>filenames of the <code>cfit</code> format files.</od>
+</option>
+<synopsis><p>Determines the number of potentially valid elevation angles in <code>fitacf</code>, <code>fit</code>, or <code>cfit</code> format files.</p></synopsis>
+<description><p>Determines the number of potentially valid elevation angles in <code>fitacf</code>, <code>fit</code>, or <code>cfit</code> format files.</p>
+<p>The number of potentially valid elevation angles is written to standard output.</p></description>
+
+<example>
+<command>find_elvstat 20040830.gbr.fitacf</command>
+<description>Find the number of potentially valid elevation angles in the <code>fitacf</code> file "<code>20040830.gbr.fitacf</code>".</description>
+</example>
+
+</binary>

--- a/codebase/superdarn/src.bin/tk/tool/find_elvstat.1.0/find_elvstat.c
+++ b/codebase/superdarn/src.bin/tk/tool/find_elvstat.1.0/find_elvstat.c
@@ -1,0 +1,215 @@
+/* find_elvstat.c
+   ========
+   Author: Angeline G. Burrell - NRL - 2023
+   This is a U.S. government work and not under copyright protection in the U.S.
+
+   This file is part of the Radar Software Toolkit (RST).
+
+   Disclaimer: RST is licensed under GPL v3.0. Please visit 
+               <https://www.gnu.org/licenses/> to see the full license
+
+   Modifications:
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "option.h"
+#include "rtime.h"
+#include "channel.h"
+#include "elvstat.h"
+#include "hlpstr.h"
+#include "errstr.h"
+
+struct OptionData opt;
+
+/**
+ * @brief Outputs an error statement for an unrecognized input option
+ **/
+
+int rst_opterr(char *txt)
+{
+    fprintf(stderr,"Option not recognized: %s\n", txt);
+    fprintf(stderr,"Please try: find_elvstat --help\n");
+    return(-1);
+}
+
+/**
+ * @brief Load the command line options
+ **/
+
+int command_options(int argc, char *argv[], int *old, unsigned char *vb,
+		    unsigned char *fitflg, unsigned char *catflg,
+		    unsigned char *nsflg, char **stmestr, char **etmestr,
+		    char **sdtestr, char **edtestr, char **exstr,
+		    char **chnstr, char **chnstr_fix)
+{
+  /* Initialize input options */
+  int farg=0;
+  unsigned char help=0, option=0, version=0, cfitflg=0;
+
+  int rst_opterr(char *txt);
+
+  /* If only information is desired, print it out and exit */
+  OptionAdd(&opt, "-help", 'x', &help);
+  OptionAdd(&opt, "-option", 'x', &option);
+  OptionAdd(&opt, "-version", 'x', &version);
+
+  /* Determine input file format */
+  OptionAdd(&opt, "old", 'x', old);      /* Old fit format */
+  OptionAdd(&opt, "fit", 'x', fitflg);   /* New fit format */
+  OptionAdd(&opt, "cfit", 'x', &cfitflg); /* cfit format    */
+
+  /* Concatenate multiple input files */
+  OptionAdd(&opt, "c", 'x', catflg); 
+
+  /* Verbose: log information to console */
+  OptionAdd(&opt, "vb", 'x', vb);
+
+  /* Set time information */
+  OptionAdd(&opt, "st", 't', stmestr);  /* Start time in HH:MM format */
+  OptionAdd(&opt, "et", 't', etmestr);  /* End time in HH:MM format */
+  OptionAdd(&opt, "sd", 't', sdtestr);  /* Start date in YYYYMMDD format */
+  OptionAdd(&opt, "ed", 't', edtestr);  /* End date in YYYYMMDD format */
+  OptionAdd(&opt, "ex", 't', exstr);    /* Use interval with extent HH:MM */
+
+  /* Process channel options */
+  OptionAdd(&opt, "cn", 't', chnstr);         /* For stereo channel a or b   */
+  OptionAdd(&opt, "cn_fix", 't', chnstr_fix); /* User-defined channel number */
+
+  /* Apply scan flag limit (ie exclude data with scan flag = -1) */
+  OptionAdd(&opt, "ns", 'x', &nsflg);
+
+  /* Process command line options */
+  farg = OptionProcess(1, argc, argv, &opt, rst_opterr);
+
+  /* If 'help' set then print help message */
+  if(help==1)
+    {
+      OptionPrintInfo(stdout, hlpstr);
+      exit(0);
+    }
+
+  /* If 'option' set then print all command line options */
+  if(option==1)
+    {
+      OptionDump(stdout, &opt);
+      exit(0);
+    }
+
+  /* If 'version' set, then print the version number */
+  if(version==1)
+    {
+      OptionVersion(stdout);
+      exit(0);
+    }
+
+  /* If command line option not recognized then print error and exit */
+  if(farg == -1) exit(-1);
+
+  if(farg == argc)
+    {
+      OptionPrintInfo(stderr, errstr);
+      exit(-1);
+    }
+
+  /* If not explicity working from cfit files, treat input as fit or fitacf */
+  if(cfitflg == 0) *fitflg = 1;
+
+  return farg;
+}
+
+/**
+ * @brief Dynamically determine the number of potentially valid elevation angles
+ **/
+
+int main(int argc, char *argv[])
+{
+  int inum, len, fnum, num_elv;
+
+  char vstr[256];
+
+  /* Initialize input options */
+  int old=0, farg=0, channel=0, channel_fix=0;
+
+  double stime=-1.0, etime=-1.0, extime=0.0, sdate=-1.0, edate=-1.0;
+
+  unsigned char fitflg=0, vb=0, catflg=0, nsflg=0;
+
+  char *chnstr=NULL, *chnstr_fix=NULL, *exstr=NULL, *vbuf=NULL;
+  char *stmestr=NULL, *etmestr=NULL, *sdtestr=NULL, *edtestr=NULL;
+
+  /* Initialize file information */
+  char **dnames=NULL, *iname=NULL;
+
+  /* Declare local subroutines */
+  int command_options(int argc, char *argv[], int *old, unsigned char *vb,
+		      unsigned char *fitflg, unsigned char *catflg,
+		      unsigned char *nsflg, char **stmestr, char **etmestr,
+		      char **sdtestr, char **edtestr, char **exstr,
+		      char **chnstr, char **chnstr_fix);
+
+  /* Process the command line options */
+  farg = command_options(argc, argv, &old, &vb, &fitflg, &catflg, &nsflg,
+			 &stmestr, &etmestr, &sdtestr, &edtestr, &exstr,
+			 &chnstr, &chnstr_fix);
+
+  /* If 'cn' set then determine Stereo channel, either A or B */
+  if(chnstr != NULL) channel = set_stereo_channel(chnstr);
+    
+  /* If 'cn_fix' set then determine appropriate channel for output file */
+  if(chnstr_fix != NULL) channel_fix = set_fix_channel(chnstr_fix);
+
+  /* Format the time data */
+  if(exstr   != NULL) extime = TimeStrToSOD(exstr);
+  if(stmestr != NULL) stime  = TimeStrToSOD(stmestr);
+  if(etmestr != NULL) etime  = TimeStrToSOD(etmestr);
+  if(sdtestr != NULL) sdate  = TimeStrToEpoch(sdtestr);
+  if(edtestr != NULL) edate  = TimeStrToEpoch(edtestr);
+
+  /* If verbose, set output */
+  if(vb) vbuf = vstr;
+
+  /* Make a list of input files */
+  if(catflg == 0)
+    {
+      /* For a single input file, an index file may also be provided */
+      dnames = (char **)malloc(sizeof(char*));
+
+      if(argc-farg > 1)
+	{
+	  iname = argv[argc-1];
+	  fnum = argc - 2;
+	}
+      else fnum = argc - 1;
+
+      len = strlen(argv[fnum]);
+      dnames[0] = (char *)malloc(sizeof(char) * (len+1));
+      strcpy(dnames[0], argv[fnum]);
+      fnum = 1;
+    }
+  else
+    {
+      /* For multiple input files, no index files are allowed */
+      fnum = argc - farg;
+      dnames = (char **)malloc(sizeof(char*) * fnum);
+
+      for(inum=0; inum<fnum; inum++)
+	{
+	  len = strlen(argv[inum+argc]);
+	  dnames[inum] = (char *)malloc(sizeof(char) * (len+1));
+	  strcpy(dnames[inum], argv[inum+argc]);
+	}
+    }
+
+  /* Establish the number of potentially valid elevation angles */
+  num_elv = get_fit_elv_stat(fnum, channel, channel_fix, old, stime, sdate,
+			     etime, edate, extime, fitflg, nsflg, vb, vbuf,
+			     iname, dnames);
+
+  /* Output the number of potentially valid elevation angles */
+  fprintf(stdout, "%d positive elevation angles below 90 degrees\n", num_elv);
+
+  return(num_elv);
+}

--- a/codebase/superdarn/src.bin/tk/tool/find_elvstat.1.0/find_elvstat.c
+++ b/codebase/superdarn/src.bin/tk/tool/find_elvstat.1.0/find_elvstat.c
@@ -207,6 +207,9 @@ int main(int argc, char *argv[])
   num_elv = get_fit_elv_stat(fnum, channel, channel_fix, old, stime, sdate,
 			     etime, edate, extime, fitflg, nsflg, vb, vbuf,
 			     iname, dnames);
+  /* Free the filename pointer */
+  for(inum=0; inum<fnum; inum++) free(dnames[inum]);
+  free(dnames);
 
   /* Output the number of potentially valid elevation angles */
   fprintf(stdout, "%d positive elevation angles below 90 degrees\n", num_elv);

--- a/codebase/superdarn/src.bin/tk/tool/find_elvstat.1.0/makefile
+++ b/codebase/superdarn/src.bin/tk/tool/find_elvstat.1.0/makefile
@@ -1,0 +1,36 @@
+# Makefile for find_elvstat
+# =========================
+# Author: Angeline G. Burrell, NRL (2023)
+# This is a U.S. government work and not under copyright protection in the U.S.
+#
+# Disclaimer:  RST is licensed under GPL v3.0. Please visit 
+#              <https://www.gnu.org/licenses/> to see the full license
+#
+# Modifications:
+#
+
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE = -I$(IPATH)/analysis -I$(IPATH)/base -I$(IPATH)/general \
+                -I$(IPATH)/superdarn -I../include/
+
+# Notes:
+# load_fit is copied from codebase/superdarn/src.bin/tk/tool/read_fit_v1.0
+SRC =   find_elvstat.c
+
+OBJS =  $(SRC:.c=.o)
+
+INC=$(IPATH)/superdarn
+
+DSTPATH = $(BINPATH)
+
+OUTPUT = find_elvstat
+
+LIBS =  -lchannel.1 -lelvstat.1 -loldfit.1 -lgtabw.1 -loldgtabw.1 -lgtable.1 \
+	-lrpos.1 -lfilter.1 -lcfit.1 -lfit.1 -lrscan.1 -lradar.1 -ldmap.1 \
+	-lopt.1 -lrtime.1 -lrcnv.1 -laacgm.1 -ligrf.1 -laacgm_v2.1 \
+	-ligrf_v2.1 -lastalg.1 -lfitacf.1
+
+SLIB = -lm -lz
+
+include $(MAKEBIN).$(SYSTEM)

--- a/codebase/superdarn/src.lib/tk/elvstat.1.0/doc/elvstat.doc.xml
+++ b/codebase/superdarn/src.lib/tk/elvstat.1.0/doc/elvstat.doc.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<library>
+<project>superdarn</project>
+<name>freqband</name>
+<location>src.lib/tk/freqband</location>
+
+
+<function>
+<name>get_fit_elv_stat</name>
+<location>src.lib/tk/elvstat</location>
+<header>superdarn/elvstat.h</header>
+<syntax>int get_fit_elv_stat(int fnum, int channel, int channel_fix, int old, double stime, double sdate, double etime, double edate, double extime, unsigned char fitflg, unsigned char nsflg, unsigned char vb, char *vbuf, char *iname, char **dnames);</syntax>
+<description><p>The <fn href="get_fit_elv_stat.html">get_fit_elv_stat</fn> function takes the input parameters needed to load cfit, fit, or fitacf files and determine the number of potentially valid elevation angles.</p>
+</description>
+<returns>Returns the number of potentially valid elevation angles.</returns>
+<errors>Returns (-1) if an error is encountered.</errors>
+</function>
+
+</library>

--- a/codebase/superdarn/src.lib/tk/elvstat.1.0/include/elvstat.h
+++ b/codebase/superdarn/src.lib/tk/elvstat.1.0/include/elvstat.h
@@ -1,0 +1,18 @@
+/* freqband.h
+   ==========
+   Author: Angeline G. Burrell - NRL - 2023
+   This is a U.S. government work and not under copyright protection in the U.S.
+
+   This file is part of the Radar Software Toolkit (RST).
+
+   Disclaimer: RST is licensed under GPL v3.0. Please visit 
+               <https://www.gnu.org/licenses/> to see the full license
+
+   Modifications:
+
+*/
+
+int get_fit_elv_stat(int fnum, int channel, int channel_fix, int old,
+		     double stime, double sdate, double etime, double edate,
+		     double extime, unsigned char fitflg, unsigned char nsflg,
+		     unsigned char vb, char *vbuf, char *iname, char **dnames);

--- a/codebase/superdarn/src.lib/tk/elvstat.1.0/src/get_fit_elv_stat.c
+++ b/codebase/superdarn/src.lib/tk/elvstat.1.0/src/get_fit_elv_stat.c
@@ -1,0 +1,347 @@
+/* get_fit_elv_stat.c
+   ====================
+   Author: Angeline G. Burrell - NRL - 2023
+   This is a U.S. government work and not under copyright protection in the U.S.
+
+   This file is part of the Radar Software Toolkit (RST).
+
+   Disclaimer: This code is licensed under GPL v3.0 please LICENSE to see the
+               full license
+
+   Modifications:
+
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <zlib.h>
+
+#include "rtypes.h"
+#include "rtime.h"
+#include "dmap.h" /* DMap library needs to go before rprm.h */
+#include "rprm.h"
+#include "scandata.h" /* scandata.h needs to go before the various fitdata.h */
+#include "fitindex.h"
+#include "fitdata.h"
+#include "fitread.h"
+#include "fitscan.h"
+#include "fitseek.h"
+#include "oldfitread.h"
+#include "oldfitscan.h"
+#include "cfitdata.h"
+#include "cfitindex.h"
+#include "cfitread.h"
+#include "cfitscan.h"
+#include "cfitseek.h"
+#include "elvstat.h"
+
+/**
+ * @brief Determine appropriate frequency bands for a fit* data set
+ *
+ * @params[in] fnum        - Number of files
+ *             channel     - Stereo channel number
+ *             channel_fix - User-specified channel number
+ *             old         - Flag for old/new FitACF input
+ *             stime       - Starting time
+ *             sdate       - Starting date
+ *             etime       - Ending time
+ *             edate       - Ending date
+ *             extime      - Time extent (zero to use start/end date-times)
+ *             fitflg      - 1 if a fit file, 0 if a cfit file
+ *             nsflg       - If 1, exclude data where scan flag is -1
+ *             vb          - Verbosity flag
+ *             vbuf        - Verbosity buffer
+ *             iname       - Index filename or NULL
+ *             dnames      - Array of filenames to open
+ *
+ * @params[out] num_elv - Returned value, number of potentially valid elevation
+ *                        angle observations
+ **/
+int get_fit_elv_stat(int fnum, int channel, int channel_fix, int old,
+		     double stime, double sdate, double etime, double edate,
+		     double extime, unsigned char fitflg, unsigned char nsflg,
+		     unsigned char vb, char *vbuf, char *iname, char **dnames)
+{
+  int yr, mo, dy, hr, mt, inum, ibm, icell;
+  int num_elv=0, ret_flg=0, state=0, syncflg=1, tlen=0;
+
+  double sc;
+
+  FILE *fp, *fitfp;
+
+  struct RadarCell cell;
+  struct RadarBeam bm;
+  struct RadarParm *prm;
+  struct FitData *fit;
+  struct CFitdata *cfit;
+  struct FitIndex *inx;
+  struct OldFitFp *oldfitfp=NULL;
+  struct CFitfp *cfitfp=NULL;
+  struct RadarScan *scan;
+
+  /* Initialize radar parameter and fit/cfit structures */
+  scan = RadarScanMake();
+  prm = RadarParmMake();
+  fit = FitMake();
+  cfit = CFitMake();
+
+  /* Cycle through all of the fit files */
+  for(inum=0; inum < fnum; inum++)
+    {
+
+      /* Assign the input and index file names */
+      fprintf(stderr, "Opening file:%s\n", dnames[inum]);
+
+      /* Open the fit, fitacf, or cfit file and read the first scan */
+      if(fitflg)
+	{
+	  /* Input file is in fit or fitacf format */
+	  if(old)
+	    {
+	      /* Input file is in fit format. Open the fit file for reading */
+	      if((oldfitfp = OldFitOpen(dnames[inum], iname)) == NULL)
+		{
+		  fprintf(stderr, "File not found.\n");
+		  exit(-1);
+                }
+
+	      /* Read first available radar scan in fit file (will use scan
+		 flag if tlen not provided) */
+	      ret_flg = OldFitReadRadarScan(oldfitfp, &state, scan, prm, fit,
+					    tlen, syncflg, channel);
+
+	      /* Verify that scan was properly read */
+	      if(ret_flg == -1)
+		{
+		  fprintf(stderr,"Error reading file.\n");
+		  exit(-1);
+                }
+            }
+	  else
+	    {
+	      /* Input file is in fitacf format */
+
+	      /* Check if index file provided */
+	      if(iname != NULL)
+		{
+		  /* Open the index file for reading */
+		  if((fp = fopen(iname, "r")) == NULL)
+		    fprintf(stderr, "Could not open index.\n");
+
+		  else
+		    {
+		      if((inx = FitIndexFload(fp)) == NULL)
+			fprintf(stderr, "Error loading index.\n");
+		      fclose(fp);
+                    }
+                }
+
+	      /* Open the fitacf file for reading */
+	      if((fitfp = fopen(dnames[inum], "r")) == NULL)
+		{
+		  fprintf(stderr, "File not found.\n");
+		  exit(-1);
+                }
+
+	      /* Read first available radar scan in fitacf file (will use scan
+		 flag if tlen not provided) */
+	      ret_flg = FitFreadRadarScan(fitfp, &state, scan, prm, fit,
+					  tlen, syncflg, channel);
+
+	      /* Verify that scan was properly read */
+	      if(ret_flg == -1)
+		{
+		  fprintf(stderr, "Error reading file.\n");
+		  exit(-1);
+                }
+            }
+        }
+      else
+	{
+	  /* Input file is in cfit or format. Open the cfit file for reading */
+	  if((cfitfp=CFitOpen(dnames[inum])) == NULL)
+	    {
+	      fprintf(stderr, "File not found.\n");
+	      exit(-1);
+            }
+
+	  /* Verify that the cfit file was properly opened */
+	  ret_flg = CFitReadRadarScan(cfitfp, &state, scan, cfit, tlen, syncflg,
+				      channel);
+	  if(ret_flg == -1)
+	    {
+	      fprintf(stderr, "Error reading file.\n");
+	      exit(-1);
+            }
+        }
+
+      /* If either start time or date not provided as input then determine it */
+      if((stime != -1) || (sdate != -1))
+	{
+	  /* We must skip the start of the files. If start time not provided */
+	  /* then use time of first record in the fit file                   */
+	  if(stime==-1) stime = ((int)scan->st_time % (24*3600));
+
+	  /* If start date not provided then use date of first record */
+	  /* in fit file, otherwise use provided sdate                */
+	  if (sdate == -1) stime += scan->st_time - ((int)scan->st_time
+						     % (24 * 3600));
+	  else stime += sdate;
+
+	  /* Calculate year, month, day, hour, minute, and second of the */
+	  /* scan start time.                                            */
+	  TimeEpochToYMDHMS(stime, &yr, &mo, &dy, &hr, &mt, &sc);
+
+	  /* Search for index of corresponding record in input file given */
+	  /* start time                                                   */
+	  if(fitflg)
+	    {
+	      /* Input file is in fit or fitacf format */
+	      if(old)
+		ret_flg = OldFitSeek(oldfitfp, yr, mo, dy, hr, mt, sc, NULL);
+	      else ret_flg = FitFseek(fitfp, yr, mo, dy, hr, mt, sc, NULL, inx);
+
+	      /* If a matching record could not be found then exit */
+	      if(ret_flg == -1)
+		{
+		  fprintf(stderr,
+			  "File does not contain the requested interval.\n");
+		  exit(-1);
+                }
+
+	      /* If using scan flag instead of tlen then continue to read
+		 fit records until reaching the beginning of a new scan */
+	      if(tlen==0)
+		{
+		  if(old)
+		    {
+		      while((ret_flg = OldFitRead(oldfitfp,prm,fit)) != -1)
+			{
+			  if(abs(prm->scan) == 1) break;
+                        }
+                    }
+		  else
+		    {
+		      while((ret_flg = FitFread(fitfp, prm, fit)) != -1)
+			{
+			  if(abs(prm->scan) == 1) break;
+                        }
+                    }
+                }
+	      else state=0;
+
+	      /* Read the first full scan of data from open fit or fitacf file
+		 corresponding to the requested start date and time */
+	      if(old)
+		ret_flg = OldFitReadRadarScan(oldfitfp, &state, scan, prm, fit,
+					      tlen, syncflg, channel);
+	      else
+		ret_flg = FitFreadRadarScan(fitfp, &state, scan, prm, fit, tlen,
+					    syncflg, channel);
+            }
+	  else
+	    {
+	      /* Input file is in cfit format */
+	      ret_flg = CFitSeek(cfitfp, yr, mo, dy, hr, mt, sc, NULL, NULL);
+
+	      /* If a matching record could not be found then exit */
+	      if(ret_flg == -1)
+		{
+		  fprintf(stderr,
+			  "File does not contain the requested interval.\n");
+		  exit(-1);
+                }
+
+	      /* If using scan flag instead of tlen then continue to read
+		 cfit records until reaching the beginning of a new scan */
+	      if(tlen==0)
+		{
+		  while((ret_flg = CFitRead(cfitfp, cfit)) != -1)
+		    {
+		      if(cfit->scan == 1) break;
+                    }
+                }
+	      else state = 0;
+
+	      /* Read the first full scan of data from open cfit file
+		 corresponding to the start date and time */
+	      ret_flg = CFitReadRadarScan(cfitfp, &state, scan, cfit, tlen,
+					  syncflg, channel);
+
+            }
+        }
+      else stime = scan->st_time;   /* If the start date and time are not
+				       provided, use the time of the input
+				       file's first record */
+
+      /* If end time provided then determine end date */
+      if(etime != -1)
+	{
+	  /* If end date not provided then use date of first record
+	     in input file */
+	  if(edate == -1) etime += scan->st_time - ((int) scan->st_time
+						    % (24 * 3600));
+	  else etime += edate;
+        }
+
+      /* If time extent provided then use that to calculate end time */
+      if(extime != 0) etime = stime + extime;
+
+      /* Continue updating the frequency limits until the input scan data is */
+      /* beyond the end time or end of input file is reached                 */
+      do
+	{
+	  /* If 'ns' option set then exclude data where scan flag = -1 */
+	  if(nsflg) exclude_outofscan(scan);
+
+	  /* Update the local frequency data */
+	  for(ibm = 0; ibm < scan->num; ibm++)
+	    {
+	      bm = scan->bm[ibm];
+
+	      for(icell = 0; icell < bm.nrang; icell++)
+		{
+		  if(bm.sct[icell])
+		    {
+		      cell = bm.rng[icell];
+
+		      /* Determine if the elevation angle has a potentially  */
+		      /* realistic value (positive and less than 90 degrees) */
+		      if(cell.elv > 0.0 && cell.elv < 90.0) num_elv++;
+		    }
+		}
+	    }
+
+	  /* Read next radar scan from input file */
+	  if(fitflg)
+	    {
+	      if(old)
+		ret_flg = OldFitReadRadarScan(oldfitfp, &state, scan, prm, fit,
+					      tlen, syncflg, channel);
+	      else
+		ret_flg = FitFreadRadarScan(fitfp, &state, scan, prm, fit,
+					    tlen, syncflg, channel);
+            }
+	  else
+	    ret_flg = CFitReadRadarScan(cfitfp, &state, scan, cfit, tlen,
+					syncflg, channel);
+
+	  /* If scan data is beyond end time then break out of loop */
+	  if((etime != -1) && (scan->st_time > etime)) break;
+	  
+        } while (ret_flg != -1);
+
+      /* Close the input file */
+      if(fitflg)
+	{
+	  if(old) OldFitClose(oldfitfp);
+	  else fclose(fitfp);
+        }
+      else CFitClose(cfitfp);
+    }
+
+  /* Return the number of elevation angles */
+  return(num_elv);
+}

--- a/codebase/superdarn/src.lib/tk/elvstat.1.0/src/makefile
+++ b/codebase/superdarn/src.lib/tk/elvstat.1.0/src/makefile
@@ -1,0 +1,24 @@
+# Makefile for elevation statistics library
+# =========================================
+# Author: Angeline G. Burrell, NRL (2023)
+# This is a U.S. government work and not under copyright protection in the U.S.
+#
+# Disclaimer: RST is licensed under GPL v3.0. Please visit 
+#             <https://www.gnu.org/licenses/> to see the full license
+#
+# Modifications:
+
+include $(MAKECFG).$(SYSTEM)
+
+INCLUDE = -I$(IPATH)/base -I$(IPATH)/general -I$(IPATH)/superdarn -I../include/
+INC = $(IPATH)/superdarn
+DSTPATH = $(LIBPATH)
+OUTPUT = elvstat
+
+SRC = get_fit_elv_stat.c
+
+OBJS = $(SRC:.c=.o)
+
+LINK = "1"
+
+include $(MAKELIB).$(SYSTEM)


### PR DESCRIPTION
Created a tool to count the number of elevation angle observations with potentially realistic values.  To test, try a radar that has and another that doesn't have elevation angles.  This, unfortunately, doesn't identify garbage values that are within a potentially realistic range.

`find_elvstat 20000131.2200.00.hal.fitacf3`

Yields:
```
Opening file:20000131.2200.00.hal.fitacf3
0 positive elevation angles below 90 degrees
```

While `find_elvstat ~/Programs/Data/SuperDARN/Downloads/20170105.1001.00.lyr.fitacf3`

Yields:
```
Opening file:20170105.1001.00.lyr.fitacf3
39809 positive elevation angles below 90 degrees
```