### PR TITLE
Fix memory leaks

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_snd.1.0/make_snd.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_snd.1.0/make_snd.c
@@ -148,6 +148,7 @@ int main(int argc,char *argv[]) {
     tmstr[24]=0;
     SndSetOriginTime(snd,tmstr);
     SndSetOriginCommand(snd,command);
+    SndSetCombf(snd,prm->combf);
 
     s=FitToSnd(snd,prm,fit,prm->scan);
     if (s==-1) {

--- a/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/rtsnd.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/rtsnd.c
@@ -359,6 +359,7 @@ int main(int argc,char *argv[]) {
         tmstr[24]=0;
         SndSetOriginTime(snd,tmstr);
         SndSetOriginCommand(snd,command);
+        SndSetCombf(snd,prm->combf);
 
         FitToSnd(snd,prm,fit,prm->scan);
 

--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fitread.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fitread.c
@@ -51,11 +51,13 @@ int FitDecode(struct DataMap *ptr,
   int qflg=0,xqflg=0;
   int xcf=0,nrang=0;
 
+  if (fit->algorithm !=NULL) free(fit->algorithm);
   if (fit->rng !=NULL) free(fit->rng);
   if (fit->xrng !=NULL) free(fit->xrng);
   if (fit->elv !=NULL) free(fit->elv);
 
   memset(fit,0,sizeof(struct FitData));
+  fit->algorithm=NULL;
   fit->rng=NULL;
   fit->xrng=NULL;
   fit->elv=NULL;

--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -185,6 +185,7 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
   if (prm->origin.command !=NULL) free(prm->origin.command);
   if (prm->pulse !=NULL) free(prm->pulse);
   for (n=0;n<2;n++) if (prm->lag[n] !=NULL) free(prm->lag[n]);
+  if (prm->combf !=NULL) free(prm->combf);
 
   memset(prm,0,sizeof(struct RadarParm));
   prm->origin.time=NULL;

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
@@ -73,7 +73,6 @@ int FitToSnd(struct SndData *ptr, struct RadarParm *prm,
   ptr->xcf = prm->xcf;
   ptr->tfreq = prm->tfreq;
   ptr->sky_noise = fit->noise.skynoise;
-  ptr->combf = prm->combf;
   ptr->fit_revision.major = fit->revision.major;
   ptr->fit_revision.minor = fit->revision.minor;
   ptr->snd_revision.major = SND_MAJOR_REVISION;


### PR DESCRIPTION
This pull request fixes a few memory leaks identified while using valgrind with some of the ROS code.  To test, try various routines like `make_fit`, `make_snd`, `make_grid`, etc. - no noticeable functionality should change.