### PR TITLE
Change attenuation variable being used by make_raw

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/make_raw.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_raw.1.8/make_raw.c
@@ -355,7 +355,7 @@ int main (int argc,char *argv[]) {
       ACFSumPower(&tprm,mplgs,lag,pwr0,
                   ptr,rngoff,skpval !=0,
                   roff,ioff,badrng,
-                  iq->noise[n],prm->mxpwr,prm->atten*atstp,
+                  iq->noise[n],prm->mxpwr,iq->atten[n]*atstp,
                   thr,lmt,&abflg);
 
       ACFCalculate(&tprm,ptr,rngoff,skpval !=0,


### PR DESCRIPTION
This pull request modifies the `make_raw` binary to use the `iq->atten` values instead of `prm->atten` when calling `ACFSumPower`.  This is both for consistency with the on-site radar processing software (eg, https://github.com/SuperDARN/ros-archive/blob/ros.1.25/qnx/code/src.lib/radarqnx4/integrategc214.1.29/src/integrategc214.c#L326-L329), and to avoid conflicts with recent changes to US USRP-style radars that use the (previously unused) `prm->atten` field to track attenuation and amplification settings in the receiver front-end cards.

Note this branch was based on the 5.1.1 release, so it should not be merged into develop until after that release is finalized.