### PR TITLE
Updating compilation test to use new NASA CDF library version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
         cc: ["gcc-default"]
-        cdf: ["39_0"]
+        cdf: ["39_1"]
 
     name: ${{ matrix.cc }} on ${{ matrix.os }} with CDF ${{ matrix.cdf }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
         cc: ["gcc-default"]
-        cdf: ["39_1"]
+        cdf: ["39_0"]
 
     name: ${{ matrix.cc }} on ${{ matrix.os }} with CDF ${{ matrix.cdf }}
     runs-on: ${{ matrix.os }}
@@ -25,7 +25,7 @@ jobs:
         cat build/.requirements.ubuntu | xargs sudo apt-get install
         echo "Get and install NASA CDF"
         sudo apt-get install wget
-        wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/latest/linux/cdf${{ matrix.cdf }}-dist-cdf.tar.gz
+        wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf${{ matrix.cdf }}/linux/cdf${{ matrix.cdf }}-dist-cdf.tar.gz
         tar -xzvf cdf${{ matrix.cdf }}-dist-cdf.tar.gz
         cd cdf${{ matrix.cdf }}-dist
         make OS=linux ENV=gnu all
@@ -39,7 +39,7 @@ jobs:
         xargs brew install < build/.requirements.darwin
         echo "Get and install NASA CDF"
         brew install wget
-        wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/latest/linux/cdf${{ matrix.cdf }}-dist-cdf.tar.gz
+        wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf${{ matrix.cdf }}/linux/cdf${{ matrix.cdf }}-dist-cdf.tar.gz
         tar -xzvf cdf${{ matrix.cdf }}-dist-cdf.tar.gz
         cd cdf${{ matrix.cdf }}-dist
         make OS=macosx ENV=arm all


### PR DESCRIPTION
This pull request modifies the `main.yml` file used by the GitHub compilation test to retrieve the latest version of the NASA CDF library (39.1).  Currently, the compilation test fails for both Ubuntu and MacOS because it can't find version 39.0.

Note this has solved the issue for Ubuntu, but the test is still failing for MacOS (at a later stage when compiling CDF):

```
install_name_tool -change libcdf.dylib @executable_path/../lib/libcdf.dylib ./bin/cdfedit
error: /Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: can't open file: ./bin/cdfedit (No such file or directory)
make[1]: *** [dylibbundler.file] Error 1
make: *** [copy.tools] Error 2
Error: Process completed with exit code 2.
```