### PR TITLE
Fixing bug in time_plot when plotting snd data

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -278,6 +278,7 @@ int main(int argc,char *argv[]) {
 
   double otime=-1;
   double atime=-1;
+  double tatime=-1;
 
   double stime=-1;
   double etime=-1;
@@ -1383,10 +1384,11 @@ int main(int argc,char *argv[]) {
 
     /* SND-format data collected at the end of a scan typically has
      * an integration time of only ~1.5 to 2.0 seconds */
-    if ((sndflg) && (atime-otime)>4) otime=atime-2;
+    if ((sndflg) && (atime-otime)>4) tatime=otime+tplot.intt.sc+tplot.intt.us/1e6;
+    else tatime=atime;
 
     lft=bwdt*(otime-stime)/(etime-stime);
-    rgt=bwdt*(atime-stime)/(etime-stime);
+    rgt=bwdt*(tatime-stime)/(etime-stime);
     if (rgt==lft) rgt++;
     if (lft<0) lft=0;
     if (lft>=bwdt) lft=bwdt-1;


### PR DESCRIPTION
This pull request fixes a bug in `time_plot` where the last snd record before the end of minute would be plotted at the wrong time.  

For example, the plots below are for 4 minutes of simulated snd mode data where the frequency increases on two different beams at the end of each minute.  You can see in the first attached plot how the highest frequency (orange) of the second beam comes just before the next minute's data:

![snd_timeplot_wrong](https://github.com/SuperDARN/rst/assets/1869073/97c7cff7-758f-48d5-a0a6-617ba8d3119c)

On this branch, the bug is fixed and the last snd record of each scan is now plotted at the correct times (ie connected to the other records at the end of the minute):

![snd_timeplot_fixed](https://github.com/SuperDARN/rst/assets/1869073/2a98eb83-0e89-4a08-8334-081928a1daf6)

These plots were produced using

```
time_plot -x -snd -a -st 14:00 -et 14:04 20231011.14.cve.snd
```

and here is the zipped file of simulated snd data:

[20231011.14.cve.snd.gz](https://github.com/SuperDARN/rst/files/12872169/20231011.14.cve.snd.gz)

No functionality has changed when plotting `fit` / `fitacf` files (or any other format).