### PR TITLE
Fixed -1 error in cnvmodel.c

### DIFF
--- a/codebase/superdarn/src.lib/tk/cnvmodel.1.0/src/cnvmodel.c
+++ b/codebase/superdarn/src.lib/tk/cnvmodel.1.0/src/cnvmodel.c
@@ -845,8 +845,8 @@ void slv_ylm_mod(float theta, float phi, int order, double complex *ylm_p,
 
       ylm_p[l*(order+1)+m] = Pmm*anorm[l*(order+1)+m]*cos(m*phi) +
               Pmm*anorm[l*(order+1)+m]*sin(m*phi) * I;
-      ylm_n[l*(order+1)+m] = pow(-1,m)*ylm_p[l*(order+1)+m];
-
+      ylm_n[l*(order+1)+m] = pow(-1,m)*creal(ylm_p[l*(order+1)+m]) +
+              (-pow(-1,m)*cimag(ylm_p[l*(order+1)+m])) * I;
     }
   }
 }

--- a/codebase/superdarn/src.lib/tk/fitacf.2.5/src/noise_acf.c
+++ b/codebase/superdarn/src.lib/tk/fitacf.2.5/src/noise_acf.c
@@ -92,7 +92,7 @@ double noise_acf(double mnpwr,struct FitPrm *ptr, double *pwr,
 
   for (i=0; i< ptr->mplgs; i++) {
 	if (np[i] > 2) {
-	  n_acf[i] = n_acf[i])/np[i];
+	  n_acf[i] = n_acf[i]/np[i];
 	} else {
 	  n_acf[i] = 0.0 + 0.0 * I;
 	}


### PR DESCRIPTION
Reverting error introduced with #620.

Tested by using `map_addmodel -old_aacgm` from the commit before #620 was merged and verifying identical fields in the resulting map file. I used [dmap](https://github.com/SuperDARNCanada/dmap) to read in the files, then used straight equality checks for each field of each record.