### PR TITLE
Adding new srng field to grid and map files

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/time_plot.1.8/time_plot.c
@@ -1428,18 +1428,18 @@ int main(int argc,char *argv[]) {
         }
 
         if ((geoflg) || (magflg)) {
-          double rho,blat,tlat,lon;
+          double rho,blat,tlat,lon,srng;
           double tmp_swap;
           if (magflg) RPosMag(0,tplot.bmnum,rng-1,site,tplot.frang,
                               tplot.rsep,tplot.rxrise,300,&rho,
-                              &blat,&lon,chisham,old_aacgm);
+                              &blat,&lon,&srng,chisham,old_aacgm);
           else RPosGeo(0,tplot.bmnum,rng-1,site,tplot.frang,tplot.rsep,
-                       tplot.rxrise,300,&rho,&blat,&lon,chisham);
+                       tplot.rxrise,300,&rho,&blat,&lon,&srng,chisham);
 
           if (magflg) RPosMag(0,tplot.bmnum,rng,site,tplot.frang,tplot.rsep,
-                              tplot.rxrise,300,&rho,&tlat,&lon,chisham,old_aacgm);
+                              tplot.rxrise,300,&rho,&tlat,&lon,&srng,chisham,old_aacgm);
           else RPosGeo(0,tplot.bmnum,rng,site,tplot.frang,tplot.rsep,
-                       tplot.rxrise,300,&rho,&tlat,&lon,chisham);
+                       tplot.rxrise,300,&rho,&tlat,&lon,&srng,chisham);
 
           if (tlat<blat) {
             tmp_swap=blat;

--- a/codebase/superdarn/src.dlm/rposdlm.1.9/rposdlm.c
+++ b/codebase/superdarn/src.dlm/rposdlm.1.9/rposdlm.c
@@ -885,7 +885,7 @@ static IDL_VPTR IDLRadarConvert(int type,int argc,IDL_VPTR *argv,char *argk) {
   struct RadarIDLSite *isite;
   int frang=180,rsep=45,rxrise=0;
   double height=300;
-  double rho,lat,lng;
+  double rho,lat,lng,srng;
 
   IDL_VPTR outargv[11];
   static IDL_LONG chisham;
@@ -1140,7 +1140,7 @@ static IDL_VPTR IDLRadarConvert(int type,int argc,IDL_VPTR *argv,char *argk) {
     if (type !=0) RPosGeoGS(center,bcrd,rcrd,&site,frang,rsep,rxrise,height,
                             &rho,&lat,&lng);
     else RPosGeo(center,bcrd,rcrd,&site,frang,rsep,rxrise,height,
-                 &rho,&lat,&lng,chisham);
+                 &rho,&lat,&lng,&srng,chisham);
 
      rptr[n]=rho;
      latptr[n]=lat;
@@ -1170,7 +1170,7 @@ static IDL_VPTR IDLRadarConvert(int type,int argc,IDL_VPTR *argv,char *argk) {
     if (type !=0) RPosGeoGS(center,bcrd,rcrd,&site,frang,rsep,rxrise,height,
                             &rho,&lat,&lng);
     else RPosGeo(center,bcrd,rcrd,&site,frang,rsep,rxrise,height,
-                 &rho,&lat,&lng,chisham);
+                 &rho,&lat,&lng,&srng,chisham);
 
     IDL_StoreScalar(argv[8],IDL_TYP_DOUBLE,(IDL_ALLTYPES *) &rho);
     IDL_StoreScalar(argv[9],IDL_TYP_DOUBLE,(IDL_ALLTYPES *) &lat);

--- a/codebase/superdarn/src.idl/lib/main.1.25/cnvmap.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/cnvmap.pro
@@ -217,7 +217,7 @@ function CnvMapRead,unit,prm,stvec,gvec,mvec,coef,bvec
            'program.id','noise.mean','noise.sd','gsct', $
            'v.min','v.max','p.min','p.max','w.min','w.max','ve.min', $
            've.max', $
-           'vector.mlat','vector.mlon','vector.kvect', $
+           'vector.mlat','vector.mlon','vector.kvect','vector.srng', $
            'vector.stid','vector.channel','vector.index', $
            'vector.vel.median','vector.vel.sd', $
            'vector.pwr.median','vector.pwr.sd', $
@@ -228,7 +228,7 @@ function CnvMapRead,unit,prm,stvec,gvec,mvec,coef,bvec
            
 
   arrtype=[2,2,2,4,2,2,2,4,4,2,4,4,4,4,4,4,4,4, $
-           4,4,4,2,2,3,4,4,4,4,4,4,8,8,8,8,4,4,4,4,4,4]
+           4,4,4,4,2,2,3,4,4,4,4,4,4,8,8,8,8,4,4,4,4,4,4]
 
   arrid=intarr(n_elements(arrname))  
   arrid[*]=-1
@@ -351,47 +351,48 @@ function CnvMapRead,unit,prm,stvec,gvec,mvec,coef,bvec
     gvec[*].mlat=(*(arrvec[arrid[18]].ptr))[*]
     gvec[*].mlon=(*(arrvec[arrid[19]].ptr))[*]
     gvec[*].azm=(*(arrvec[arrid[20]].ptr))[*]
-    gvec[*].st_id=(*(arrvec[arrid[21]].ptr))[*]
-    gvec[*].chn=(*(arrvec[arrid[22]].ptr))[*]
-    gvec[*].index=(*(arrvec[arrid[23]].ptr))[*]
+    gvec[*].srng=(*(arrvec[arrid[21]].ptr))[*]
+    gvec[*].st_id=(*(arrvec[arrid[22]].ptr))[*]
+    gvec[*].chn=(*(arrvec[arrid[23]].ptr))[*]
+    gvec[*].index=(*(arrvec[arrid[24]].ptr))[*]
  
-    gvec[*].vel.median=(*(arrvec[arrid[24]].ptr))[*]
-    gvec[*].vel.sd=(*(arrvec[arrid[25]].ptr))[*]
+    gvec[*].vel.median=(*(arrvec[arrid[25]].ptr))[*]
+    gvec[*].vel.sd=(*(arrvec[arrid[26]].ptr))[*]
 
-    if arrid[26] ne -1 then begin
+    if arrid[27] ne -1 then begin
       prm.xtd=1
-      gvec[*].pwr.median=(*(arrvec[arrid[26]].ptr))[*]
-      gvec[*].pwr.sd=(*(arrvec[arrid[27]].ptr))[*]
-      gvec[*].wdt.median=(*(arrvec[arrid[28]].ptr))[*]
-      gvec[*].wdt.sd=(*(arrvec[arrid[29]].ptr))[*]
+      gvec[*].pwr.median=(*(arrvec[arrid[27]].ptr))[*]
+      gvec[*].pwr.sd=(*(arrvec[arrid[28]].ptr))[*]
+      gvec[*].wdt.median=(*(arrvec[arrid[29]].ptr))[*]
+      gvec[*].wdt.sd=(*(arrvec[arrid[30]].ptr))[*]
     endif
   endif
 
-  if arrid[30] ne -1 then begin
-    prm.coefnum=N_ELEMENTS(*(arrvec[arrid[30]].ptr))
+  if arrid[31] ne -1 then begin
+    prm.coefnum=N_ELEMENTS(*(arrvec[arrid[31]].ptr))
     coef=dblarr(prm.coefnum,4)
-    coef[*,0]=(*(arrvec[arrid[30]].ptr))[*]
-    coef[*,1]=(*(arrvec[arrid[31]].ptr))[*]
-    coef[*,2]=(*(arrvec[arrid[32]].ptr))[*]
-    coef[*,3]=(*(arrvec[arrid[33]].ptr))[*]
+    coef[*,0]=(*(arrvec[arrid[31]].ptr))[*]
+    coef[*,1]=(*(arrvec[arrid[32]].ptr))[*]
+    coef[*,2]=(*(arrvec[arrid[33]].ptr))[*]
+    coef[*,3]=(*(arrvec[arrid[34]].ptr))[*]
   endif
 
-  if arrid[34] ne -1 then begin
+  if arrid[35] ne -1 then begin
     GridMakeGVec,mvec
-    prm.modnum=N_ELEMENTS(*(arrvec[arrid[34]].ptr))
+    prm.modnum=N_ELEMENTS(*(arrvec[arrid[35]].ptr))
     mvec=replicate(mvec,prm.modnum)
-    mvec[*].mlat=(*(arrvec[arrid[34]].ptr))[*]
-    mvec[*].mlon=(*(arrvec[arrid[35]].ptr))[*]
-    mvec[*].azm=(*(arrvec[arrid[36]].ptr))[*] 
-    mvec[*].vel.median=(*(arrvec[arrid[37]].ptr))[*]
+    mvec[*].mlat=(*(arrvec[arrid[35]].ptr))[*]
+    mvec[*].mlon=(*(arrvec[arrid[36]].ptr))[*]
+    mvec[*].azm=(*(arrvec[arrid[37]].ptr))[*] 
+    mvec[*].vel.median=(*(arrvec[arrid[38]].ptr))[*]
   endif
   
-  if arrid[38] ne -1 then begin
+  if arrid[39] ne -1 then begin
     CnvMapMakeBnd,bvec
-    prm.bndnum=N_ELEMENTS(*(arrvec[arrid[38]].ptr))
+    prm.bndnum=N_ELEMENTS(*(arrvec[arrid[39]].ptr))
     bvec=replicate(bvec,prm.bndnum)
-    bvec[*].lat=(*(arrvec[arrid[38]].ptr))[*]
-    bvec[*].lon=(*(arrvec[arrid[39]].ptr))[*]
+    bvec[*].lat=(*(arrvec[arrid[39]].ptr))[*]
+    bvec[*].lon=(*(arrvec[arrid[40]].ptr))[*]
   endif
 
   st=DataMapFreeScalar(sclvec)
@@ -509,6 +510,7 @@ function CnvMapWrite,unit,prm,stvec,gvec,mvec,coef,bvec
     s=DataMapMakeArray('vector.mlat',gvec[0:vcnum-1].mlat,arrvec)
     s=DataMapMakeArray('vector.mlon',gvec[0:vcnum-1].mlon,arrvec)
     s=DataMapMakeArray('vector.kvect',gvec[0:vcnum-1].azm,arrvec)
+    s=DataMapMakeArray('vector.srng',gvec[0:vcnum-1].srng,arrvec)
     s=DataMapMakeArray('vector.stid',gvec[0:vcnum-1].st_id,arrvec)
     s=DataMapMakeArray('vector.channel',gvec[0:vcnum-1].chn,arrvec)
     s=DataMapMakeArray('vector.index',gvec[0:vcnum-1].index,arrvec)

--- a/codebase/superdarn/src.idl/lib/main.1.25/grd.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/grd.pro
@@ -138,6 +138,7 @@ pro GridMakeGVec,gvec
    gvec={GridGVec, mlat:0.0, $
                    mlon:0.0, $
                    azm: 0.0, $
+                   srng: 0.0, $
                    vel: {GridValue,median:0.0,sd:0.0}, $
                    pwr: {GridValue,median:0.0,sd:0.0}, $
                    wdt: {GridValue,median:0.0,sd:0.0}, $
@@ -198,13 +199,13 @@ function GridRead,unit,prm,stvec,gvec
            'program.id','noise.mean','noise.sd','gsct', $
            'v.min','v.max','p.min','p.max','w.min','w.max','ve.min', $
            've.max', $
-           'vector.mlat','vector.mlon','vector.kvect', $
+           'vector.mlat','vector.mlon','vector.kvect','vector.srng', $
            'vector.stid','vector.channel','vector.index', $
            'vector.vel.median','vector.vel.sd', $
            'vector.pwr.median','vector.pwr.sd', $
            'vector.wdt.median','vector.wdt.sd']
 
-  arrtype=[2,2,2,4,2,2,2,4,4,2,4,4,4,4,4,4,4,4,4,4,4,2,2,3,4,4,4,4,4,4]
+  arrtype=[2,2,2,4,2,2,2,4,4,2,4,4,4,4,4,4,4,4,4,4,4,4,2,2,3,4,4,4,4,4,4]
 
   arrid=intarr(n_elements(arrname))  
   arrid[*]=-1
@@ -277,19 +278,20 @@ function GridRead,unit,prm,stvec,gvec
     gvec[*].mlat=(*(arrvec[arrid[18]].ptr))[*]
     gvec[*].mlon=(*(arrvec[arrid[19]].ptr))[*]
     gvec[*].azm=(*(arrvec[arrid[20]].ptr))[*]
-    gvec[*].st_id=(*(arrvec[arrid[21]].ptr))[*]
-    gvec[*].chn=(*(arrvec[arrid[22]].ptr))[*]
-    gvec[*].index=(*(arrvec[arrid[23]].ptr))[*]
+    gvec[*].srng=(*(arrvec[arrid[21]].ptr))[*]
+    gvec[*].st_id=(*(arrvec[arrid[22]].ptr))[*]
+    gvec[*].chn=(*(arrvec[arrid[23]].ptr))[*]
+    gvec[*].index=(*(arrvec[arrid[24]].ptr))[*]
  
-    gvec[*].vel.median=(*(arrvec[arrid[24]].ptr))[*]
-    gvec[*].vel.sd=(*(arrvec[arrid[25]].ptr))[*]
+    gvec[*].vel.median=(*(arrvec[arrid[25]].ptr))[*]
+    gvec[*].vel.sd=(*(arrvec[arrid[26]].ptr))[*]
 
-    if arrid[26] ne -1 then begin
+    if arrid[27] ne -1 then begin
       prm.xtd=1
-      gvec[*].pwr.median=(*(arrvec[arrid[26]].ptr))[*]
-      gvec[*].pwr.sd=(*(arrvec[arrid[27]].ptr))[*]
-      gvec[*].wdt.median=(*(arrvec[arrid[28]].ptr))[*]
-      gvec[*].wdt.sd=(*(arrvec[arrid[29]].ptr))[*]
+      gvec[*].pwr.median=(*(arrvec[arrid[27]].ptr))[*]
+      gvec[*].pwr.sd=(*(arrvec[arrid[28]].ptr))[*]
+      gvec[*].wdt.median=(*(arrvec[arrid[29]].ptr))[*]
+      gvec[*].wdt.sd=(*(arrvec[arrid[30]].ptr))[*]
     endif
   endif
 
@@ -365,6 +367,7 @@ function GridWrite,unit,prm,stvec,gvec
     s=DataMapMakeArray('vector.mlat',gvec[0:vcnum-1].mlat,arrvec)
     s=DataMapMakeArray('vector.mlon',gvec[0:vcnum-1].mlon,arrvec)
     s=DataMapMakeArray('vector.kvect',gvec[0:vcnum-1].azm,arrvec)
+    s=DataMapMakeArray('vector.srng',gvec[0:vcnum-1].srng,arrvec)
     s=DataMapMakeArray('vector.stid',gvec[0:vcnum-1].st_id,arrvec)
     s=DataMapMakeArray('vector.channel',gvec[0:vcnum-1].chn,arrvec)
     s=DataMapMakeArray('vector.index',gvec[0:vcnum-1].index,arrvec)

--- a/codebase/superdarn/src.lib/tk/binplotlib.1.0/src/geobeam.c
+++ b/codebase/superdarn/src.lib/tk/binplotlib.1.0/src/geobeam.c
@@ -36,9 +36,9 @@ int GeoLocCenter(struct RadarSite *site,int mag,float *lat,float *lon,
                  int chisham,int old_aacgm) {
 
     int s;
-    double glat,glon,mlat,mlon,rho;
+    double glat,glon,mlat,mlon,rho,srng;
     RPosGeo(0,8,35,site,180,45,100,
-            300.0,&rho,&glat,&glon,chisham);
+            300.0,&rho,&glat,&glon,&srng,chisham);
 
     if (mag) { 
         if (old_aacgm) 
@@ -75,7 +75,7 @@ int GeoLocBeam(struct RadarSite *site,int year,
     int n,s,x;
     int rng;
     double rho,lat,lon,glat,glon,mlat,mlon;
-    double geoazm,elv,magazm;
+    double geoazm,elv,magazm,srng;
 
     for (n=0;n<geol->num;n++) {
         if (geol->bm[n].bm !=bm->bm) continue;
@@ -114,16 +114,16 @@ int GeoLocBeam(struct RadarSite *site,int year,
 
     for (rng=0;rng<=bm->nrang;rng++) {
         RPosGeo(0,bm->bm,rng,site,bm->frang,bm->rsep,bm->rxrise,
-                300.0,&rho,&lat,&lon,chisham);
+                300.0,&rho,&lat,&lon,&srng,chisham);
         geol->bm[n].glat[0][rng]=lat;
         geol->bm[n].glon[0][rng]=lon;
         RPosGeo(0,bm->bm+1,rng,site,bm->frang,bm->rsep,bm->rxrise,
-                300.0,&rho,&lat,&lon,chisham);
+                300.0,&rho,&lat,&lon,&srng,chisham);
         geol->bm[n].glat[2][rng]=lat;
         geol->bm[n].glon[2][rng]=lon;
         if (rng<bm->nrang) {
             RPosGeo(1,bm->bm,rng,site,bm->frang,bm->rsep,bm->rxrise,
-                    300.0,&rho,&lat,&lon,chisham);
+                    300.0,&rho,&lat,&lon,&srng,chisham);
             geol->bm[n].glat[1][rng]=lat;
             geol->bm[n].glon[1][rng]=lon;
             RPosRngBmAzmElv(bm->bm,rng,year,site,
@@ -161,7 +161,7 @@ int GeoLocBeam(struct RadarSite *site,int year,
         geol->bm[n].mlon[2][rng]=mlon;
         if (rng<bm->nrang) {
             RPosInvMag(bm->bm,rng,year,site,bm->frang,bm->rsep,bm->rxrise,
-                       300.0,&mlat,&mlon,&magazm,chisham,old_aacgm);
+                       300.0,&mlat,&mlon,&magazm,&srng,chisham,old_aacgm);
             geol->bm[n].mlat[1][rng]=mlat;
             geol->bm[n].mlon[1][rng]=mlon;
             geol->bm[n].mazm[rng]=magazm;

--- a/codebase/superdarn/src.lib/tk/binplotlib.1.0/src/make_fov.c
+++ b/codebase/superdarn/src.lib/tk/binplotlib.1.0/src/make_fov.c
@@ -39,7 +39,7 @@ Modifications:
 struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
                              float alt,int chisham) {
 
-    double rho,lat,lon;
+    double rho,lat,lon,srng;
     int i,rn,bm;
     float pnt[2];
     int yr,mo,dy,hr,mt;
@@ -62,7 +62,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
 
         for (rn=0;rn<=maxrange;rn++) {
             RPosGeo(0,0,rn,site,frang,rsep,
-                    site->recrise,alt,&rho,&lat,&lon,chisham);
+                    site->recrise,alt,&rho,&lat,&lon,&srng,chisham);
             pnt[0]=lat;
             pnt[1]=lon;
             PolygonAdd(ptr,pnt);
@@ -70,7 +70,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
 
         for (bm=1;bm<=site->maxbeam;bm++) {
             RPosGeo(0,bm,maxrange,site,frang,rsep,
-                    site->recrise,alt,&rho,&lat,&lon,chisham);
+                    site->recrise,alt,&rho,&lat,&lon,&srng,chisham);
             pnt[0]=lat;
             pnt[1]=lon;
             PolygonAdd(ptr,pnt);
@@ -78,7 +78,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
 
         for (rn=maxrange-1;rn>=0;rn--) {
             RPosGeo(0,site->maxbeam,rn,site,frang,rsep,
-                    site->recrise,alt,&rho,&lat,&lon,chisham);
+                    site->recrise,alt,&rho,&lat,&lon,&srng,chisham);
             pnt[0]=lat;
             pnt[1]=lon;
             PolygonAdd(ptr,pnt);
@@ -86,7 +86,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
 
         for (bm=site->maxbeam-1;bm>0;bm--) {
             RPosGeo(0,bm,0,site,frang,rsep,
-                    site->recrise,alt,&rho,&lat,&lon,chisham);
+                    site->recrise,alt,&rho,&lat,&lon,&srng,chisham);
             pnt[0]=lat;
             pnt[1]=lon;
             PolygonAdd(ptr,pnt);
@@ -99,7 +99,7 @@ struct PolygonData *make_fov(double tval,struct RadarNetwork *network,
 struct PolygonData *make_field_fov(double tval,struct RadarNetwork *network,
                                    int id,int chisham) {
 
-    double rho,lat,lon;
+    double rho,lat,lon,srng;
     int i,rn,bm;
     float pnt[2];
     int yr,mo,dy,hr,mt;
@@ -124,7 +124,7 @@ struct PolygonData *make_field_fov(double tval,struct RadarNetwork *network,
 
         for (rn=0;rn<=maxrange;rn++) {
             RPosGeo(0,0,rn,site,frang,rsep,
-                    site->recrise,0,&rho,&lat,&lon,chisham);
+                    site->recrise,0,&rho,&lat,&lon,&srng,chisham);
             pnt[0]=lat;
             pnt[1]=lon;
             PolygonAdd(ptr,pnt);
@@ -132,7 +132,7 @@ struct PolygonData *make_field_fov(double tval,struct RadarNetwork *network,
 
         for (bm=1;bm<=site->maxbeam;bm++) {
             RPosGeo(0,bm,maxrange,site,frang,rsep,
-                    site->recrise,0,&rho,&lat,&lon,chisham);
+                    site->recrise,0,&rho,&lat,&lon,&srng,chisham);
             pnt[0]=lat;
             pnt[1]=lon;
             PolygonAdd(ptr,pnt);
@@ -140,7 +140,7 @@ struct PolygonData *make_field_fov(double tval,struct RadarNetwork *network,
 
         for (rn=maxrange-1;rn>=0;rn--) {
             RPosGeo(0,site->maxbeam,rn,site,frang,rsep,
-                    site->recrise,0,&rho,&lat,&lon,chisham);
+                    site->recrise,0,&rho,&lat,&lon,&srng,chisham);
             pnt[0]=lat;
             pnt[1]=lon;
             PolygonAdd(ptr,pnt);
@@ -148,7 +148,7 @@ struct PolygonData *make_field_fov(double tval,struct RadarNetwork *network,
 
         for (bm=site->maxbeam-1;bm>0;bm--) {
             RPosGeo(0,bm,0,site,frang,rsep,
-                    site->recrise,0,&rho,&lat,&lon,chisham);
+                    site->recrise,0,&rho,&lat,&lon,&srng,chisham);
             pnt[0]=lat;
             pnt[1]=lon;
             PolygonAdd(ptr,pnt);
@@ -162,7 +162,7 @@ struct PolygonData *make_field_fov(double tval,struct RadarNetwork *network,
 struct PolygonData *make_grid_fov(double tval,struct RadarNetwork *network,
                                   int chisham,int old_aacgm) {
 
-    double rho,lat,lon;
+    double rho,lat,lon,srng;
     int i,rn,bm;
     float pnt[2];
     int yr,mo,dy,hr,mt;
@@ -186,7 +186,7 @@ struct PolygonData *make_grid_fov(double tval,struct RadarNetwork *network,
 
         for (rn=0;rn<=maxrange;rn++) {
             RPosMag(0,0,rn,site,frang,rsep,
-                    site->recrise,0,&rho,&lat,&lon,
+                    site->recrise,0,&rho,&lat,&lon,&srng,
                     chisham,old_aacgm);
             pnt[0]=lat;
             pnt[1]=lon;
@@ -195,7 +195,7 @@ struct PolygonData *make_grid_fov(double tval,struct RadarNetwork *network,
 
         for (bm=1;bm<=site->maxbeam;bm++) {
             RPosMag(0,bm,maxrange,site,frang,rsep,
-                    site->recrise,0,&rho,&lat,&lon,
+                    site->recrise,0,&rho,&lat,&lon,&srng,
                     chisham,old_aacgm);
             pnt[0]=lat;
             pnt[1]=lon;
@@ -204,7 +204,7 @@ struct PolygonData *make_grid_fov(double tval,struct RadarNetwork *network,
 
         for (rn=maxrange-1;rn>=0;rn--) {
             RPosMag(0,site->maxbeam,rn,site,frang,rsep,
-                    site->recrise,0,&rho,&lat,&lon,
+                    site->recrise,0,&rho,&lat,&lon,&srng,
                     chisham,old_aacgm);
             pnt[0]=lat;
             pnt[1]=lon;
@@ -213,7 +213,7 @@ struct PolygonData *make_grid_fov(double tval,struct RadarNetwork *network,
 
         for (bm=site->maxbeam-1;bm>0;bm--) {
             RPosMag(0,bm,0,site,frang,rsep,
-                    site->recrise,0,&rho,&lat,&lon,
+                    site->recrise,0,&rho,&lat,&lon,&srng,
                     chisham,old_aacgm);
             pnt[0]=lat;
             pnt[1]=lon;
@@ -229,7 +229,7 @@ struct PolygonData *make_grid_fov(double tval,struct RadarNetwork *network,
 struct PolygonData *make_grid_fov_data(struct GridData *gptr,struct RadarNetwork *network,
                                        int chisham,int old_aacgm) {
 
-    double rho,lat,lon;
+    double rho,lat,lon,srng;
     int i,j,rn,bm;
     float pnt[2];
     int yr,mo,dy,hr,mt;
@@ -260,7 +260,7 @@ struct PolygonData *make_grid_fov_data(struct GridData *gptr,struct RadarNetwork
 
             for (rn=0;rn<=maxrange;rn++) {
                 RPosMag(0,0,rn,site,frang,rsep,
-                        site->recrise,0,&rho,&lat,&lon,
+                        site->recrise,0,&rho,&lat,&lon,&srng,
                         chisham,old_aacgm);
                 pnt[0]=lat;
                 pnt[1]=lon;
@@ -269,7 +269,7 @@ struct PolygonData *make_grid_fov_data(struct GridData *gptr,struct RadarNetwork
 
             for (bm=1;bm<=site->maxbeam;bm++) {
                 RPosMag(0,bm,maxrange,site,frang,rsep,
-                        site->recrise,0,&rho,&lat,&lon,
+                        site->recrise,0,&rho,&lat,&lon,&srng,
                         chisham,old_aacgm);
                 pnt[0]=lat;
                 pnt[1]=lon;
@@ -278,7 +278,7 @@ struct PolygonData *make_grid_fov_data(struct GridData *gptr,struct RadarNetwork
 
             for (rn=maxrange-1;rn>=0;rn--) {
                 RPosMag(0,site->maxbeam,rn,site,frang,rsep,
-                        site->recrise,0,&rho,&lat,&lon,
+                        site->recrise,0,&rho,&lat,&lon,&srng,
                         chisham,old_aacgm);
                 pnt[0]=lat;
                 pnt[1]=lon;
@@ -287,7 +287,7 @@ struct PolygonData *make_grid_fov_data(struct GridData *gptr,struct RadarNetwork
 
             for (bm=site->maxbeam-1;bm>0;bm--) {
                 RPosMag(0,bm,0,site,frang,rsep,
-                        site->recrise,0,&rho,&lat,&lon,
+                        site->recrise,0,&rho,&lat,&lon,&srng,
                         chisham,old_aacgm);
                 pnt[0]=lat;
                 pnt[1]=lon;

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/readmap.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/readmap.c
@@ -137,7 +137,7 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
                  "program.id","noise.mean","noise.sd","gsct",
                  "v.min","v.max","p.min","p.max","w.min","w.max","ve.min",
                  "ve.max",
-                 "vector.mlat","vector.mlon","vector.kvect",
+                 "vector.mlat","vector.mlon","vector.kvect","vector.srng",
                  "vector.stid","vector.channel","vector.index",
                  "vector.vel.median","vector.vel.sd",
                  "vector.pwr.median","vector.pwr.sd",
@@ -152,7 +152,7 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
                DATASHORT,DATAFLOAT,DATAFLOAT,DATASHORT,
                DATAFLOAT,DATAFLOAT,DATAFLOAT,DATAFLOAT,DATAFLOAT,DATAFLOAT,
                DATAFLOAT,DATAFLOAT,
-               DATAFLOAT,DATAFLOAT,DATAFLOAT,
+               DATAFLOAT,DATAFLOAT,DATAFLOAT,DATAFLOAT,
                DATASHORT,DATASHORT,DATAINT,
                DATAFLOAT,DATAFLOAT,
                DATAFLOAT,DATAFLOAT,
@@ -161,7 +161,7 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
                DATAFLOAT,DATAFLOAT,DATAFLOAT,DATAFLOAT,
                DATAFLOAT,DATAFLOAT};
 
-  struct DataMapArray *adata[50];
+  struct DataMapArray *adata[41];
 
   ptr=DataMapReadBlock(fid,&size);
 
@@ -361,26 +361,28 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
       grd->data[n].mlat=adata[18]->data.fptr[n];
       grd->data[n].mlon=adata[19]->data.fptr[n];
       grd->data[n].azm=adata[20]->data.fptr[n];
+      if (adata[21] !=NULL) grd->data[n].srng=adata[21]->data.fptr[n];
+      else grd->data[n].srng=0;
 
-      grd->data[n].st_id=adata[21]->data.sptr[n];
-      grd->data[n].chn=adata[22]->data.sptr[n];
-      grd->data[n].index=adata[23]->data.iptr[n];
-      grd->data[n].vel.median=adata[24]->data.fptr[n];
-      grd->data[n].vel.sd=adata[25]->data.fptr[n];
+      grd->data[n].st_id=adata[22]->data.sptr[n];
+      grd->data[n].chn=adata[23]->data.sptr[n];
+      grd->data[n].index=adata[24]->data.iptr[n];
+      grd->data[n].vel.median=adata[25]->data.fptr[n];
+      grd->data[n].vel.sd=adata[26]->data.fptr[n];
       grd->data[n].pwr.median=0;
       grd->data[n].pwr.sd=0;
       grd->data[n].wdt.median=0;
       grd->data[n].wdt.sd=0;
 
-      if (adata[26] !=NULL) grd->data[n].pwr.median=adata[26]->data.fptr[n];
-      if (adata[27] !=NULL) grd->data[n].pwr.sd=adata[27]->data.fptr[n];
-      if (adata[28] !=NULL) grd->data[n].wdt.median=adata[28]->data.fptr[n];
-      if (adata[29] !=NULL) grd->data[n].wdt.sd=adata[29]->data.fptr[n];
+      if (adata[27] !=NULL) grd->data[n].pwr.median=adata[27]->data.fptr[n];
+      if (adata[28] !=NULL) grd->data[n].pwr.sd=adata[28]->data.fptr[n];
+      if (adata[29] !=NULL) grd->data[n].wdt.median=adata[29]->data.fptr[n];
+      if (adata[30] !=NULL) grd->data[n].wdt.sd=adata[30]->data.fptr[n];
     }
   }
 
-  if (adata[30] !=NULL) {
-   map->num_coef=adata[30]->rng[0];
+  if (adata[31] !=NULL) {
+   map->num_coef=adata[31]->rng[0];
    if (map->coef !=NULL) {
       tmp=realloc(map->coef,sizeof(double)*4*map->num_coef);
       if (tmp==NULL) {
@@ -400,16 +402,16 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
   }
   if (map->coef !=NULL) {
     for (n=0;n<map->num_coef;n++) {
-       map->coef[4*n]=adata[30]->data.dptr[n];
-       map->coef[4*n+1]=adata[31]->data.dptr[n];
-       map->coef[4*n+2]=adata[32]->data.dptr[n];
-       map->coef[4*n+3]=adata[33]->data.dptr[n];
+       map->coef[4*n]=adata[31]->data.dptr[n];
+       map->coef[4*n+1]=adata[32]->data.dptr[n];
+       map->coef[4*n+2]=adata[33]->data.dptr[n];
+       map->coef[4*n+3]=adata[34]->data.dptr[n];
     }
   }
 
 
-  if (adata[34] !=NULL) {
-   map->num_model=adata[34]->rng[0];
+  if (adata[35] !=NULL) {
+   map->num_model=adata[35]->rng[0];
    if (map->model !=NULL) {
       tmp=realloc(map->model,sizeof(struct GridGVec)*map->num_model);
       if (tmp==NULL) {
@@ -429,10 +431,11 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
   }
   if (map->model !=NULL) {
     for (n=0;n<map->num_model;n++) {
-      map->model[n].mlat=adata[34]->data.fptr[n];
-      map->model[n].mlon=adata[35]->data.fptr[n];
-      map->model[n].azm=adata[36]->data.fptr[n];
-      map->model[n].vel.median=adata[37]->data.fptr[n];
+      map->model[n].mlat=adata[35]->data.fptr[n];
+      map->model[n].mlon=adata[36]->data.fptr[n];
+      map->model[n].azm=adata[37]->data.fptr[n];
+      map->model[n].srng=0;
+      map->model[n].vel.median=adata[38]->data.fptr[n];
       map->model[n].vel.sd=0;
       map->model[n].pwr.median=0;
       map->model[n].pwr.sd=0;
@@ -445,9 +448,9 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
   }
 
 
-  if (adata[38] !=NULL) {
+  if (adata[39] !=NULL) {
 
-    map->num_bnd=adata[38]->rng[0];
+    map->num_bnd=adata[39]->rng[0];
     if (map->bnd_lat !=NULL) {
        tmp=realloc(map->bnd_lat,sizeof(double)*map->num_bnd);
        if (tmp==NULL) {
@@ -481,8 +484,8 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
    }
    if (map->bnd_lat !=NULL) {
      for (n=0;n<map->num_bnd;n++) {
-        map->bnd_lat[n]=adata[38]->data.fptr[n];
-        map->bnd_lon[n]=adata[39]->data.fptr[n];
+        map->bnd_lat[n]=adata[39]->data.fptr[n];
+        map->bnd_lon[n]=adata[40]->data.fptr[n];
      }
   }
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/writemap.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/writemap.c
@@ -94,6 +94,7 @@ int CnvMapWrite(int fid,struct CnvMapData *map,struct GridData *grd) {
   float *gmlon=NULL;
   float *gmlat=NULL;
   float *kvect=NULL;
+  float *srng=NULL;
   int16 *vstid=NULL;
   int16 *vchn=NULL;
   int32 *index=NULL;
@@ -137,7 +138,7 @@ int CnvMapWrite(int fid,struct CnvMapData *map,struct GridData *grd) {
 
   for (n=0;n<grd->vcnum;n++) if (grd->data[n].st_id !=-1) npnt++;
 
-  size+=npnt*(3*sizeof(float)+sizeof(int32)*2*sizeof(int16)+
+  size+=npnt*(4*sizeof(float)+sizeof(int32)*2*sizeof(int16)+
                       (2+4*xtd)*sizeof(float));
 
   size+=map->num_coef*4*sizeof(double);
@@ -220,6 +221,8 @@ int CnvMapWrite(int fid,struct CnvMapData *map,struct GridData *grd) {
     bptr+=npnt*sizeof(float);
     kvect=(float *) bptr;
     bptr+=npnt*sizeof(float);
+    srng=(float *) bptr;
+    bptr+=npnt*sizeof(float);
     vstid=(int16 *) bptr;
     bptr+=npnt*sizeof(int16);
     vchn=(int16 *)  bptr;
@@ -246,6 +249,7 @@ int CnvMapWrite(int fid,struct CnvMapData *map,struct GridData *grd) {
       gmlat[n]=grd->data[p].mlat;
       gmlon[n]=grd->data[p].mlon;
       kvect[n]=grd->data[p].azm;
+      srng[n]=grd->data[p].srng;
       vstid[n]=grd->data[p].st_id;
       vchn[n]=grd->data[p].chn;
       index[n]=grd->data[p].index;
@@ -440,6 +444,7 @@ int CnvMapWrite(int fid,struct CnvMapData *map,struct GridData *grd) {
     DataMapAddArray(data,"vector.mlat",DATAFLOAT,1,&npnt,gmlat);
     DataMapAddArray(data,"vector.mlon",DATAFLOAT,1,&npnt,gmlon);
     DataMapAddArray(data,"vector.kvect",DATAFLOAT,1,&npnt,kvect);
+    DataMapAddArray(data,"vector.srng",DATAFLOAT,1,&npnt,srng);
     DataMapAddArray(data,"vector.stid",DATASHORT,1,&npnt,vstid);
     DataMapAddArray(data,"vector.channel",DATASHORT,1,&npnt,vchn);
     DataMapAddArray(data,"vector.index",DATAINT,1,&npnt,index);

--- a/codebase/superdarn/src.lib/tk/grid.1.24/include/griddata.h
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/include/griddata.h
@@ -59,6 +59,7 @@ struct GridSVec {
 struct GridGVec {
     double mlat,mlon;
     double azm;
+    double srng;
     struct {
         double median;
         double sd;

--- a/codebase/superdarn/src.lib/tk/grid.1.24/src/avggrid.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/src/avggrid.c
@@ -96,6 +96,7 @@ void GridAverage(struct GridData *mptr,struct GridData *ptr,int flg) {
         else ptr->data=realloc(ptr->data,sizeof(struct GridGVec)*ptr->vcnum);
 
         ptr->data[k].azm=mptr->data[i].azm;
+        ptr->data[k].srng=mptr->data[i].srng;
         ptr->data[k].vel.median=mptr->data[i].vel.median;
         ptr->data[k].vel.sd=mptr->data[i].vel.sd;
         ptr->data[k].pwr.median=mptr->data[i].pwr.median;
@@ -118,6 +119,7 @@ void GridAverage(struct GridData *mptr,struct GridData *ptr,int flg) {
                 ptr->data[k].mlon=mptr->data[i].mlon;
                 ptr->data[k].mlat=mptr->data[i].mlat;
                 ptr->data[k].azm+=mptr->data[i].azm;
+                ptr->data[k].srng+=mptr->data[i].srng;
 
 
                 ptr->data[k].vel.median+=mptr->data[i].vel.median;
@@ -134,6 +136,7 @@ void GridAverage(struct GridData *mptr,struct GridData *ptr,int flg) {
                 ptr->data[k].mlon=mptr->data[i].mlon;
                 ptr->data[k].mlat=mptr->data[i].mlat;
                 ptr->data[k].azm=mptr->data[i].azm;
+                ptr->data[k].srng=mptr->data[i].srng;
                 ptr->data[k].vel.median=mptr->data[i].vel.median;
                 ptr->data[k].vel.sd=mptr->data[i].vel.sd;
                 ptr->data[k].pwr.median=mptr->data[i].pwr.median;
@@ -147,6 +150,7 @@ void GridAverage(struct GridData *mptr,struct GridData *ptr,int flg) {
                 ptr->data[k].mlon=mptr->data[i].mlon;
                 ptr->data[k].mlat=mptr->data[i].mlat;
                 ptr->data[k].azm=mptr->data[i].azm;
+                ptr->data[k].srng=mptr->data[i].srng;
                 ptr->data[k].vel.median=mptr->data[i].vel.median;
                 ptr->data[k].vel.sd=mptr->data[i].vel.sd;
                 ptr->data[k].pwr.median=mptr->data[i].pwr.median;
@@ -160,6 +164,7 @@ void GridAverage(struct GridData *mptr,struct GridData *ptr,int flg) {
                 ptr->data[k].mlon=mptr->data[i].mlon;
                 ptr->data[k].mlat=mptr->data[i].mlat;
                 ptr->data[k].azm=mptr->data[i].azm;
+                ptr->data[k].srng=mptr->data[i].srng;
 
                 ptr->data[k].vel.median=mptr->data[i].vel.median;
                 ptr->data[k].vel.sd=mptr->data[i].vel.sd;
@@ -175,6 +180,7 @@ void GridAverage(struct GridData *mptr,struct GridData *ptr,int flg) {
                 ptr->data[k].mlon=mptr->data[i].mlon;
                 ptr->data[k].mlat=mptr->data[i].mlat;
                 ptr->data[k].azm=mptr->data[i].azm;
+                ptr->data[k].srng=mptr->data[i].srng;
 
                 ptr->data[k].vel.median=mptr->data[i].vel.median;
                 ptr->data[k].vel.sd=mptr->data[i].vel.sd;
@@ -190,6 +196,7 @@ void GridAverage(struct GridData *mptr,struct GridData *ptr,int flg) {
                 ptr->data[k].mlon=mptr->data[i].mlon;
                 ptr->data[k].mlat=mptr->data[i].mlat;
                 ptr->data[k].azm=mptr->data[i].azm;
+                ptr->data[k].srng=mptr->data[i].srng;
 
                 ptr->data[k].vel.median=mptr->data[i].vel.median;
                 ptr->data[k].vel.sd=mptr->data[i].vel.sd;
@@ -205,6 +212,7 @@ void GridAverage(struct GridData *mptr,struct GridData *ptr,int flg) {
                 ptr->data[k].mlon=mptr->data[i].mlon;
                 ptr->data[k].mlat=mptr->data[i].mlat;
                 ptr->data[k].azm=mptr->data[i].azm;
+                ptr->data[k].srng=mptr->data[i].srng;
 
                 ptr->data[k].vel.median=mptr->data[i].vel.median;
                 ptr->data[k].vel.sd=mptr->data[i].vel.sd;
@@ -221,6 +229,7 @@ void GridAverage(struct GridData *mptr,struct GridData *ptr,int flg) {
   if (flg==0) {
     for (i=0;i<ptr->vcnum;i++) {
       ptr->data[i].azm=ptr->data[i].azm/ptr->data[i].st_id;
+      ptr->data[i].srng=ptr->data[i].srng/ptr->data[i].st_id;
       ptr->data[i].vel.median=ptr->data[i].vel.median/ptr->data[i].st_id;
       ptr->data[i].vel.sd=ptr->data[i].vel.sd/ptr->data[i].st_id;
 

--- a/codebase/superdarn/src.lib/tk/grid.1.24/src/integrategrid.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/src/integrategrid.c
@@ -113,6 +113,7 @@ void GridIntegrate(struct GridData *a,struct GridData *b,double *err) {
         if (w_e<err[2]) w_e=err[2];
 
         a->data[pnt].azm+=b->data[m].azm;
+        a->data[pnt].srng+=b->data[m].srng;
         a->data[pnt].vel.median+=b->data[m].vel.median*1/(v_e*v_e);
         a->data[pnt].pwr.median+=b->data[m].pwr.median*1/(p_e*p_e);
         a->data[pnt].wdt.median+=b->data[m].wdt.median*1/(w_e*w_e);
@@ -123,6 +124,7 @@ void GridIntegrate(struct GridData *a,struct GridData *b,double *err) {
       }
 
       a->data[pnt].azm=a->data[pnt].azm/(l-k);
+      a->data[pnt].srng=a->data[pnt].srng/(l-k);
       
       a->data[pnt].vel.median=a->data[pnt].vel.median/a->data[pnt].vel.sd;
       a->data[pnt].wdt.median=a->data[pnt].wdt.median/a->data[pnt].wdt.sd;

--- a/codebase/superdarn/src.lib/tk/grid.1.24/src/mergegrid.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/src/mergegrid.c
@@ -170,6 +170,7 @@ void GridMerge(struct GridData *mptr,struct GridData *ptr) {
 
     ptr->data[ptr->vcnum].mlon=data[0]->mlon;
     ptr->data[ptr->vcnum].mlat=data[0]->mlat;
+    ptr->data[ptr->vcnum].srng=data[0]->srng;
     ptr->data[ptr->vcnum].vel.median=sqrt(vpar*vpar+vper*vper);
     ptr->data[ptr->vcnum].vel.sd=0;
     ptr->data[ptr->vcnum].pwr.median=0;

--- a/codebase/superdarn/src.lib/tk/grid.1.24/src/readgrid.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/src/readgrid.c
@@ -62,7 +62,7 @@ int GridRead(int fid,struct GridData *gp) {
                  "program.id","noise.mean","noise.sd","gsct",
                  "v.min","v.max","p.min","p.max","w.min","w.max","ve.min",
                  "ve.max",
-                 "vector.mlat","vector.mlon","vector.kvect",
+                 "vector.mlat","vector.mlon","vector.kvect","vector.srng",
                  "vector.stid","vector.channel","vector.index",
                  "vector.vel.median","vector.vel.sd",
                  "vector.pwr.median","vector.pwr.sd",
@@ -73,13 +73,13 @@ int GridRead(int fid,struct GridData *gp) {
                DATASHORT,DATAFLOAT,DATAFLOAT,DATASHORT,
                DATAFLOAT,DATAFLOAT,DATAFLOAT,DATAFLOAT,DATAFLOAT,DATAFLOAT,
                DATAFLOAT,DATAFLOAT,
-               DATAFLOAT,DATAFLOAT,DATAFLOAT,
+               DATAFLOAT,DATAFLOAT,DATAFLOAT,DATAFLOAT,
                DATASHORT,DATASHORT,DATAINT,
                DATAFLOAT,DATAFLOAT,
                DATAFLOAT,DATAFLOAT,
                DATAFLOAT,DATAFLOAT};
 
-  struct DataMapArray *adata[40];
+  struct DataMapArray *adata[31];
 
   ptr=DataMapReadBlock(fid,&size);
   if (ptr==NULL) return -1;
@@ -206,7 +206,7 @@ int GridRead(int fid,struct GridData *gp) {
 
   gp->xtd=0;
 
-  for (n=26;n<30;n++) if (adata[n] !=NULL) {
+  for (n=27;n<31;n++) if (adata[n] !=NULL) {
     gp->xtd=1;
     break;
   }
@@ -214,21 +214,23 @@ int GridRead(int fid,struct GridData *gp) {
     gp->data[n].mlat=adata[18]->data.fptr[n];
     gp->data[n].mlon=adata[19]->data.fptr[n];
     gp->data[n].azm=adata[20]->data.fptr[n];
+    if (adata[21] !=NULL) gp->data[n].srng=adata[21]->data.fptr[n];
+    else gp->data[n].srng=0;
     
-    gp->data[n].st_id=adata[21]->data.sptr[n];
-    gp->data[n].chn=adata[22]->data.sptr[n];
-    gp->data[n].index=adata[23]->data.iptr[n];
-    gp->data[n].vel.median=adata[24]->data.fptr[n];
-    gp->data[n].vel.sd=adata[25]->data.fptr[n];
+    gp->data[n].st_id=adata[22]->data.sptr[n];
+    gp->data[n].chn=adata[23]->data.sptr[n];
+    gp->data[n].index=adata[24]->data.iptr[n];
+    gp->data[n].vel.median=adata[25]->data.fptr[n];
+    gp->data[n].vel.sd=adata[26]->data.fptr[n];
     gp->data[n].pwr.median=0;
     gp->data[n].pwr.sd=0;
     gp->data[n].wdt.median=0;
     gp->data[n].wdt.sd=0;
 
-    if (adata[26] !=NULL) gp->data[n].pwr.median=adata[26]->data.fptr[n];
-    if (adata[27] !=NULL) gp->data[n].pwr.sd=adata[27]->data.fptr[n];
-    if (adata[28] !=NULL) gp->data[n].wdt.median=adata[28]->data.fptr[n];
-    if (adata[29] !=NULL) gp->data[n].wdt.sd=adata[29]->data.fptr[n];
+    if (adata[27] !=NULL) gp->data[n].pwr.median=adata[27]->data.fptr[n];
+    if (adata[28] !=NULL) gp->data[n].pwr.sd=adata[28]->data.fptr[n];
+    if (adata[29] !=NULL) gp->data[n].wdt.median=adata[29]->data.fptr[n];
+    if (adata[30] !=NULL) gp->data[n].wdt.sd=adata[30]->data.fptr[n];
     
   }
    

--- a/codebase/superdarn/src.lib/tk/grid.1.24/src/writegrid.c
+++ b/codebase/superdarn/src.lib/tk/grid.1.24/src/writegrid.c
@@ -72,6 +72,7 @@ int GridWrite(int fid,struct GridData *ptr) {
   float *gmlon=NULL;
   float *gmlat=NULL;
   float *kvect=NULL;
+  float *srng=NULL;
   int16 *vstid=NULL;
   int16 *vchn=NULL;
   int32 *index=NULL;
@@ -97,7 +98,7 @@ int GridWrite(int fid,struct GridData *ptr) {
 
   for (n=0;n<ptr->vcnum;n++) if (ptr->data[n].st_id !=-1) npnt++;
 
-  size+=npnt*(3*sizeof(float)+sizeof(int32)+
+  size+=npnt*(4*sizeof(float)+sizeof(int32)+
               2*sizeof(int16)+(2+4*xtd)*sizeof(float));
   if (size==0) return 0;
   buf=malloc(size);
@@ -175,6 +176,8 @@ int GridWrite(int fid,struct GridData *ptr) {
     bptr+=npnt*sizeof(float);
     kvect=(float *) bptr;
     bptr+=npnt*sizeof(float);
+    srng=(float *) bptr;
+    bptr+=npnt*sizeof(float);
     vstid=(int16 *) bptr;
     bptr+=npnt*sizeof(int16);
     vchn=(int16 *)  bptr;
@@ -201,6 +204,7 @@ int GridWrite(int fid,struct GridData *ptr) {
       gmlat[n]=ptr->data[p].mlat;
       gmlon[n]=ptr->data[p].mlon;
       kvect[n]=ptr->data[p].azm;
+      srng[n]=ptr->data[p].srng;
       vstid[n]=ptr->data[p].st_id;
       vchn[n]=ptr->data[p].chn;
       index[n]=ptr->data[p].index;
@@ -270,6 +274,7 @@ int GridWrite(int fid,struct GridData *ptr) {
     DataMapAddArray(data,"vector.mlat",DATAFLOAT,1,&npnt,gmlat);
     DataMapAddArray(data,"vector.mlon",DATAFLOAT,1,&npnt,gmlon);
     DataMapAddArray(data,"vector.kvect",DATAFLOAT,1,&npnt,kvect);
+    DataMapAddArray(data,"vector.srng",DATAFLOAT,1,&npnt,srng);
     DataMapAddArray(data,"vector.stid",DATASHORT,1,&npnt,vstid);
     DataMapAddArray(data,"vector.channel",DATASHORT,1,&npnt,vchn);
     DataMapAddArray(data,"vector.index",DATAINT,1,&npnt,index);

--- a/codebase/superdarn/src.lib/tk/gtable.2.0/include/gtable.h
+++ b/codebase/superdarn/src.lib/tk/gtable.2.0/include/gtable.h
@@ -36,6 +36,7 @@ struct GridBm {
     int rxrise;
     int nrang;
     double *azm;
+    double *srng;
     double *ival;
     int *inx;
 };
@@ -46,7 +47,8 @@ struct GridPnt {
     int ref;
     double mlat;
     double mlon;
-    double azm; 
+    double azm;
+    double srng;
     struct {
         double median;
         double median_n;

--- a/codebase/superdarn/src.lib/tk/gtablewrite.1.9/src/gtablewrite.c
+++ b/codebase/superdarn/src.lib/tk/gtablewrite.1.9/src/gtablewrite.c
@@ -82,6 +82,7 @@ int GridTableWrite(int fid,struct GridTable *ptr,char *logbuf,int xtd) {
     float *gmlon=NULL;
     float *gmlat=NULL;
     float *kvect=NULL;
+    float *srng=NULL;
     int16 *vstid=NULL;
     int16 *vchn=NULL;
     int32 *index=NULL;
@@ -115,38 +116,39 @@ int GridTableWrite(int fid,struct GridTable *ptr,char *logbuf,int xtd) {
     ve_max[0]=ptr->max[3];
 
     if (npnt !=0) {
-        size=npnt*(3*sizeof(float)+sizeof(int32)+2*sizeof(int16)+
+        size=npnt*(4*sizeof(float)+sizeof(int32)+2*sizeof(int16)+
                     (2+4*xtd)*sizeof(float));
         buf=malloc(size);
         if (buf==NULL) return -1;
         gmlon=(float *) (buf);
         gmlat=(float *) (buf+sizeof(float)*npnt);
         kvect=(float *) (buf+2*sizeof(float)*npnt);
-        vstid=(int16 *) (buf+3*sizeof(float)*npnt);
-        vchn=(int16 *)  (buf+3*sizeof(float)*npnt+sizeof(int16)*npnt);
-        index=(int32 *) (buf+3*sizeof(float)*npnt+2*sizeof(int16)*npnt);
-        vlos=(float *)  (buf+3*sizeof(float)*npnt+
+        srng=(float *)  (buf+3*sizeof(float)*npnt);
+        vstid=(int16 *) (buf+4*sizeof(float)*npnt);
+        vchn=(int16 *)  (buf+4*sizeof(float)*npnt+sizeof(int16)*npnt);
+        index=(int32 *) (buf+4*sizeof(float)*npnt+2*sizeof(int16)*npnt);
+        vlos=(float *)  (buf+4*sizeof(float)*npnt+
                                sizeof(int32)*npnt+
                              2*sizeof(int16)*npnt);
-        vlos_sd=(float *) (buf+3*sizeof(float)*npnt+
+        vlos_sd=(float *) (buf+4*sizeof(float)*npnt+
                                  sizeof(int32)*npnt+
                                2*sizeof(int16)*npnt+
                                  sizeof(float)*npnt);
 
         if (xtd) {
-            pwr=(float *) (buf+3*sizeof(float)*npnt+
+            pwr=(float *) (buf+4*sizeof(float)*npnt+
                                  sizeof(int32)*npnt+
                                2*sizeof(int16)*npnt+
                                2*sizeof(float)*npnt);
-            pwr_sd=(float *) (buf+3*sizeof(float)*npnt+
+            pwr_sd=(float *) (buf+4*sizeof(float)*npnt+
                                     sizeof(int32)*npnt+
                                   2*sizeof(int16)*npnt+
                                   3*sizeof(float)*npnt);
-            wdt=(float *) (buf+3*sizeof(float)*npnt+
+            wdt=(float *) (buf+4*sizeof(float)*npnt+
                                  sizeof(int32)*npnt+
                                2*sizeof(int16)*npnt+
                                4*sizeof(float)*npnt);
-            wdt_sd=(float *) (buf+3*sizeof(float)*npnt+
+            wdt_sd=(float *) (buf+4*sizeof(float)*npnt+
                                     sizeof(int32)*npnt+
                                   2*sizeof(int16)*npnt+
                                   5*sizeof(float)*npnt);
@@ -157,6 +159,7 @@ int GridTableWrite(int fid,struct GridTable *ptr,char *logbuf,int xtd) {
             gmlat[n]=ptr->pnt[p].mlat;
             gmlon[n]=ptr->pnt[p].mlon;
             kvect[n]=ptr->pnt[p].azm;
+            srng[n]=ptr->pnt[p].srng;
             vstid[n]=ptr->st_id;
             vchn[n]=ptr->chn;
             index[n]=ptr->pnt[p].ref;
@@ -231,6 +234,7 @@ int GridTableWrite(int fid,struct GridTable *ptr,char *logbuf,int xtd) {
         DataMapAddArray(data,"vector.mlat",DATAFLOAT,1,&npnt,gmlat);
         DataMapAddArray(data,"vector.mlon",DATAFLOAT,1,&npnt,gmlon);
         DataMapAddArray(data,"vector.kvect",DATAFLOAT,1,&npnt,kvect);
+        DataMapAddArray(data,"vector.srng",DATAFLOAT,1,&npnt,srng);
         DataMapAddArray(data,"vector.stid",DATASHORT,1,&npnt,vstid);
         DataMapAddArray(data,"vector.channel",DATASHORT,1,&npnt,vchn);
         DataMapAddArray(data,"vector.index",DATAINT,1,&npnt,index);

--- a/codebase/superdarn/src.lib/tk/idl/cnvmapidl.1.3/src/cnvmapidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/cnvmapidl.1.3/src/cnvmapidl.c
@@ -155,6 +155,7 @@ void IDLCopyCnvMapGVecFromIDL(struct GridIDLGVec *igvec,
     map->model[n].mlat=gptr->mlat;
     map->model[n].mlon=gptr->mlon;
     map->model[n].azm=gptr->azm;
+    map->model[n].srng=gptr->srng;
     map->model[n].vel.median=gptr->vel.median;
     map->model[n].vel.sd=gptr->vel.sd;    
     map->model[n].pwr.median=gptr->pwr.median;
@@ -317,6 +318,7 @@ void IDLCopyCnvMapGVecToIDL(struct CnvMapData *map,int nvec,int size,
      gptr->mlat=map->model[n].mlat;
      gptr->mlon=map->model[n].mlon;
      gptr->azm=map->model[n].azm;
+     gptr->srng=map->model[n].srng;
      gptr->vel.median=map->model[n].vel.median;
      gptr->vel.sd=map->model[n].vel.sd;
      gptr->pwr.median=map->model[n].pwr.median;

--- a/codebase/superdarn/src.lib/tk/idl/grdidl.1.4/include/grdidl.h
+++ b/codebase/superdarn/src.lib/tk/idl/grdidl.1.4/include/grdidl.h
@@ -85,6 +85,7 @@ struct GridIDLGVec {
   float mlat;
   float mlon;
   float azm;
+  float srng;
   struct {
     float median;
     float sd;

--- a/codebase/superdarn/src.lib/tk/idl/grdidl.1.4/src/grdidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/grdidl.1.4/src/grdidl.c
@@ -115,6 +115,7 @@ void IDLCopyGridGVecFromIDL(struct GridIDLGVec *igvec,
     grd->data[n].mlat=gptr->mlat;
     grd->data[n].mlon=gptr->mlon;
     grd->data[n].azm=gptr->azm;
+    grd->data[n].srng=gptr->srng;
     grd->data[n].vel.median=gptr->vel.median;
     grd->data[n].vel.sd=gptr->vel.sd;    
     grd->data[n].pwr.median=gptr->pwr.median;
@@ -207,6 +208,7 @@ void IDLCopyGridGVecToIDL(struct GridData *grd,int nvec,int size,
      gptr->mlat=grd->data[n].mlat;
      gptr->mlon=grd->data[n].mlon;
      gptr->azm=grd->data[n].azm;
+     gptr->srng=grd->data[n].srng;
      gptr->vel.median=grd->data[n].vel.median;
      gptr->vel.sd=grd->data[n].vel.sd;
      gptr->pwr.median=grd->data[n].pwr.median;
@@ -303,31 +305,29 @@ struct GridIDLGVec *IDLMakeGridGVec(int nvec,IDL_VPTR *vptr) {
 
   void *s=NULL;
 
- static IDL_STRUCT_TAG_DEF value[]={
+  static IDL_STRUCT_TAG_DEF value[]={
     {"MEDIAN",0,(void *) IDL_TYP_FLOAT},
     {"SD",0,(void *) IDL_TYP_FLOAT},
     {0}};
 
   static IDL_STRUCT_TAG_DEF gridgvec[]={    
-    {"MLAT",0, (void *) IDL_TYP_FLOAT},   /* 0 */
-    {"MLON",0, (void *) IDL_TYP_FLOAT},   /* 1 */ 
+    {"MLAT",0,(void *) IDL_TYP_FLOAT},   /* 0 */
+    {"MLON",0,(void *) IDL_TYP_FLOAT},   /* 1 */ 
     {"AZM",0,(void *) IDL_TYP_FLOAT}, /* 2 */
-    {"VEL",0,NULL}, /* 3 */
-    {"PWR",0,NULL}, /* 4 */
-    {"WDT",0,NULL}, /* 5 */
-    {"ST_ID",0,(void *) IDL_TYP_INT}, /* 6 */
-    {"CHN",0,(void *) IDL_TYP_INT}, /* 7 */ 
-    {"INDEX",0,(void *) IDL_TYP_LONG}, /* 8 */ 
-
-
+    {"SRNG",0,(void *) IDL_TYP_FLOAT}, /* 3 */
+    {"VEL",0,NULL}, /* 4 */
+    {"PWR",0,NULL}, /* 5 */
+    {"WDT",0,NULL}, /* 6 */
+    {"ST_ID",0,(void *) IDL_TYP_INT}, /* 7 */
+    {"CHN",0,(void *) IDL_TYP_INT}, /* 8 */ 
+    {"INDEX",0,(void *) IDL_TYP_LONG}, /* 9 */ 
     {0}};
 
   static IDL_MEMINT ilDims[IDL_MAX_ARRAY_DIM];
 
-  gridgvec[3].type=IDL_MakeStruct("GRIDVALUE",value);
   gridgvec[4].type=IDL_MakeStruct("GRIDVALUE",value);
   gridgvec[5].type=IDL_MakeStruct("GRIDVALUE",value);
-
+  gridgvec[6].type=IDL_MakeStruct("GRIDVALUE",value);
  
   s=IDL_MakeStruct("GRIDGVEC",gridgvec);
 

--- a/codebase/superdarn/src.lib/tk/oldcnvmap.1.2/src/readmap.c
+++ b/codebase/superdarn/src.lib/tk/oldcnvmap.1.2/src/readmap.c
@@ -81,6 +81,7 @@ int OldCnvMapDecodeOne(char *name,char *unit,char *type,
     mp->model[pnt].mlat=data[1].data.fval;
     mp->model[pnt].mlon=data[0].data.fval;
     mp->model[pnt].azm=data[2].data.fval;
+    mp->model[pnt].srng=0;
     mp->model[pnt].vel.median=data[3].data.fval;
     mp->model[pnt].vel.sd=0;
     mp->model[pnt].pwr.median=0;

--- a/codebase/superdarn/src.lib/tk/oldgrid.1.3/src/oldreadgrid.c
+++ b/codebase/superdarn/src.lib/tk/oldgrid.1.3/src/oldreadgrid.c
@@ -184,6 +184,7 @@ int OldGridDecodeThree(char *name,char *unit,char *type,
     gp->data[pnt].mlat=data[1].data.fval;
     gp->data[pnt].mlon=data[0].data.fval;
     gp->data[pnt].azm=data[2].data.fval;
+    gp->data[pnt].srng=0;
     gp->data[pnt].st_id=data[3].data.ival;
     gp->data[pnt].chn=0;
     gp->data[pnt].index=data[4].data.ival;
@@ -224,6 +225,7 @@ int OldGridDecodeFour(char *name,char *unit,char *type,
     gp->data[pnt].mlat=data[1].data.fval;
     gp->data[pnt].mlon=data[0].data.fval;
     gp->data[pnt].azm=data[2].data.fval;
+    gp->data[pnt].srng=0;
     gp->data[pnt].st_id=data[3].data.ival;
     gp->data[pnt].chn=0;
     gp->data[pnt].index=data[4].data.ival;
@@ -268,6 +270,7 @@ int OldGridDecodeFive(char *name,char *unit,char *type,
     gp->data[pnt].mlat=data[1].data.fval;
     gp->data[pnt].mlon=data[0].data.fval;
     gp->data[pnt].azm=data[2].data.fval;
+    gp->data[pnt].srng=0;
     gp->data[pnt].st_id=data[3].data.ival;
     gp->data[pnt].chn=data[4].data.ival;
 
@@ -310,6 +313,7 @@ int OldGridDecodeSix(char *name,char *unit,char *type,
     gp->data[pnt].mlat=data[1].data.fval;
     gp->data[pnt].mlon=data[0].data.fval;
     gp->data[pnt].azm=data[2].data.fval;
+    gp->data[pnt].srng=0;
     gp->data[pnt].st_id=data[3].data.ival;
     gp->data[pnt].chn=data[4].data.ival;
 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/include/invmag.h
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/include/invmag.h
@@ -30,7 +30,7 @@ int RPosRngBmAzmElv(int bm,int rn,int year,
 
 int RPosInvMag(int bm,int rn,int year,struct RadarSite *hdw,double frang,
                double rsep,double rx,double height,
-               double *mlat,double *mlon,double *azm,
+               double *mlat,double *mlon,double *azm,double *srng,
                int chisham,int old_aacgm);
 
 #endif

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/include/rpos.h
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/include/rpos.h
@@ -40,12 +40,13 @@ double slant_range(int frang,int rsep,
 void RPosGeo(int center,int bcrd,int rcrd,
              struct RadarSite *pos,
              int lagfr,int smsep,int rxrise,double height,
-             double *rho,double *lat,double *lng,int chisham);
+             double *rho,double *lat,double *lng,double *srng,int chisham);
 
 void RPosMag(int center,int bcrd,int rcrd,
              struct RadarSite *pos,
              int lagfr,int smsep,int rxrise,double height,
-             double *rho,double *lat,double *lng,int chisham,int old_aacgm);
+             double *rho,double *lat,double *lng,double *srng,int chisham,
+             int old_aacgm);
 
 void RPosCubic(int center,int bcrd,int rcrd,
                struct RadarSite *pos,

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/src/cnvtcoord.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/src/cnvtcoord.c
@@ -333,7 +333,7 @@ void RPosGeo(int center, int bcrd, int rcrd,
              int frang, int rsep,
              int rxrise, double height,
              double *rho, double *lat, double *lng,
-             int chisham) {
+             double *srng, int chisham) {
 
     double rx;
     double psi,d;
@@ -358,6 +358,7 @@ void RPosGeo(int center, int bcrd, int rcrd,
 
     /* Calculate the slant range to the range gate [km] */
     d=slant_range(frang,rsep,rx,range_edge,rcrd+1);
+    *srng=d;
 
     /* If the input height is less than 90 then it is actually an input
      * elevation angle [deg], so we calculat the field point height */
@@ -375,7 +376,7 @@ void RPosMag(int center,int bcrd,int rcrd,
              struct RadarSite *pos,
              int frang,int rsep,int rxrise,double height,
              double *rho,double *lat,double *lng,
-             int chisham,int old_aacgm) {
+             double *srng, int chisham,int old_aacgm) {
 
     double rx;
     double radius;
@@ -396,6 +397,7 @@ void RPosMag(int center,int bcrd,int rcrd,
     offset=pos->maxbeam/2.0-0.5;
     psi=pos->bmsep*(bcrd-offset)+bm_edge+pos->bmoff;
     d=slant_range(frang,rsep,rx,range_edge,rcrd+1);
+    *srng=d;
     if (height < 90) height=-RE+sqrt((RE*RE)+2*d*RE*sind(height)+(d*d));
 
     fldpnth(pos->geolat,pos->geolon,psi,pos->boresite,

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/src/invmag.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/src/invmag.c
@@ -217,7 +217,7 @@ int RPosRngBmAzmElv(int bm, int rn, int year,
     double gbx,gby,gbz; 
     double ghx,ghy,ghz;
     double bx,by,bz,b;
-    double dummy;
+    double dummy,srng;
     int s;
 
     /* Get geodetic latitude/longitude from radar hardware info [deg] */
@@ -232,7 +232,7 @@ int RPosRngBmAzmElv(int bm, int rn, int year,
      * surface of the oblate spheroid (ie not constant with latitude) plus
      * virtual height (frho) */
     RPosGeo(1,bm,rn,hdw,frang,rsep,rx,
-            height,&frho,&flat,&flon,chisham);
+            height,&frho,&flat,&flon,&srng,chisham);
 
     /* Convert range/beam position from geocentric spherical coordinates
      * (frho,flat,flon) to global Cartesian coordinates (fx,fy,fz) */
@@ -297,7 +297,7 @@ int RPosRngBmAzmElv(int bm, int rn, int year,
  **/
 int RPosInvMag(int bm, int rn, int year, struct RadarSite *hdw, double frang,
                double rsep, double rx, double height,
-               double *mlat, double *mlon, double *azm, 
+               double *mlat, double *mlon, double *azm, double *srng,
                int chisham, int old_aacgm) {
 
     double flat,flon,frho;
@@ -328,7 +328,7 @@ int RPosInvMag(int bm, int rn, int year, struct RadarSite *hdw, double frang,
      * surface of the oblate spheroid (ie not constant with latitude) plus
      * virtual height (frho) */
     RPosGeo(1,bm,rn,hdw,frang,rsep,rx,
-            height,&frho,&flat,&flon,chisham);
+            height,&frho,&flat,&flon,srng,chisham);
 
     /* Convert range/beam position from geocentric spherical coordinates
      * (frho,flat,flon) to global Cartesian coordinates (fx,fy,fz) */


### PR DESCRIPTION
This pull request adds a new `srng` field to grid and map files that contains the (average) slant range of the velocity vector recorded by a radar in a given grid cell.  All C and IDL read/write routines have been updated to handle files both with and without this new field.

Note this is a preliminary step towards more flexible filtering of line-of-sight data based on the measured slant range, which can possibly be contaminated by E-region echoes at near ranges or incorrectly mapped at very far ranges.  Ultimately, it should be faster to apply a post-processing range filter on this new `srng` field than using the current `-minsrng` and `-maxsrng` options with `make_grid` (since those require slant range calculations for all ranges of every input scan).

To test, try creating grid and map files with your favorite options and see if anything breaks.  The contents of the `srng` field can be viewed with either `dmapdump -d` or your favorite IDL plotting software (at least until pydarnio is updated).