### PR TITLE
Comment out `nan` warning message - fitacf3

### DIFF
--- a/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/fitting.c
+++ b/codebase/superdarn/src.lib/tk/fitacf_v3.0/src/fitting.c
@@ -254,11 +254,12 @@ void calculate_phase_sigma(llist_node phase, llist_node range, FITPRMS *fit_prms
     pwr = exp(-1 * fabs(range_node->l_pwr_fit->b) * phase_node->t);
     inverse_pwr_2 = 1/(pwr * pwr);
     phase_node->sigma = sqrt((inverse_alpha_2 * inverse_pwr_2 - 1)/(2 * fit_prms->nave));
-    if(isnan(phase_node->sigma)){
+//  TODO: Figure out why this is here and if something should be done if nan values appear
+/*    if(isnan(phase_node->sigma)){
       fprintf(stderr,"range: %d, inverse_alpha: %f, pwr slope: %f, pwr: %f, inverse pwr: %f\n",
         range_node->range,inverse_alpha_2, range_node->l_pwr_fit->b,pwr,inverse_pwr_2);
     }
-
+*/
 }
 
 /**


### PR DESCRIPTION
As we discussed in the Nov. 2025 Data Analysis Working Group meeting, some of the regenerated `cve`, `cvw` have `-nan` values in the acfd and other data arrays.  These values cause the current fitacf3 processing to output a lot of warning messages about calculated values that are also `-nan`.

This pull request comments out the check for `-nan` and the subsequent warning print statement.  An example file which this fixes is the `20201231.0601.00.cvw.rawacf.bz2` file.