### PR TITLE
Modifying trim_iq to add support for optional chnnum

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/trim_iq.1.5/doc/trim_iq.doc.xml
+++ b/codebase/superdarn/src.bin/tk/tool/trim_iq.1.5/doc/trim_iq.doc.xml
@@ -22,6 +22,8 @@
 </option>
 <option><on>-ex <ar>hr:mn</ar></on><od>extract an interval whose extent is <ar>hr:mn</ar>.</od>
 </option>
+<option><on>-chnnum <ar>chnnum</ar></on><od>set the number of receiver channels to <ar>chnnum</ar>. The default value is taken from the IQ structure of the input <code>iqdat</code> format file.</od>
+</option>
 <option><on><ar>iqdatname</ar></on><od>filename of the <code>iqdat</code> format file to trim. If this is omitted, the file will be read from standard input</od>
 </option>
 

--- a/codebase/superdarn/src.bin/tk/tool/trim_iq.1.5/trim_iq.c
+++ b/codebase/superdarn/src.bin/tk/tool/trim_iq.1.5/trim_iq.c
@@ -124,6 +124,8 @@ int main (int argc,char *argv[]) {
 
   FILE *fp=NULL;
 
+  int chnnum=0;
+
   // origin time for when the file is produced
   time_t ctime;
   // counter for origin command length  
@@ -145,6 +147,7 @@ int main (int argc,char *argv[]) {
   OptionAdd(&opt,"sd",'t',&sdtestr);
   OptionAdd(&opt,"ed",'t',&edtestr);
   OptionAdd(&opt,"ex",'t',&exstr);
+  OptionAdd(&opt,"chnnum",'i',&chnnum);
 
   arg=OptionProcess(1,argc,argv,&opt,rst_opterr);
 
@@ -234,17 +237,18 @@ int main (int argc,char *argv[]) {
 
   if (extime !=0) etime=stime+extime;
 
-    // initialize array to be empty?
-    command[0]=0;
-    for (int c=0; c<argc; c++) {
-      // check if the origin command is too long
-      n+=strlen(argv[c])+1;
-      // if so cut it off
-      if (n>127) break;
-      // add space between command line arguments and copy to origin command
-      if (c !=0) strcat(command," ");
-      strcat(command, argv[c]);
-    }
+  // initialize array to be empty?
+  command[0]=0;
+  for (int c=0; c<argc; c++) {
+    // check if the origin command is too long
+    n+=strlen(argv[c])+1;
+    // if so cut it off
+    if (n>127) break;
+    // add space between command line arguments and copy to origin command
+    if (c !=0) strcat(command," ");
+    strcat(command, argv[c]);
+  }
+
   do {
 
     atime=TimeYMDHMSToEpoch(prm->time.yr,prm->time.mo,prm->time.dy,
@@ -268,14 +272,16 @@ int main (int argc,char *argv[]) {
       fprintf(stderr,"\n");
     }
 
-      // origin  code 1 means it is not produced on site
-      prm->origin.code=1;
-      // copy it over to the file
-      ctime= time((time_t) 0);
-      RadarParmSetOriginCommand(prm,command);
-      strcpy(tmstr,asctime(gmtime(&ctime)));
-      tmstr[24]=0;
-      RadarParmSetOriginTime(prm,tmstr);
+    // origin  code 1 means it is not produced on site
+    prm->origin.code=1;
+    // copy it over to the file
+    ctime= time((time_t) 0);
+    RadarParmSetOriginCommand(prm,command);
+    strcpy(tmstr,asctime(gmtime(&ctime)));
+    tmstr[24]=0;
+    RadarParmSetOriginTime(prm,tmstr);
+
+    if (chnnum > 0) iq->chnnum=chnnum;
 
     IQFwrite(stdout,prm,iq,badtr,samples);
 


### PR DESCRIPTION
This pull request fixes a bug accidentally introduced by #566.  That pull request fixed a bug where the `data` arrays in `iqdat` files for some radars were being incorrectly doubled in size (#565). However, I just discovered this caused a new problem for certain radars (probably just the QNX6/MSI-style radars like Fort Hays and Christmas Valley) where `trim_iq` would only carry over half the `data` array of each record to the output file.

To address this, I've added a new (optional) `chnnum` keyword to `trim_iq` allowing users to override the default `chnnum` value in the `iq` structure (similar to `make_raw`).  Note that I've also cleaned up some other line spacing elsewhere in `trim_iq`.