### PR TITLE
FIX: Bug when `CMPLX` macro undefined.

### DIFF
--- a/codebase/analysis/src.bin/cdf/istp_plot.1.11/locate.c
+++ b/codebase/analysis/src.bin/cdf/istp_plot.1.11/locate.c
@@ -67,12 +67,7 @@ int infname(char *body,char *str) {
   return 1;
 }
 
-
-#ifdef  _DARWIN
-int dsel(struct dirent *dp) {
-#else 
 int dsel(const struct dirent *dp) {
-#endif
   if (dp->d_name[0]=='.') return 0;
   return 1;
 }

--- a/codebase/analysis/src.bin/cdf/istp_text.1.24/locate.c
+++ b/codebase/analysis/src.bin/cdf/istp_text.1.24/locate.c
@@ -67,12 +67,7 @@ int infname(char *body,char *str) {
   return 1;
 }
 
-
-#ifdef  _DARWIN
-int dsel(struct dirent *dp) {
-#else 
 int dsel(const struct dirent *dp) {
-#endif
   if (dp->d_name[0]=='.') return 0;
   return 1;
 }

--- a/codebase/analysis/src.lib/aacgm/aacgm.1.15/src/rylm.c
+++ b/codebase/analysis/src.lib/aacgm/aacgm.1.15/src/rylm.c
@@ -42,11 +42,11 @@ int rylm(double colat,double lon,int order,
 	  double *ylmval) {
    
     double d1;
-    complex z1, z2;
+    double complex z1, z2;
 
     /* Local variables */
-    complex q_fac;
-    complex q_val;
+    double complex q_fac;
+    double complex q_val;
     int l, m;
     int la,lb,lc,ld,le,lf;
 
@@ -62,9 +62,9 @@ int rylm(double colat,double lon,int order,
     sin_lon = sin(lon);
 
     d1 = -sin_theta;
-    z2 = CMPLX(cos_lon, sin_lon);
+    z2 = cos_lon + sin_lon * I;
 
-    z1 = CMPLX(d1 * creal(z2), d1 * cimag(z2));
+    z1 = d1 * z2;
 
     q_fac = z1;
 
@@ -89,9 +89,8 @@ int rylm(double colat,double lon,int order,
     for (l = 2; l <= order; l++) {
 
 	d1 = l*2 - 1.;
-	z2 = CMPLX(d1 * creal(q_fac), d1 * cimag(q_fac));
-	z1 = CMPLX(creal(z2) * creal(q_val) - cimag(z2) * cimag(q_val), 
-            creal(z2) * cimag(q_val) + cimag(z2) * creal(q_val));
+	z2 = d1 * q_fac;
+	z1 = z2 * q_val;
 	q_val = z1;
 
 	la = l*l + (2*l) + 1;

--- a/codebase/superdarn/src.bin/tk/tool/imfdelay.1.7/locate.c
+++ b/codebase/superdarn/src.bin/tk/tool/imfdelay.1.7/locate.c
@@ -64,12 +64,7 @@ int infname(char *body,char *str) {
   return 1;
 }
 
-
-#ifdef  _DARWIN
-int dsel(struct dirent *dp) {
-#else 
 int dsel(const struct dirent *dp) {
-#endif
   if (dp->d_name[0]=='.') return 0;
   return 1;
 }

--- a/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/locate.c
+++ b/codebase/superdarn/src.bin/tk/tool/map_addimf.1.18/locate.c
@@ -64,12 +64,7 @@ int infname(char *body,char *str) {
   return 1;
 }
 
-
-#ifdef  _DARWIN
-int dsel(struct dirent *dp) {
-#else 
 int dsel(const struct dirent *dp) {
-#endif
   if (dp->d_name[0]=='.') return 0;
   return 1;
 }

--- a/codebase/superdarn/src.lib/tk/cnvmodel.1.0/src/cnvmodel.c
+++ b/codebase/superdarn/src.lib/tk/cnvmodel.1.0/src/cnvmodel.c
@@ -238,10 +238,10 @@ struct model *load_model(FILE *fp, int ihem, int ilev, int iang,
 
       if (m < 0) {
         k = l*(ptr->ltop+1)-m;
-        ptr->aoeff_n[k] = CMPLX(cr, ci);
+        ptr->aoeff_n[k] = cr + ci * I;
       } else {
         k = l*(ptr->ltop+1)+m;
-        ptr->aoeff_p[k] = CMPLX(cr, ci);
+        ptr->aoeff_p[k] = cr + ci * I;
       }
 
     }
@@ -517,40 +517,24 @@ struct model *interp_coeffs(int ih, float tilt, float mag, float cang, int imod)
     for (m=-l; m<=l; m++) {
       if (m < 0) {
         k = l*(ptr->ltop+1)-m;
-        An[k] = CMPLX(creal(model[ih][it1][im1][ia1]->aoeff_n[k])/denom, 
-                cimag(model[ih][it1][im1][ia1]->aoeff_n[k])/denom);
-        Bn[k] = CMPLX(creal(model[ih][it1][im1][ia2]->aoeff_n[k])/denom, 
-                cimag(model[ih][it1][im1][ia2]->aoeff_n[k])/denom);
-        Cn[k] = CMPLX(creal(model[ih][it1][im2][ia1]->aoeff_n[k])/denom, 
-                cimag(model[ih][it1][im2][ia1]->aoeff_n[k])/denom);
-        Dn[k] = CMPLX(creal(model[ih][it1][im2][ia2]->aoeff_n[k])/denom, 
-                cimag(model[ih][it1][im2][ia2]->aoeff_n[k])/denom);
-        En[k] = CMPLX(creal(model[ih][it2][im1][ia1]->aoeff_n[k])/denom, 
-                cimag(model[ih][it2][im1][ia1]->aoeff_n[k])/denom);
-        Fn[k] = CMPLX(creal(model[ih][it2][im1][ia2]->aoeff_n[k])/denom, 
-                cimag(model[ih][it2][im1][ia2]->aoeff_n[k])/denom);
-        Gn[k] = CMPLX(creal(model[ih][it2][im2][ia1]->aoeff_n[k])/denom, 
-                cimag(model[ih][it2][im2][ia1]->aoeff_n[k])/denom);
-        Hn[k] = CMPLX(creal(model[ih][it2][im2][ia2]->aoeff_n[k])/denom, 
-                cimag(model[ih][it2][im2][ia2]->aoeff_n[k])/denom);
+        An[k] = model[ih][it1][im1][ia1]->aoeff_n[k] / denom;
+        Bn[k] = model[ih][it1][im1][ia2]->aoeff_n[k] / denom;
+        Cn[k] = model[ih][it1][im2][ia1]->aoeff_n[k] / denom;
+        Dn[k] = model[ih][it1][im2][ia2]->aoeff_n[k] / denom;
+        En[k] = model[ih][it2][im1][ia1]->aoeff_n[k] / denom;
+        Fn[k] = model[ih][it2][im1][ia2]->aoeff_n[k] / denom;
+        Gn[k] = model[ih][it2][im2][ia1]->aoeff_n[k] / denom;
+        Hn[k] = model[ih][it2][im2][ia2]->aoeff_n[k] / denom;
       } else {
         k = l*(ptr->ltop+1)+m;
-        Ap[k] = CMPLX(creal(model[ih][it1][im1][ia1]->aoeff_p[k])/denom,
-                cimag(model[ih][it1][im1][ia1]->aoeff_p[k])/denom);
-        Bp[k] = CMPLX(creal(model[ih][it1][im1][ia2]->aoeff_p[k])/denom,
-                cimag(model[ih][it1][im1][ia2]->aoeff_p[k])/denom);
-        Cp[k] = CMPLX(creal(model[ih][it1][im2][ia1]->aoeff_p[k])/denom,
-                cimag(model[ih][it1][im2][ia1]->aoeff_p[k])/denom);
-        Dp[k] = CMPLX(creal(model[ih][it1][im2][ia2]->aoeff_p[k])/denom,
-                cimag(model[ih][it1][im2][ia2]->aoeff_p[k])/denom);
-        Ep[k] = CMPLX(creal(model[ih][it2][im1][ia1]->aoeff_p[k])/denom,
-                cimag(model[ih][it2][im1][ia1]->aoeff_p[k])/denom);
-        Fp[k] = CMPLX(creal(model[ih][it2][im1][ia2]->aoeff_p[k])/denom,
-                cimag(model[ih][it2][im1][ia2]->aoeff_p[k])/denom);
-        Gp[k] = CMPLX(creal(model[ih][it2][im2][ia1]->aoeff_p[k])/denom,
-                cimag(model[ih][it2][im2][ia1]->aoeff_p[k])/denom);
-        Hp[k] = CMPLX(creal(model[ih][it2][im2][ia2]->aoeff_p[k])/denom,
-                cimag(model[ih][it2][im2][ia2]->aoeff_p[k])/denom);
+        Ap[k] = model[ih][it1][im1][ia1]->aoeff_p[k] / denom;
+        Bp[k] = model[ih][it1][im1][ia2]->aoeff_p[k] / denom;
+        Cp[k] = model[ih][it1][im2][ia1]->aoeff_p[k] / denom;
+        Dp[k] = model[ih][it1][im2][ia2]->aoeff_p[k] / denom;
+        Ep[k] = model[ih][it2][im1][ia1]->aoeff_p[k] / denom;
+        Fp[k] = model[ih][it2][im1][ia2]->aoeff_p[k] / denom;
+        Gp[k] = model[ih][it2][im2][ia1]->aoeff_p[k] / denom;
+        Hp[k] = model[ih][it2][im2][ia2]->aoeff_p[k] / denom;
       }
     }
   }
@@ -561,27 +545,16 @@ struct model *interp_coeffs(int ih, float tilt, float mag, float cang, int imod)
         k = l*(ptr->ltop+1)-m;
         // note: aoeff_n[k]
         // TODO: rest of this should probably be a function
-        ptr->aoeff_n[k] = CMPLX(creal(An[k])*afp*mgp*dtp + 
-                creal(Bn[k])*afn*mgp*dtp + creal(Cn[k])*afp*mgn*dtp +
-                creal(Dn[k])*afn*mgn*dtp + creal(En[k])*afp*mgp*dtn + 
-                creal(Fn[k])*afn*mgp*dtn + creal(Gn[k])*afp*mgn*dtn + 
-                creal(Hn[k])*afn*mgn*dtn, cimag(An[k])*afp*mgp*dtp +
-                cimag(Bn[k])*afn*mgp*dtp + cimag(Cn[k])*afp*mgn*dtp +
-                cimag(Dn[k])*afn*mgn*dtp + cimag(En[k])*afp*mgp*dtn +
-                cimag(Fn[k])*afn*mgp*dtn + cimag(Gn[k])*afp*mgn*dtn +
-                cimag(Hn[k])*afn*mgn*dtn);
+        ptr->aoeff_n[k] =
+                An[k]*afp*mgp*dtp + Bn[k]*afn*mgp*dtp + Cn[k]*afp*mgn*dtp + Dn[k]*afn*mgn*dtp +
+                En[k]*afp*mgp*dtn + Fn[k]*afn*mgp*dtn + Gn[k]*afp*mgn*dtn + Hn[k]*afn*mgn*dtn;
       } else {
         k = l*(ptr->ltop+1)+m;
         // Note: aoeff_p[k]
-        ptr->aoeff_p[k] = CMPLX(creal(Ap[k])*afp*mgp*dtp +
-                creal(Bp[k])*afn*mgp*dtp + creal(Cp[k])*afp*mgn*dtp +
-                creal(Dp[k])*afn*mgn*dtp + creal(Ep[k])*afp*mgp*dtn +
-                creal(Fp[k])*afn*mgp*dtn + creal(Gp[k])*afp*mgn*dtn +
-                creal(Hp[k])*afn*mgn*dtn, cimag(Ap[k])*afp*mgp*dtp +
-                cimag(Bp[k])*afn*mgp*dtp + cimag(Cp[k])*afp*mgn*dtp +
-                cimag(Dp[k])*afn*mgn*dtp + cimag(Ep[k])*afp*mgp*dtn +
-                cimag(Fp[k])*afn*mgp*dtn + cimag(Gp[k])*afp*mgn*dtn +
-                cimag(Hp[k])*afn*mgn*dtn);
+        ptr->aoeff_p[k] =
+                Ap[k]*afp*mgp*dtp + Bp[k]*afn*mgp*dtp + Cp[k]*afp*mgn*dtp + Dp[k]*afn*mgn*dtp +
+                Ep[k]*afp*mgp*dtn + Fp[k]*afn*mgp*dtn + Gp[k]*afp*mgn*dtn + Hp[k]*afn*mgn*dtn;
+
 
       }
     }
@@ -811,8 +784,7 @@ double factorial(double n)
 double complex cmult(double complex b,double complex c)
 {
   double complex a; 
-  a = CMPLX(creal(b)*creal(c) - cimag(b)*cimag(c),
-          creal(b)*cimag(c) + cimag(b)*creal(c));
+  a = b * c;
   return a;
 }
 
@@ -871,10 +843,9 @@ void slv_ylm_mod(float theta, float phi, int order, double complex *ylm_p,
       }
       plm_p[l*(order+1)+m]=Pmm;
 
-      ylm_p[l*(order+1)+m] = CMPLX(Pmm*anorm[l*(order+1)+m]*cos(m*phi), 
-              Pmm*anorm[l*(order+1)+m]*sin(m*phi));
-      ylm_n[l*(order+1)+m] = CMPLX(pow(-1,m)*creal(ylm_p[l*(order+1)+m]),
-              -pow(-1,m)*cimag(ylm_p[l*(order+1)+m]));
+      ylm_p[l*(order+1)+m] = Pmm*anorm[l*(order+1)+m]*cos(m*phi) +
+              Pmm*anorm[l*(order+1)+m]*sin(m*phi) * I;
+      ylm_n[l*(order+1)+m] = pow(-1,m)*ylm_p[l*(order+1)+m];
 
     }
   }
@@ -935,7 +906,7 @@ void slv_sph_kset(float latmin, int num, float *phi, float *the,
 
   for (i=0;i<num;i++) {
 
-    Ix = CMPLX(0, 0);
+    Ix = 0.0 + 0.0 * I;
     for (l=0;l<=ltop;l++) {
       mlow=-l;
       if (mtop<l) mlow=-mtop;
@@ -946,24 +917,24 @@ void slv_sph_kset(float latmin, int num, float *phi, float *the,
         t = cmult(mod->aoeff_n[l*(ltop+1)-m],
               ylm_nx[i*(ltop+1)*(ltop+1)+l*(ltop+1)-m]);
 
-        Ix += CMPLX(creal(t), cimag(t));
+        Ix += t;
       }
 
       for (m=0;m<=mhgh;m++) {
 
         t = cmult(mod->aoeff_p[l*(ltop+1)+m],
               ylm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m]);
-        Ix += CMPLX(creal(t), cimag(t));
+        Ix += t;
        }
     }
 
     pot[i] = creal(Ix);
     pot_arr[i] = creal(Ix);
-    xot_arr[i] = CMPLX(creal(Ix), cimag(Ix));
+    xot_arr[i] = Ix;
   }
 
   for (i=0;i<num;i++) {
-    Ix = CMPLX(0, 0);
+    Ix = 0.0 + 0.0 * I;
 
     for (l=0;l<=ltop;l++) {
 
@@ -974,7 +945,7 @@ void slv_sph_kset(float latmin, int num, float *phi, float *the,
       for (m=mlow;m<0;m++) {
         t = cmult(mod->aoeff_n[l*(ltop+1)-m],
               ylm_nx[i*(ltop+1)*(ltop+1)+l*(ltop+1)-m]);
-        Ix += CMPLX(m*creal(t), m*cimag(t));
+        Ix += m * t;
 
       }
 
@@ -982,13 +953,13 @@ void slv_sph_kset(float latmin, int num, float *phi, float *the,
 
          t = cmult(mod->aoeff_p[l*(ltop+1)+m],
                ylm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m]);
-         Ix += CMPLX(m*creal(t), m*cimag(t));
+         Ix += m * t;
        }
     }
 
     ele_phi[i] = (1000.0/(Rd*sin(the_col[i])))*cimag(Ix);
 
-    Ix = CMPLX(0, 0);
+    Ix = 0.0 + 0.0 * I;
     for (l=0;l<=ltop;l++) {
       mlow=-l;
       if (mtop<l) mlow=-mtop;
@@ -996,41 +967,41 @@ void slv_sph_kset(float latmin, int num, float *phi, float *the,
 
       for (m=mlow;m<0;m++) {
         n=-m;
-        T1 = CMPLX(n*cos(the[i])/sin(the[i])*
-                plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)-m],
-                n*cos(the[i])/sin(the[i])*
-                plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)-m]);
+        T1 = (n*cos(the[i])/sin(the[i])*
+              plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)-m]) +
+             (n*cos(the[i])/sin(the[i])*
+              plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)-m]) * I;
         if ((n+1) <=l) {
-           T2 = CMPLX(plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+n+1], 
-                   plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+n+1]);
+           T2 = (plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+n+1]) +
+                (plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+n+1]) * I;
         } else {
-          T2 = CMPLX(0, 0);
+          T2 = 0.0 + 0.0 * I;
         }
 
-        T1= CMPLX((creal(T1)+creal(T2))*pow(-1,m)*
-                cos(m*phi[i])*anorm[l*(ltop+1)-m], 
-                (cimag(T1)+cimag(T2))*pow(-1,m)*
-                sin(m*phi[i])*anorm[l*(ltop+1)-m]);
+        T1= ((creal(T1)+creal(T2))*pow(-1,m)*
+             cos(m*phi[i])*anorm[l*(ltop+1)-m]) +
+            ((cimag(T1)+cimag(T2))*pow(-1,m)*
+             sin(m*phi[i])*anorm[l*(ltop+1)-m]) * I;
         t = cmult(T1,mod->aoeff_n[l*(ltop+1)-m]);
-        Ix += CMPLX(creal(t), cimag(t));
+        Ix += t;
       }
 
       for (m=0;m<=mhgh;m++) {
-        T1 = CMPLX(m*cos(the[i])/sin(the[i])*
-                plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m], 
-                m*cos(the[i])/sin(the[i])*
-                plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m]);
+        T1 = (m*cos(the[i])/sin(the[i])*
+              plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m]) +
+             (m*cos(the[i])/sin(the[i])*
+              plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m]) * I;
         if ((m+1) <=l) {
-          T2 = CMPLX(plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m+1], 
-                  plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m+1]);
+          T2 = (plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m+1]) +
+               (plm_px[i*(ltop+1)*(ltop+1)+l*(ltop+1)+m+1]) * I;
         } else {
-          T2 = CMPLX(0, 0);
+          T2 = 0.0 + 0.0 * I;
         }
-        T1 = CMPLX((creal(T1)+creal(T2))*cos(m*phi[i])*anorm[l*(ltop+1)+m],
-                (cimag(T1)+cimag(T2))*sin(m*phi[i])*anorm[l*(ltop+1)+m]);
+        T1 = ((creal(T1)+creal(T2))*cos(m*phi[i])*anorm[l*(ltop+1)+m]) +
+             ((cimag(T1)+cimag(T2))*sin(m*phi[i])*anorm[l*(ltop+1)+m]) * I;
         t = cmult(T1,mod->aoeff_p[l*(ltop+1)+m]);
 
-        Ix += CMPLX(creal(t), cimag(t));
+        Ix += t;
       }
     }
     if (latmin > 0)

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACFBadLags/FitACFBadLags.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/doc/src/FitACFBadLags/FitACFBadLags.c
@@ -157,7 +157,7 @@ int main(int argc,char *argv[]) {
       }
       if (fblk.prm.xcf) {
         for (j=0;j<fblk.prm.mplgs;j++) {
-          fblk.xcfd[i][j] = CMPLX(raw.xcfd[i][j][0], raw.xcfd[i][j][1]);
+          fblk.xcfd[i][j] = raw.xcfd[i][j][0] + raw.xcfd[i][j][1] * I;
         }
       } 
     }   

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fit_noise.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fit_noise.c
@@ -50,21 +50,21 @@ void fit_noise(double complex *ncf,int *badlag,struct FitACFBadSample *badsmp,
       A = exp(ptr->p_s);
       for (j=0; j < prm->mplgs; ++j) {
         t = (prm->lag[1][j] - prm->lag[0][j])*tau;
-        ncf[j] = CMPLX(A*exp(-ptr->w_l*t)*cos(ptr->v*t), 
-                A*exp(-ptr->w_l*t)*sin(ptr->v*t));
+        ncf[j] = A*exp(-ptr->w_l*t)*cos(ptr->v*t) +
+                 A*exp(-ptr->w_l*t)*sin(ptr->v*t) * I;
       }
     } else {
       if (ptr->p_s > skynoise) ptr->p_s = skynoise;
       A = exp(ptr->p_s);
       for (j=0; j < prm->mplgs; ++j) {
         t = (prm->lag[1][j] - prm->lag[0][j])*tau;
-        ncf[j] = CMPLX( A*exp(-(ptr->w_s*t)*(ptr->w_s*t))*cos(ptr->v*t),
-                A*exp(-(ptr->w_s*t)*(ptr->w_s*t))*sin(ptr->v*t));
+        ncf[j] = A*exp(-(ptr->w_s*t)*(ptr->w_s*t))*cos(ptr->v*t) +
+                 A*exp(-(ptr->w_s*t)*(ptr->w_s*t))*sin(ptr->v*t) * I;
       }
     }
   } else
     for (j=0; j < prm->mplgs; ++j) {
-      ncf[j] = CMPLX(0, 0);
+      ncf[j] = 0.0 + 0.0 * I;
     }
   return;
 }

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fitacf.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/fitacf.c
@@ -156,14 +156,14 @@ int fill_fit_block(struct RadarParm *prm, struct RawData *raw,
 
         if (raw->acfd[0] !=NULL) {
             for (j=0;j<input->prm.mplgs;j++) {
-                input->acfd[i*input->prm.mplgs+j] = CMPLX(raw->acfd[0][i*input->prm.mplgs+j], 
-                        raw->acfd[1][i*input->prm.mplgs+j]);
+                input->acfd[i*input->prm.mplgs+j] = raw->acfd[0][i*input->prm.mplgs+j] +
+                        raw->acfd[1][i*input->prm.mplgs+j] * I;
             }
         }
         if (raw->xcfd[0] !=NULL) {
             for (j=0;j<input->prm.mplgs;j++) {
-                input->xcfd[i*input->prm.mplgs+j] = CMPLX(raw->xcfd[0][i*input->prm.mplgs+j], 
-                        raw->xcfd[1][i*input->prm.mplgs+j]);
+                input->xcfd[i*input->prm.mplgs+j] = raw->xcfd[0][i*input->prm.mplgs+j] +
+                        raw->xcfd[1][i*input->prm.mplgs+j] * I;
             }
         }
     }

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/noise_acf.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/noise_acf.c
@@ -58,7 +58,7 @@ double noise_acf(double mnpwr,struct FitPrm *ptr, double *pwr,
   memset(bad,0,sizeof(int)*ptr->mplgs);
 
   for (i=0; i< ptr->mplgs; i++) {
-	n_acf[i] = CMPLX(0, 0);
+	n_acf[i] = 0.0 + 0.0 * I;
 	np[i] = 0;
   }
   plim = PLIM * mnpwr;
@@ -74,8 +74,7 @@ double noise_acf(double mnpwr,struct FitPrm *ptr, double *pwr,
 	    if ((fabs(creal(raw[i*ptr->mplgs+j])) < plim) &&
 			(fabs(cimag(raw[i*ptr->mplgs+j])) < plim) &&
 			(bad[j] == 0)) {
-		  n_acf[j] = CMPLX((creal(n_acf[j]) + creal(raw[i*ptr->mplgs+j])),
-                  (cimag(n_acf[j]) + cimag(raw[i*ptr->mplgs+j])));
+		  n_acf[j] = n_acf[j] + raw[i*ptr->mplgs+j];
 		  ++(np[j]);
 		}
 	  }
@@ -84,7 +83,7 @@ double noise_acf(double mnpwr,struct FitPrm *ptr, double *pwr,
 
   if (np[0] <= 2) {
 	for (i=0; i < ptr->mplgs; ++i) {
-	  n_acf[i] = CMPLX(0, 0);
+	  n_acf[i] = 0.0 + 0.0 * I;
 	}
     free(np);
     free(bad);
@@ -93,9 +92,9 @@ double noise_acf(double mnpwr,struct FitPrm *ptr, double *pwr,
 
   for (i=0; i< ptr->mplgs; i++) {
 	if (np[i] > 2) {
-	  n_acf[i] = CMPLX((creal(n_acf[i])/np[i]), (cimag(n_acf[i])/np[i]));
+	  n_acf[i] = n_acf[i])/np[i];
 	} else {
-	  n_acf[i] = CMPLX(0, 0);
+	  n_acf[i] = 0.0 + 0.0 * I;
 	}
   }
 

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/remove_noise.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/remove_noise.c
@@ -45,7 +45,7 @@ void remove_noise(int mplgs, double complex *acf, double complex *ncf) {
       acf[i] -= ncf[i];	
     }
   else for (i=0; i < mplgs; i++) {
-    acf[i] = CMPLX(0,0);
+    acf[i] = 0.0 + 0.0 * I;
   }
   return;
 }

--- a/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
+++ b/codebase/superdarn/src.lib/tk/lmfit.1.0/src/lmfit.c
@@ -144,12 +144,12 @@ void setup_fblk(struct RadarParm *prm, struct RawData *raw,struct FitBlock *inpu
 
     if (raw->acfd[0] !=NULL) {
       for (j=0;j<input->prm.mplgs;j++) {
-        input->acfd[i*input->prm.mplgs+j] = CMPLX(raw->acfd[0][i*input->prm.mplgs+j], raw->acfd[1][i*input->prm.mplgs+j]);
+        input->acfd[i*input->prm.mplgs+j] = raw->acfd[0][i*input->prm.mplgs+j] + raw->acfd[1][i*input->prm.mplgs+j] * I;
       }
     }
     if (raw->xcfd[0] !=NULL) {
       for (j=0;j<input->prm.mplgs;j++) {
-        input->xcfd[i*input->prm.mplgs+j] = CMPLX(raw->xcfd[0][i*input->prm.mplgs+j], raw->xcfd[1][i*input->prm.mplgs+j]);
+        input->xcfd[i*input->prm.mplgs+j] = raw->xcfd[0][i*input->prm.mplgs+j] + raw->xcfd[1][i*input->prm.mplgs+j] * I;
       }
     }
   }


### PR DESCRIPTION
Targeting #619 

**NOTE**: This branch has no conflicts with the main branch, so the target branch for this PR could be changed if this change would be better suited as a hotfix.

## Changes
* Replaced complex number instantiation using `CMPLX(real, imag)` with `real + imag * I` as per https://stackoverflow.com/a/9860772
* Specified double precision for complex numbers in `rylm.c`
* Simplified complex number instantiation/multiplication in some places. Previously, some calculations were extracting the real and imaginary parts separately and using them in a `CMPLX()` call to create a new complex number, rather than simply using the already-complex number.
* Answer at https://stackoverflow.com/a/59597456 explains that `CMPLX` is missing on MacOS when compiling with `gcc` because the responsibility of defining macros like `CMPLX` is not up to `gcc`, so it truly is not defined anywhere. This is not a linker issue nor an issue with the `complex.h` header file missing/not found/wrong.
