### PR TITLE
Modifying RadarParmDecode to set ifmode to zero by default

### DIFF
--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -195,8 +195,6 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
   prm->lag[1]=NULL;
   prm->combf=NULL;
 
-  prm->ifmode=-1;
-
   for (c=0;c<ptr->snum;c++) {
     s=ptr->scl[c];
 


### PR DESCRIPTION
This pull request addresses an inconsistency identified by Sessai, where currently the `RadarParmDecode` function sets the `ifmode` field to `-1` if the field is not present, eg for files written by QNX4-era (or earlier) radars.  This pull request modifies the behavior such that the `ifmode` field is always set to zero (`0`) by default (which matches our documentation).

To test, you can try something like this:

```
make_fit -fitacf2 20230129.0616.03.sys.rawacf > 20230129.0616.03.sys.fitacf
dmapdump 20230129.0616.03.sys.fitacf > 20230129.0616.03.sys.fitacf.dump
grep -r "ifmode" 20230129.0616.03.sys.fitacf.dump | tail -1
```

On this branch, the `ifmode` field in the radar parameter block should be `0`, while on develop it will be `-1`. No other functionality has changed.