### PR TITLE
Adding new -xshift and -yshift options to field_plot

### DIFF
--- a/codebase/general/src.lib/map.1.18/src/tfunc.c
+++ b/codebase/general/src.lib/map.1.18/src/tfunc.c
@@ -131,6 +131,8 @@ int MapStereographic(int ssze,void *src,int dsze,void *dst,void *data) {
   float plon=0;
   float plat=0;
   float lat,lon;
+  float xshift=0;
+  float yshift=0;
  
   pnt=(float *)src;
   lat=pnt[0];
@@ -146,6 +148,8 @@ int MapStereographic(int ssze,void *src,int dsze,void *dst,void *data) {
     plon=arg[1];
     k=arg[2];
     f=arg[3];
+    xshift=arg[4];
+    yshift=arg[5];
   }
  
   lat=lat*PI/180;
@@ -162,10 +166,10 @@ int MapStereographic(int ssze,void *src,int dsze,void *dst,void *data) {
   k=2*k/(1+z);
 
   pnt=(float *) dst;
-  if (f==0) pnt[0]=(1.0+k*cos(lat)*sin(lon-plon))/2.0;
-  else pnt[0]=(1.0-k*cos(lat)*sin(lon-plon))/2.0;
+  if (f==0) pnt[0]=(1.0+k*cos(lat)*sin(lon-plon))/2.0 + xshift;
+  else pnt[0]=(1.0-k*cos(lat)*sin(lon-plon))/2.0 + xshift;
   pnt[1]=(1.0-k*(cos(plat)*sin(lat)-sin(plat)*cos(lat)*
-                 cos(lon-plon)))/2.0;
+                 cos(lon-plon)))/2.0 + yshift;
  
  return 0;
 }

--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/doc/field_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/doc/field_plot.doc.xml
@@ -92,9 +92,9 @@
 </option>
 <option><on>-flip</on><od>flip the direction of the X-axis.</od>
 </option>
-<option><on>-xshift</on><od>shift the plot horizontally by a percentage of the plotting region (+/- 1.0)</od>
+<option><on>-xshift</on><od>shift the plot horizontally by a proportion of the plotting region (+/- 1.0)</od>
 </option>
-<option><on>-yshift</on><od>shift the plot vertically by a percentage of the plotting region (+/- 1.0)</od>
+<option><on>-yshift</on><od>shift the plot vertically by a proportion of the plotting region (+/- 1.0)</od>
 </option>
 <option><on>-square</on><od>force the use of a square bounding box around the plot.</od>
 </option>

--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/doc/field_plot.doc.xml
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/doc/field_plot.doc.xml
@@ -92,6 +92,10 @@
 </option>
 <option><on>-flip</on><od>flip the direction of the X-axis.</od>
 </option>
+<option><on>-xshift</on><od>shift the plot horizontally by a percentage of the plotting region (+/- 1.0)</od>
+</option>
+<option><on>-yshift</on><od>shift the plot vertically by a percentage of the plotting region (+/- 1.0)</od>
+</option>
 <option><on>-square</on><od>force the use of a square bounding box around the plot.</od>
 </option>
 <option><on>-coast</on><od>plot coastlines.</od>

--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
@@ -510,6 +510,8 @@ int main(int argc,char *argv[]) {
   float lat=1e10,lon=0;
   float latmin=50.0;
   float sf=1.0;
+  float xshift=0.0;
+  float yshift=0.0;
 
   unsigned char magflg=0;
   unsigned char rotflg=0;
@@ -566,7 +568,7 @@ int main(int argc,char *argv[]) {
   unsigned int gscol;
 
   FILE *mapfp;
-  float marg[4];
+  float marg[6];
   int i,n,c;
 
   char *stmestr=NULL;
@@ -838,6 +840,8 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"mag",'x',&magflg);
   OptionAdd(&opt,"rotate",'x',&rotflg);
   OptionAdd(&opt,"flip",'x',&flip);
+  OptionAdd(&opt,"xshift",'f',&xshift);
+  OptionAdd(&opt,"yshift",'f',&yshift);
 
   OptionAdd(&opt,"coast",'x',&mapflg);
   OptionAdd(&opt,"fcoast",'x',&fmapflg);
@@ -1288,6 +1292,9 @@ int main(int argc,char *argv[]) {
   if (ortho) marg[2]=sf;
   else marg[2]=1.25*0.5*sf*90.0/(90-fabs(latmin));
   marg[3]=flip;
+
+  if (abs(xshift) < 1.0) marg[4]=xshift;
+  if (abs(yshift) < 1.0) marg[5]=yshift;
 
   tfunc=MapStereographic;
   if (ortho) tfunc=MapOrthographic;

--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
@@ -378,7 +378,7 @@ int main(int argc,char *argv[]) {
   
 
   FILE *mapfp;
-  float marg[4];
+  float marg[6];
   int i;
 
   char *tmetxt=NULL;
@@ -728,6 +728,8 @@ int main(int argc,char *argv[]) {
   else if (stereo) marg[2]=1.25*0.5*sf*90.0/(90-fabs(latmin));
   else marg[2]=1;
   marg[3]=flip;
+  marg[4]=0.0;
+  marg[5]=0.0;
 
   strcpy(tsfx,"LT");
   if (magflg) strcpy(tsfx,"MLT");

--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
@@ -522,7 +522,7 @@ int main(int argc,char *argv[]) {
   unsigned int ffovcol;
 
   FILE *mapfp;
-  float marg[4];
+  float marg[6];
   int i;
 
   int flg=0;
@@ -984,6 +984,8 @@ int main(int argc,char *argv[]) {
   if (ortho) marg[2]=sf;
   else marg[2]=1.25*0.5*sf*90.0/(90-fabs(latmin));
   marg[3]=flip;
+  marg[4]=0.0;
+  marg[5]=0.0;
 
   tfunc=MapStereographic;
   if (ortho) tfunc=MapOrthographic;

--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
@@ -367,7 +367,7 @@ int main(int argc,char *argv[]) {
   unsigned int fpolycol;
 
   FILE *mapfp;
-  float marg[4];
+  float marg[6];
   int i;
 
   int flg=0;
@@ -898,6 +898,8 @@ int main(int argc,char *argv[]) {
   if (ortho) marg[2]=sf;
   else marg[2]=1.25*0.5*sf*90.0/(90-fabs(latmin));
   marg[3]=flip;
+  marg[4]=0.0;
+  marg[5]=0.0;
 
   tfunc=MapStereographic;
   if (ortho) tfunc=MapOrthographic;

--- a/codebase/superdarn/src.bin/tk/plot/vec_plot.1.9/vec_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/vec_plot.1.9/vec_plot.c
@@ -351,7 +351,7 @@ int main(int argc,char *argv[]) {
   char *txtcol_txt=NULL;
   char *grdcol_txt=NULL;
 
-  float marg[8]={0,0,0,0};
+  float marg[8]={0,0,0,0,0,0};
   int c=0;
 
   int old_aacgm=0;


### PR DESCRIPTION
This pull request modifieds the `field_plot` binary and `MapStereographic` function (in `tfunc.c`) to support user-controlled horizontal and vertical shifting of the plotting region.  This is particularly useful for radars where the default options, or some combination of `-latmin` / `-lat` / `-lon`, aren't quite sufficient.

For example, this is the default for Iceland East (ICE) in magnetic coordinates:

![default](https://github.com/SuperDARN/rst/assets/1869073/5756629b-2649-4268-96cc-4ef5080f17b4)

If we want to zoom in a little better, one could set `-latmin 60 -lat 85 -lon 65`:

![no_shift](https://github.com/SuperDARN/rst/assets/1869073/a12ed2ce-6c4c-49b2-a420-58c99b17ddc7)

Finally, with the new `-xshift` option one can actually center the radar FOV, eg `-latmin 60 -lat 85 -lon 65 -xshift -0.35`:

![shift](https://github.com/SuperDARN/rst/assets/1869073/400e056e-3ada-4ed1-b941-a54206ef6a24)

These new `-xshift` and `-yshift` options can be used with any `field_plot` figure in the (default) stereographic projection; orthographic projections will be unchanged.