### PR TITLE
Fixing array indexing bugs in make_sim and sim_real

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_sim.1.0/make_sim.c
@@ -410,7 +410,7 @@ int main(int argc,char *argv[])
     for (i=0;i<10;i++)
       tau[i] = i;
     /*no lag 10*/
-    for (i=10;i<18;i++)
+    for (i=10;i<n_lags;i++)
       tau[i] = (i+1);
   }
   /*spaletascan*/

--- a/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
+++ b/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/sim_real.c
@@ -382,7 +382,7 @@ int main(int argc,char *argv[])
       for (i=0;i<10;i++)
         tau[i] = i;
       /*no lag 10*/
-      for (i=10;i<18;i++)
+      for (i=10;i<n_lags;i++)
         tau[i] = (i+1);
     }
     /*katscan (default)*/


### PR DESCRIPTION
As the title suggests, this pull request fixes an array indexing bug in both `make_sim` and `sim_real` when populating the lag arrays.  No functionality has changed.