### PR TITLE
Modifying FitReadRadarScan to store sky noise in RadarBeam structure rather than search noise

### DIFF
--- a/codebase/superdarn/src.lib/tk/fit.1.35/src/fitscan.c
+++ b/codebase/superdarn/src.lib/tk/fit.1.35/src/fitscan.c
@@ -146,7 +146,7 @@ int FitReadRadarScan(int fid, int *state,
         bm->rsep=prm->rsep;
         bm->rxrise=prm->rxrise;
         bm->freq=prm->tfreq;
-        bm->noise=prm->noise.search;
+        bm->noise=fit->noise.skynoise;
         bm->atten=prm->atten;
         bm->channel=prm->channel;
         bm->nrang=prm->nrang;

--- a/docs/references/general/grid.md
+++ b/docs/references/general/grid.md
@@ -61,11 +61,11 @@ In the table below, *numstid* is the number of radars included in that grid reco
 | *channel*   |  **None**       |  *[numstid]*     | ***short*** | A list of channel numbers associated with the station id |
 | *nvec*      | **None** | *[numstid]*  | ***short*** | Number of velocity vectors for each station|
 | *freq*      | *kHz* | *[numstid]* | ***float*** | Transmitted frequency for each radar |
-| *major.revision* | **None** | *[numstid]* | ***short*** | Major `make_grid` version number                    |
+| *major.revision* | **None** | *[numstid]* | ***short*** | Major `make_grid` version number |
 | *minor.revision* | **None** | *[numstid]* | ***short*** | Minor `make_grid` version number |
 | *program.id*     | **None** | *[numstid]* | ***short*** | Control program ID | 
-| *noise.mean*      | **None** | *[numstid]* | ***float*** | Mean noise |
-| *noise.sd*        | **None** | *[numstid]* | ***float*** | Noise Standard deviation |
+| *noise.mean*      | **None** | *[numstid]* | ***float*** | Mean sky noise |
+| *noise.sd*        | **None** | *[numstid]* | ***float*** | Sky noise standard deviation |
 | *gsct*            | **None** | *[numstid]* | ***short*** | Groundscatter flag |
 | *v.min*           | *m/s* | *[numstid]* | ***float*** | Minimum velocity threshold |
 | *v.max*           | *m/s* | *[numstid]* | ***float*** | Velocity maximum threshold |
@@ -83,9 +83,9 @@ In the table below, *numstid* is the number of radars included in that grid reco
 | *vector.index*    | **None**  | *[numv]*   | ***int***   | Grid cell index |
 | *vector.vel.median* | *m/s* | *[numv]*   | ***float*** | Weighted mean velocity magnitude |
 | *vector.vel.sd*     | *m/s*   | *[numv]*   | ***float*** | Velocity standard deviation |
-| *vector.pwr.median* | *dB*  | *[numv]*   | ***float*** | Weighted mean power|
-| *vector.pwr.sd*     | *dB*  | *[numv]*   | ***float*** | Power standard deviation|
-| *vector.wdt.median* | *m/s* | *[numv]*   | ***float*** | Weighted mean spectral width|
-| *vector.wdt.sd      | *m/s* | *[numv]*   | ***float*** | Standard deviation of spectral width|
+| *vector.pwr.median* | *dB*  | *[numv]*   | ***float*** | Weighted mean power |
+| *vector.pwr.sd*     | *dB*  | *[numv]*   | ***float*** | Power standard deviation |
+| *vector.wdt.median* | *m/s* | *[numv]*   | ***float*** | Weighted mean spectral width |
+| *vector.wdt.sd*     | *m/s* | *[numv]*   | ***float*** | Standard deviation of spectral width |
 
 

--- a/docs/references/general/map.md
+++ b/docs/references/general/map.md
@@ -101,8 +101,8 @@ A map file will not necessarily contain a complete set of all the variables list
 | *major.revision* | **None** | *[numstid]* | ***short*** | Major `make_grid` version number |
 | *minor.revision* | **None** | *[numstid]* | ***short*** | Minor `make_grid` version number |
 | *program.id*     | **None** | *[numstid]* | ***short*** | Control program ID | 
-| *noise.mean*      | **None** | *[numstid]* | ***float*** | Mean noise |
-| *noise.sd*        | **None** | *[numstid]* | ***float*** | Noise Standard deviation |
+| *noise.mean*      | **None** | *[numstid]* | ***float*** | Mean sky noise |
+| *noise.sd*        | **None** | *[numstid]* | ***float*** | Sky noise standard deviation |
 | *gsct*            | **None** | *[numstid]* | ***short*** | Groundscatter flag |
 | *v.min*           | *m/s* | *[numstid]* | ***float*** | Minimum velocity threshold |
 | *v.max*           | *m/s* | *[numstid]* | ***float*** | Maximum velocity threshold |
@@ -123,7 +123,7 @@ A map file will not necessarily contain a complete set of all the variables list
 | *vector.pwr.median* | *dB*  | *[numv]*   | ***float*** | Weighted mean power |
 | *vector.pwr.sd*     | *dB*  | *[numv]*   | ***float*** | Power standard deviation |
 | *vector.wdt.median* | *m/s* | *[numv]*   | ***float*** | Weighted mean spectral width |
-| *vector.wdt.sd      | *m/s* | *[numv]*   | ***float*** | Standard deviation of spectral width |
+| *vector.wdt.sd*     | *m/s* | *[numv]*   | ***float*** | Standard deviation of spectral width |
 | *N*               | **None** | *[numft]* | ***double*** | L value of the expansion between 0 and Lmax |
 | *N+1*             | **None** | *[numft]* | ***double*** | M value of the expansion between -L and +L, negative values indicating the sin(M*phi) term |
 | *N+2*             | **None** | *[numft]* | ***double*** | Value of the coefficient  |


### PR DESCRIPTION
This pull request addresses one issue recently raised in #570, where the fitted sky noise value is now used instead of the `search.noise` parameter to populate the `noise` fields in grid and map files.  You can test this by comparing noise values in grid files for different radars (some of which calculate search noise differently or not at all).