### PR TITLE
Modifying sim_real to support XCFs and 16-pulse sequence

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/doc/sim_real.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/sim_real.1.0/doc/sim_real.doc.xml
@@ -15,6 +15,8 @@
 </option>
 <option><on>-tauscan</on><od>use Ray Greenwald's 13-pulse sequence.</od>
 </option>
+<option><on>-spaletascan</on><od>use Mrinal Balaji / Jef Spaleta's 16-pulse sequence.</od>
+</option>
 <option><on>-oldscan</on><od>use the old 7-pulse sequence.</od>
 </option>
 <option><on>-constant</on><od>use a constant irregularity lifetime distribution (default is exponential).</od>


### PR DESCRIPTION
As the title suggests, this pull request builds on #521 by adding XCF support to `sim_real`, which we believe was intended to take a FITACF-format file as input and generate simulated ACFs for each beam and range gate where the quality flag was set to 1 (ie for subsequent testing of different fitting algorithms).  I've also added support for the extended 16-pulse sequence that was previously added to `make_sim`.

One outstanding issue (that hopefully @pasha-ponomarenko can help address) - I do not think the `noise_lev` parameter is being handled correctly.  In AJ's original implementation, he used a plain-text file where some input value of `noise_lev` was used to scale the lag0 power to assign `amp0` at each range gate, eg

```
fscanf(fitfp,"%d  %lf  %d  %lf  %d  %d  %lf  %lf  %lf  %d\n",&cpid,&freq,&prm->bmnum,&noise_lev,&nave,&lagfr,&dt,&smsep,&rngsep,&nrang);
...
amp0 = noise_lev*pow(10.,(fit->rng[i].p_0/10.));
amp0_arr[i] = amp0;
```

In AJ's original code he set the `noise.search` field in the output RAWACF file's parameter block to this input value, so I naively assumed that `noise.search` from the input FITACF file could be used as `noise_lev` for the above amplitude scaling.  However this does not appear to be the case (at least not for the MSI-style radars like Christmas Valley and Iceland I've tested), causing the subsequent fits to the ACFs and XCFs to fail and the calculated SNR's to be wrong.