### PR TITLE
Modifying FitDecode of fit library to check against both phi0 and elv

### DIFF
--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fitread.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fitread.c
@@ -97,7 +97,7 @@ int FitDecode(struct DataMap *ptr,
 
     if ((strcmp(a->name,"pwr0")==0) && (a->type==DATAFLOAT) &&
         (a->dim==1)) nrang=a->rng[0];
-    if ((strcmp(a->name,"phi0")==0) && (a->type==DATAFLOAT) &&
+    if ( ((strcmp(a->name,"phi0")==0) || (strcmp(a->name,"elv")==0)) && (a->type==DATAFLOAT) &&
         (a->dim==1)) xcf=1;
   }
 


### PR DESCRIPTION
This pull request modifies `FitDecode` of the `fit` library to check against both the `phi0` and `elv` fields when reading fitted XCF data to determine whether to populate the XCF arrays. This is necessary because older radars do not transmit all of the fitted parameters in real-time (ie `phi0`), meaning that the elevation angles were not being populated when received by modern routines (eg `fitacfclientgui`).