### PR TITLE
Adding .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.pro linguist-language=IDL
+*.h linguist-language=C
+
+hdw.dat.* -linguist-detectable
+tdiff.dat.* -linguist-detectable
+*.asc -linguist-detectable
+*.dat -linguist-detectable


### PR DESCRIPTION
This pull request addresses #452 by overriding the linguist file detection with a new `.gitattributes` file, which has been found to work well in a similar RST-based repository.