### PR TITLE
Fixing bug in GridTableWrite

### DIFF
--- a/codebase/superdarn/src.lib/tk/gtablewrite.1.9/src/gtablewrite.c
+++ b/codebase/superdarn/src.lib/tk/gtablewrite.1.9/src/gtablewrite.c
@@ -126,10 +126,10 @@ int GridTableWrite(int fid,struct GridTable *ptr,char *logbuf,int xtd) {
         vchn=(int16 *)  (buf+3*sizeof(float)*npnt+sizeof(int16)*npnt);
         index=(int32 *) (buf+3*sizeof(float)*npnt+2*sizeof(int16)*npnt);
         vlos=(float *)  (buf+3*sizeof(float)*npnt+
-                               sizeof(32)*npnt+
+                               sizeof(int32)*npnt+
                              2*sizeof(int16)*npnt);
         vlos_sd=(float *) (buf+3*sizeof(float)*npnt+
-                                 sizeof(32)*npnt+
+                                 sizeof(int32)*npnt+
                                2*sizeof(int16)*npnt+
                                  sizeof(float)*npnt);
 


### PR DESCRIPTION
This pull request fixes a bug in `GridTableWrite` which appears to date back to the introduction of this library. As far as I can tell no functionality changes on my system (phew), but that may not be true on all other systems depending on the return value of `sizeof(32)` vs `sizeof(int32)`.