### PR TITLE
Bugfix: setting `xqflg` to zero in `fit_speck_removal`

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/fit_speck_removal.c
+++ b/codebase/superdarn/src.bin/tk/tool/fit_speck_removal.1.0/fit_speck_removal.c
@@ -28,6 +28,7 @@ Modifications:
     2021-09-17 E.C.Bland, University Centre in Svalbard (UNIS): fix handling of qflg>1 data from fitacf2.5, 
 	           which in rare cases might include values other than qflg=0 for rejected ACFs.
     2022-02-23 E.C.Bland, (UNIS): add statistics on number of rejected ACFs
+    2024-04-04 E.C.Bland: Bugfix - xqflg also needs to be set to zero to properly remove isolated ACFs
 */
 
 
@@ -325,6 +326,7 @@ int main (int argc,char *argv[]) {
         if (sum < 5) 
         {
             fit->rng[range].qflg=0;
+            if (prm->xcf!=NULL) fit->xrng[range].qflg=0;
             echoes_removed+=1;
         }
         echoes_total+=1;


### PR DESCRIPTION
This PR fixes a bug identified by @pasha-ponomarenko in `fit_speck_removal`. For radars with `xcf=1`, the XCF quality flag also needs to be set to zero. This bug was not obvious when reading the output files using standard RST C code, but it does become apparent when reading the data with IDL. 