### PR TITLE
Updating radar.dat and HAN hdw.dat files after Borealis upgrade

### DIFF
--- a/tables/superdarn/hdw/hdw.dat.han
+++ b/tables/superdarn/hdw/hdw.dat.han
@@ -2,8 +2,12 @@
 #
 # **********************************************************************
 # ==Notes==
-#
-#
+# Updated on 15/07/25 by M Jones following the installation of the 'Borealis' SDR system at Han.
+#      - Added entry for system back online 08072025
+#      - Added estimated TDIFF of 225 ns for channel A. Set Channel B TDIFF to 0 ns as not used with Borealis system.
+#      - RXRIS changed to 0 us. Rise time assumed to be < 10 us with Borealis system.
+#      - Number of attenuation stages changed to 0 as no gain control of front end with Borealis system.
+#      - Number of range gates increased to 225 to reflect capability of Borealis system.
 # **********************************************************************
 #
 #                              GEOGRAPHIC              BORE-   OFF  BEAM V  |--------- interferometer ---------| |--- RX ---| RNG MX
@@ -11,4 +15,5 @@
   10  1 19950222 00:00:00  62.31357   26.60562    0.0  -12.0  0.00  3.24  1  1  0.000  0.000    0.0  185.0  -2.2  100.0  10 7  75 16
   10  1 19951207 00:00:00  62.31357   26.60562    0.0  -12.0  0.00  3.24  1  1  0.135  0.181    0.0  185.0  -2.2  100.0  10 7  75 16
   10 -1 20190720 00:00:00  62.31357   26.60562    0.0  -12.0  0.00  3.24  1  1  0.135  0.181    0.0  185.0  -2.2  100.0  10 7  75 16
+  10  1 20250708 00:00:00  62.31357   26.60562    0.0  -12.0  0.00  3.24  1  1  0.225  0.000    0.0  185.0  -2.2    0.0  10 0 225 16
 # EOF

--- a/tables/superdarn/radar.dat
+++ b/tables/superdarn/radar.dat
@@ -42,7 +42,7 @@
 7    1 20000108 25000101 "Kodiak"                  "Penn State University"               "hdw.dat.kod" "kod" "a"
 8   -1 19940601 20190322 "Stokkseyri"              "Lancaster University"                "hdw.dat.sto" "sto" "w"
 9   -1 19951120 20180909 "Pykkvibaer"              "University of Leicester"             "hdw.dat.pyk" "pyk" "e"
-10  -1 19950222 20190720 "Hankasalmi"              "University of Leicester"             "hdw.dat.han" "han" "f"
+10   1 19950222 25000101 "Hankasalmi"              "University of Leicester"             "hdw.dat.han" "han" "f"
 11   1 19970302 25000101 "SANAE"                   "University of KwaZulu-Natal"         "hdw.dat.san" "san" "d"
 12   1 19950201 25000101 "Syowa South"             "NIPR"                                "hdw.dat.sys" "sys" "j"
 13   1 19970208 25000101 "Syowa East"              "NIPR"                                "hdw.dat.sye" "sye" "n"


### PR DESCRIPTION
This pull request updates the radar.dat and Hankasalmi (HAN) hdw.dat files following the upgrade to a new Borealis system and resumed radar operations in July 2025, as provided by the radar PI (Tim Yeoman) - see https://github.com/SuperDARN/hdw/pull/12.