### PR TITLE
Modifying rtcfit to fix documentation and remove unused -f option

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/doc/rtcfit.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/doc/rtcfit.doc.xml
@@ -38,12 +38,12 @@
 </description>
 
 <example>
-<command>make_cfit -L log -if pid.id kapqnx.jhuapl.edu 1024</command>
+<command>rtcfit -L log -if pid.id kapqnx.jhuapl.edu 1024</command>
 <description>Generates <code>cfit</code> files from the host "<code>kapqnx.jhuapl.edu</code>", served at port 1024. The process identifier is recorded in the file "<code>pid.id</code>", and logs of all transactions are recorded in the file "<code>log.<em>yyyymmdd</em></code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, and <em>dd</em> is the day.</description>
 </example>
 
 <example>
-<command>make_cfit -L log -if pid.id -rpf port.kap kapqnx.jhuapl.edu</command>
+<command>rtcfit -L log -if pid.id -rpf port.kap kapqnx.jhuapl.edu</command>
 <description>Generates <code>cfit</code> files from the host "<code>kapqnx.jhuapl.edu</code>", served at port contained in the file "<code>port.kap</code>". The process identifier is recorded in the file "<code>pid.id</code>", and logs of all transactions are recorded in the file "<code>log.<em>yyyymmdd</em></code>" where <em>yyyy</em> is the year, <em>mm</em> is the month, and <em>dd</em> is the day.</description>
 </example>
 

--- a/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/rtcfit.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtcfit.1.12/rtcfit.c
@@ -110,7 +110,6 @@ int main(int argc,char *argv[]) {
   unsigned char vb=0;
  
   char *logstr=NULL;
-  char *fnamestr=NULL;
   char *pathstr=NULL;
   char *pidstr=NULL;
 
@@ -198,7 +197,6 @@ int main(int argc,char *argv[]) {
   OptionAdd(&opt,"rpf",'x',&port_flag);
   
   OptionAdd(&opt,"L",'t',&logstr);
-  OptionAdd(&opt,"f",'t',&fnamestr);
   OptionAdd(&opt,"p",'t',&pathstr);
   OptionAdd(&opt,"if",'t',&pidstr);
 


### PR DESCRIPTION
This pull request fixes the html documentation for `rtcfit` (ie changing `make_cfit` to `rtcfit` in the examples) and removes an unused `-f` option, thus making the output of `--help` and `--option` consistent. No functionality has changed.