### PR TITLE
Fixes to AACGM_v2 conversions and rpos geolocation

### DIFF
--- a/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/field_plot.1.12/field_plot.c
@@ -261,7 +261,7 @@ int AACGM_v2_transform(int ssze,void *src,int dsze,void *dst,void *data) {
   if (data==NULL) {
     glat=pnt[0];
     glon=pnt[1];
-    s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&r,0);
+    s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&r,GEOCENTRIC);
     pnt=(float *)dst;
     pnt[0]=mlat;
     pnt[1]=mlon;

--- a/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/fov_plot.1.10/fov_plot.c
@@ -146,7 +146,7 @@ int AACGM_v2_transform(int ssze,void *src,int dsze,void *dst,void *data) {
   if (data==NULL) {
     glat=pnt[0];
     glon=pnt[1];
-    s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&r,0);
+    s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&r,GEOCENTRIC);
     pnt=(float *)dst;
     pnt[0]=mlat;
     pnt[1]=mlon;

--- a/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/grid_plot.1.12/grid_plot.c
@@ -231,7 +231,7 @@ int AACGM_v2_transform(int ssze,void *src,int dsze,void *dst,void *data) {
   if (data==NULL) {
     glat=pnt[0];
     glon=pnt[1];
-    s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&r,0);
+    s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&r,GEOCENTRIC);
     pnt=(float *)dst;
     pnt[0]=mlat;
     pnt[1]=mlon;

--- a/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
+++ b/codebase/superdarn/src.bin/tk/plot/map_plot.1.12/map_plot.c
@@ -1802,7 +1802,7 @@ int AACGM_v2_transform(int ssze,void *src,int dsze,void *dst,void *data)
   if (data==NULL) {
     glat=pnt[0];
     glon=pnt[1];
-    s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&r,0);
+    s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&r,GEOCENTRIC);
     pnt=(float *)dst;
     pnt[0]=mlat;
     pnt[1]=mlon;

--- a/codebase/superdarn/src.idl/lib/main.1.25/radar.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/radar.pro
@@ -858,6 +858,10 @@ pro RadarFldPnth,gdlat,gdlon,psi,bore,fh,r,frho,flat,flon,chisham=chisham
   
     endrep until (abs(fhx-xh) le 0.5)
 
+    if keyword_set(chisham) and r gt 2137.5 then begin
+        frho = frad + sqrt(rrad*rrad + (r/3.0)*(r/3.0) + 2.0*(r/3.0)*rrad*sin(!PI*xel/180.0)) - rrad
+    endif
+
 end
  
 

--- a/codebase/superdarn/src.lib/tk/binplotlib.1.0/src/geobeam.c
+++ b/codebase/superdarn/src.lib/tk/binplotlib.1.0/src/geobeam.c
@@ -41,22 +41,9 @@ int GeoLocCenter(struct RadarSite *site,int mag,float *lat,float *lon,
             300.0,&rho,&glat,&glon,&srng,chisham);
 
     if (mag) { 
-        if (old_aacgm) 
-        {
-            s=AACGMConvert(glat,glon,300,&mlat,&mlon,&rho,0);
-            if (s == -1)
-            {
-                fprintf(stderr, "Warning: AACGMConvert returned a -1\n");
-            }
-        }
-        else
-        {
-            s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&rho,0);
-            if (s == -1)
-            {
-                fprintf(stderr, "Warning: AACGMConvert returned a -1\n");
-            }
-        }
+        if (old_aacgm) s=AACGMConvert(glat,glon,300,&mlat,&mlon,&rho,0);
+        else           s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&rho,GEOCENTRIC);
+        if (s == -1) printf(stderr, "Warning: AACGMConvert returned a -1\n");
         *lat=mlat;
         *lon=mlon;
     } else {
@@ -134,29 +121,16 @@ int GeoLocBeam(struct RadarSite *site,int year,
 
         glat=geol->bm[n].glat[0][rng];
         glon=geol->bm[n].glon[0][rng];
-        if (old_aacgm) 
-        {
-            s=AACGMConvert(glat,glon,300,&mlat,&mlon,&rho,0);
-            if (s == -1)
-            {
-                fprintf(stderr, "Warning: AACGMConvert returned a -1\n");
-            }
-        }
-        else           
-        {
-            s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&rho,0);
-            if (s == -1)
-            {
-                fprintf(stderr, "Warning: AACGMConvert returned a -1\n");
-            }
-        }
+        if (old_aacgm) s=AACGMConvert(glat,glon,300,&mlat,&mlon,&rho,0);
+        else           s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&rho,GEOCENTRIC);
+        if (s == -1) fprintf(stderr, "Warning: AACGMConvert returned a -1\n");
         geol->bm[n].mlat[0][rng]=mlat;
         geol->bm[n].mlon[0][rng]=mlon;
 
         glat=geol->bm[n].glat[2][rng];
         glon=geol->bm[n].glon[2][rng];
         if (old_aacgm) s=AACGMConvert(glat,glon,300,&mlat,&mlon,&rho,0);
-        else           s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&rho,0);
+        else           s=AACGM_v2_Convert(glat,glon,300,&mlat,&mlon,&rho,GEOCENTRIC);
         geol->bm[n].mlat[2][rng]=mlat;
         geol->bm[n].mlon[2][rng]=mlon;
         if (rng<bm->nrang) {

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/src/cnvtcoord.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/src/cnvtcoord.c
@@ -273,6 +273,12 @@ void fldpnth(double gdlat, double gdlon, double psi, double bore,
     
     } while(fabs(fhx-xh) > 0.5);
 
+    /* Use actual elevation angle for 1.5-hop propagation with Chisham model
+     * to find true virtual height (instead of pseudo virtual height) */
+    if ((chisham) && (r>2137.5)) {
+        *frho = frad + sqrt(RE*RE + (r/3.0)*(r/3.0) + 2.0*(r/3.0)*RE*sind(xel))-RE;
+    }
+
 } 
 
 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/src/cnvtcoord.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/src/cnvtcoord.c
@@ -276,7 +276,7 @@ void fldpnth(double gdlat, double gdlon, double psi, double bore,
     /* Use actual elevation angle for 1.5-hop propagation with Chisham model
      * to find true virtual height (instead of pseudo virtual height) */
     if ((chisham) && (r>2137.5)) {
-        *frho = frad + sqrt(RE*RE + (r/3.0)*(r/3.0) + 2.0*(r/3.0)*RE*sind(xel))-RE;
+        *frho = frad + sqrt(rrad*rrad + (r/3.0)*(r/3.0) + 2.0*(r/3.0)*rrad*sind(xel)) - rrad;
     }
 
 } 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/src/cnvtcoord.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/src/cnvtcoord.c
@@ -410,7 +410,7 @@ void RPosMag(int center,int bcrd,int rcrd,
             height,d,rho,lat,lng,chisham);
 
     if (old_aacgm) AACGMConvert(*lat,*lng,(double) height,lat,lng,&radius,0);
-    else           AACGM_v2_Convert(*lat,*lng,(double) height,lat,lng,&radius,0);
+    else           AACGM_v2_Convert(*lat,*lng,(double) height,lat,lng,&radius,GEOCENTRIC);
 
 }
 

--- a/codebase/superdarn/src.lib/tk/rpos.1.7/src/invmag.c
+++ b/codebase/superdarn/src.lib/tk/rpos.1.7/src/invmag.c
@@ -399,7 +399,7 @@ int RPosInvMag(int bm, int rn, int year, struct RadarSite *hdw, double frang,
       *mlat = out[0];
       *mlon = out[1];
     } else if (magflg == 1) s=AACGMConvert(flat,flon,tmp_ht,mlat,mlon,&dummy,0);
-    else s=AACGM_v2_Convert(flat,flon,tmp_ht,mlat,mlon,&dummy,0);
+    else s=AACGM_v2_Convert(flat,flon,tmp_ht,mlat,mlon,&dummy,GEOCENTRIC);
     if (s==-1) return -1;
 
     /* Calculate pointing direction latitude/longitude (xlat,xlon) given
@@ -416,7 +416,7 @@ int RPosInvMag(int bm, int rn, int year, struct RadarSite *hdw, double frang,
       nlat = out[0];
       nlon = out[1];
     } else if (magflg == 1) s=AACGMConvert(xlat,xlon,tmp_ht,&nlat,&nlon,&dummy,0);
-    else s=AACGM_v2_Convert(xlat,xlon,tmp_ht,&nlat,&nlon,&dummy,0);
+    else s=AACGM_v2_Convert(xlat,xlon,tmp_ht,&nlat,&nlon,&dummy,GEOCENTRIC);
     if (s==-1) return -1;
 
     /* Make sure nlon varies between +/- 180 degrees */


### PR DESCRIPTION
This pull request addresses #660 and #548 by making several changes throughout the RST.  First, the calls to `AACGM_v2_Convert` now use the `GEOCENTRIC` option where the input coordinates are already in geocentric (rather than geodetic) coordinates, thus avoiding an extra conversion into geocentric coordinates.  There isn't an obvious way to test this other than to insert your own debug print statements into the modified plotting binaries or `invmag.c`, or just running `make_grid` to ensure it still gives nearly identical results.

Second, an older bug causing AACGM_v2 warnings when applying the Chisham virtual height model to very long-range (presumably multi-hop) scatter has been fixed by modifying `fldpnth` to return the "corrected" virtual height for multi-hop ionospheric scatter rather than the artificially-high "pseudo" virtual height needed for the Chisham VHM's range-finding.  This particular fix is most easily tested by using `make_grid` with the `-chisham` keyword on recent Falkland Islands (FIR) data.

Note there is another error in `cnvtcoord.c` where input elevation angles are not correctly handled by `fldpnth`, but that may be better left for another pull request (or perhaps those functions should be replaced entirely by the more comprehensive `RPosGeo_v2` functionality I added a few years ago).