### PR TITLE
Fixing elvstat library XML documentation

### DIFF
--- a/codebase/superdarn/src.lib/tk/elvstat.1.0/doc/elvstat.doc.xml
+++ b/codebase/superdarn/src.lib/tk/elvstat.1.0/doc/elvstat.doc.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <library>
 <project>superdarn</project>
-<name>freqband</name>
-<location>src.lib/tk/freqband</location>
+<name>elvstat</name>
+<location>src.lib/tk/elvstat</location>
 
 
 <function>


### PR DESCRIPTION
This pull request fixes two minor typos in the `elvstat` library XML documentation that I missed when reviewing #574 (leftover references to `freqband` library); no functionality has changed.