### PR TITLE
Fix xmldoc bins

### DIFF
--- a/build/script/make.build
+++ b/build/script/make.build
@@ -59,7 +59,7 @@ makebuild() {
 
 liblist="xml/xml xml/xmldb xml/tagdb xml/xmldoclib \
          task/option httpd/rscript"
-binlist="xmldoc/xmldoc xmldoc/scdoc \
+binlist="xmldoc/xmldoc xmldoc/xmldoc xmldoc/scdoc \
          build/addtext build/maketree build/makeall"
 
 rm -f ${LIBPATH}/*

--- a/codebase/base/src.bin/xmldoc/scdoc.1.4/doc/scdoc.doc.xml
+++ b/codebase/base/src.bin/xmldoc/scdoc.1.4/doc/scdoc.doc.xml
@@ -3,9 +3,13 @@
 <project>base</project>
 <name>scdoc</name>
 <location>src.bin/xmldoc/scdoc</location>
+
 <syntax>scdoc --help</syntax>
 <syntax>scdoc <ar>table</ar> <ar>script</ar></syntax>
+
 <option><on>--help</on><od>print the help message and exit.</od>
+</option>
+<option><on>--version</on><od>print the RST version number and exit.</od>
 </option>
 <option><on><ar>table</ar></on><od>filename of the file containing the table of search and replace terms.</od>
 </option>
@@ -44,6 +48,7 @@
 <p>The lookup table and script are read from the two files specified on the command line, the resultant output text is written to standard output.</p>
 <p>This program is primarily used to generate HTML pages for the documentation system.</p>
 </description>
+
 <example>
 <command>scdoc table.xml page.script &gt; page.html</command>
 <description>Read the lookup table from the file "<code>table.xml</code>" and use it to replace text in the script "<code>page.script</code>". Write the HTML output to the file "<code>page.html</code>".

--- a/codebase/base/src.bin/xmldoc/scdoc.1.4/scdoc.c
+++ b/codebase/base/src.bin/xmldoc/scdoc.1.4/scdoc.c
@@ -43,6 +43,11 @@
 int arg;
 struct OptionData opt;
 
+int rst_opterr(char *txt) {
+  fprintf(stderr,"Option not recognized: %s\n",txt);
+  fprintf(stderr,"Please try: scdoc --help\n");
+  return(-1);
+}
 
 struct {
   int num;
@@ -181,6 +186,7 @@ int main(int argc,char *argv[]) {
 
   unsigned char help=0;
   unsigned char option=0;
+  unsigned char version=0;
 
   struct OptionText *ignore=NULL;
   struct OptionText *remove=NULL;
@@ -192,10 +198,15 @@ int main(int argc,char *argv[]) {
  
   OptionAdd(&opt,"-help",'x',&help);
   OptionAdd(&opt,"-option",'x',&option);
+  OptionAdd(&opt,"-version",'x',&version);
   OptionAdd(&opt,"i",'a',&ignore);
   OptionAdd(&opt,"r",'a',&remove);
 
-  arg=OptionProcess(1,argc,argv,&opt,NULL);   
+  arg=OptionProcess(1,argc,argv,&opt,rst_opterr);
+
+  if (arg==-1) {
+    exit(-1);
+  }
 
   if (help==1) {
     OptionPrintInfo(stdout,hlpstr);
@@ -204,6 +215,11 @@ int main(int argc,char *argv[]) {
 
   if (option==1) {
     OptionDump(stdout,&opt);
+    exit(0);
+  }
+
+  if (version==1) {
+    OptionVersion(stdout);
     exit(0);
   }
 

--- a/codebase/base/src.bin/xmldoc/xmldoc.1.6/doc/xmldoc.doc.xml
+++ b/codebase/base/src.bin/xmldoc/xmldoc.1.6/doc/xmldoc.doc.xml
@@ -3,16 +3,24 @@
 <project>base</project>
 <name>xmldoc</name>
 <location>src.bin/xmldoc/xmldoc</location>
+
 <syntax>xmldoc --help</syntax>
 <syntax>xmldoc [-ilf] <ar>workdir</ar> <ar>cfgname</ar> <ar>xmldoc</ar> [<ar>search</ar>]</syntax>
+
 <option><on>--help</on><od>print the help message and exit.</od>
+</option>
+<option><on>--version</on><od>print the RST version number and exit.</od>
 </option>
 <option><on>-ilf</on><od>ignore line feeds in the XML document.</od>
 </option>
 <option><on><ar>workdir</ar></on><od>working directory to operate in.</od>
 </option>
-<option><on><ar>cfgname</ar></on><od>filename of the configuration file.</od></option>
-<option><on><ar>xmldoc</ar></on><od>filename of the XML document to process.</od></option>
-<option><on><ar>search</ar></on><od>search text.</od></option>
+<option><on><ar>cfgname</ar></on><od>filename of the configuration file.</od>
+</option>
+<option><on><ar>xmldoc</ar></on><od>filename of the XML document to process.</od>
+</option>
+<option><on><ar>search</ar></on><od>search text.</od>
+</option>
 <synopsis><p>XML documentation system document parser.</p></synopsis>
+
 </binary>

--- a/codebase/base/src.bin/xmldoc/xmldoc.1.6/makefile
+++ b/codebase/base/src.bin/xmldoc/xmldoc.1.6/makefile
@@ -4,10 +4,9 @@
 include $(MAKECFG).$(SYSTEM)
 
 INCLUDE=-I$(IPATH)/base
-SRC=loadconfig.c loadconfig.h xmldoc.c xmldoc.h
+
 OBJS = loadconfig.o xmldoc.o 
 SRC=hlpstr.h errstr.h loadconfig.c loadconfig.h xmldoc.c xmldoc.h
-OBJS = loadconfig.o xmldoc.o 
 DSTPATH = $(BINPATH)
 OUTPUT = xmldoc
 LIBS=-lrscript.1 -lrxmldoc.1 -ltagdb.1 -lrxmldb.1 -lrxml.1 -lopt.1 

--- a/codebase/base/src.bin/xmldoc/xmldoc.1.6/xmldoc.c
+++ b/codebase/base/src.bin/xmldoc/xmldoc.1.6/xmldoc.c
@@ -49,6 +49,12 @@
 int arg;
 struct OptionData opt;
 
+int rst_opterr(char *txt) {
+  fprintf(stderr,"Option not recognized: %s\n",txt);
+  fprintf(stderr,"Please try: xmldoc --help\n");
+  return(-1);
+}
+
 
 struct xmldoc xmldoc;
 
@@ -296,6 +302,7 @@ int main(int argc,char *argv[]) {
   FILE *xmlfp;
   unsigned char help=0;
   unsigned char option=0;
+  unsigned char version=0;
   unsigned char ilf=0; 
   char *pathstr=NULL;
   char *scstr=NULL;
@@ -325,6 +332,7 @@ int main(int argc,char *argv[]) {
  
   OptionAdd(&opt,"-help",'x',&help);
   OptionAdd(&opt,"-option",'x',&option);
+  OptionAdd(&opt,"-version",'x',&version);
 
   OptionAdd(&opt,"ilf",'x',&ilf);
 
@@ -335,7 +343,11 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"script",'t',&scstr);
   OptionAdd(&opt,"sctype",'i',&sctype);
 
-  arg=OptionProcess(1,argc,argv,&opt,NULL);   
+  arg=OptionProcess(1,argc,argv,&opt,rst_opterr);
+
+  if (arg==-1) {
+    exit(-1);
+  }
 
   if (help==1) {
     OptionPrintInfo(stdout,hlpstr);
@@ -344,6 +356,11 @@ int main(int argc,char *argv[]) {
 
   if (option==1) {
     OptionDump(stdout,&opt);
+    exit(0);
+  }
+
+  if (version==1) {
+    OptionVersion(stdout);
     exit(0);
   }
  


### PR DESCRIPTION
This pull request adds option error handling and `--version` support to the `scdoc` and `xmldoc` binaries, and also modifies `make.build` so that `xmldoc` is compiled twice.  This allows for the help message (printed with `xmldoc --help`) to be correctly displayed (since `xmldoc` is needed to parse its own XML documentation).  No functionality has changed.