### PR TITLE
Modifying rtsnd to add support for bmoff parameter from hdw file

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/rtsnd.c
+++ b/codebase/superdarn/src.bin/tk/tool/rtsnd.1.0/rtsnd.c
@@ -350,7 +350,7 @@ int main(int argc,char *argv[]) {
         /* calculate beam azimuth */
         if (prm->bmazm == 0) {
           offset = site->maxbeam/2.0 - 0.5;
-          prm->bmazm = site->boresite + site->bmsep*(prm->bmnum-offset);
+          prm->bmazm = site->boresite + site->bmsep*(prm->bmnum-offset) + site->bmoff;
         }
 
         snd->origin.code=1;


### PR DESCRIPTION
As indicated by the title, this pull request adds support for the `bmoff` parameter when calculating `bmazm` in the `rtsnd` binary (similar to #517 and #521).