### PR TITLE
Adding new wide (TX) field to the radar parameter block

### DIFF
--- a/codebase/superdarn/src.idl/lib/main.1.25/rprm.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/rprm.pro
@@ -96,6 +96,7 @@ pro RadarMakeRadarPrm,prm
          tfreq: 0, $
          offset: 0, $
          ifmode: 0, $
+         wide: 0, $
          mxpwr: 0L, $
          lvmax: 0L, $
          pulse: intarr(PULSE_SIZE), $
@@ -149,6 +150,7 @@ function RadarEncodeRadarPrm,prm,sclvec,arrvec,new=new
   s=DataMapMakeScalar('mplgs',prm.mplgs,sclvec)
   s=DataMapMakeScalar('mplgexs',prm.mplgexs,sclvec)
   s=DataMapMakeScalar('ifmode',prm.ifmode,sclvec)
+  s=DataMapMakeScalar('wide',prm.wide,sclvec)
   s=DataMapMakeScalar('nrang',prm.nrang,sclvec)
   s=DataMapMakeScalar('frang',prm.frang,sclvec)
   s=DataMapMakeScalar('rsep',prm.rsep,sclvec)
@@ -175,11 +177,11 @@ function RadarDecodeRadarPrm,prm,sclvec,arrvec
            'time.us','txpow','nave','atten','lagfr','smsep','ercod', $
            'stat.agc','stat.lopwr','noise.search','noise.mean','channel', $
            'bmnum','bmazm','scan','offset','rxrise','intt.sc','intt.us', $
-           'txpl', 'mpinc','mppul','mplgs','mplgexs','ifmode','nrang', $
+           'txpl', 'mpinc','mppul','mplgs','mplgexs','ifmode','wide','nrang', $
            'frang', 'rsep','xcf','tfreq', 'mxpwr','lvmax','combf']
 
   scltype=[1,1,1,9,9,2,2,2,2,2,2,2,2,3,2,2,2,2,2,2,2,2,4,4,2,2,4,2,2,2,2,3, $
-           2,2,2,2,2,2,2,2,2,2,2,3,3,9]
+           2,2,2,2,2,2,2,2,2,2,2,2,3,3,9]
   
   sclid=intarr(n_elements(sclname))
   sclid[*]=-1
@@ -258,13 +260,14 @@ function RadarDecodeRadarPrm,prm,sclvec,arrvec
   if (sclid[35] ne -1) then prm.mplgs=*(sclvec[sclid[35]].ptr)
   if (sclid[36] ne -1) then prm.mplgexs=*(sclvec[sclid[36]].ptr)
   if (sclid[37] ne -1) then prm.ifmode=*(sclvec[sclid[37]].ptr)
-  if (sclid[38] ne -1) then prm.nrang=*(sclvec[sclid[38]].ptr)
-  if (sclid[39] ne -1) then prm.frang=*(sclvec[sclid[39]].ptr)
-  if (sclid[40] ne -1) then prm.rsep=*(sclvec[sclid[40]].ptr)
-  if (sclid[41] ne -1) then prm.xcf=*(sclvec[sclid[41]].ptr)
-  if (sclid[42] ne -1) then prm.tfreq=*(sclvec[sclid[42]].ptr)
-  if (sclid[43] ne -1) then prm.mxpwr=*(sclvec[sclid[43]].ptr)
-  if (sclid[44] ne -1) then prm.lvmax=*(sclvec[sclid[44]].ptr)
+  if (sclid[38] ne -1) then prm.wide=*(sclvec[sclid[38]].ptr)
+  if (sclid[39] ne -1) then prm.nrang=*(sclvec[sclid[39]].ptr)
+  if (sclid[40] ne -1) then prm.frang=*(sclvec[sclid[40]].ptr)
+  if (sclid[41] ne -1) then prm.rsep=*(sclvec[sclid[41]].ptr)
+  if (sclid[42] ne -1) then prm.xcf=*(sclvec[sclid[42]].ptr)
+  if (sclid[43] ne -1) then prm.tfreq=*(sclvec[sclid[43]].ptr)
+  if (sclid[44] ne -1) then prm.mxpwr=*(sclvec[sclid[44]].ptr)
+  if (sclid[45] ne -1) then prm.lvmax=*(sclvec[sclid[45]].ptr)
   if (prm.mppul gt 0) && (arrid[0] ne -1) then $
      prm.pulse[0:prm.mppul-1]=*(arrvec[arrid[0]].ptr)
   if (prm.mplgs gt 0) && (arrid[1] ne -1) then $

--- a/codebase/superdarn/src.idl/lib/main.1.25/rprm.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/rprm.pro
@@ -96,7 +96,7 @@ pro RadarMakeRadarPrm,prm
          tfreq: 0, $
          offset: 0, $
          ifmode: 0, $
-         wide: 0, $
+         widetx: 0, $
          mxpwr: 0L, $
          lvmax: 0L, $
          pulse: intarr(PULSE_SIZE), $
@@ -150,7 +150,7 @@ function RadarEncodeRadarPrm,prm,sclvec,arrvec,new=new
   s=DataMapMakeScalar('mplgs',prm.mplgs,sclvec)
   s=DataMapMakeScalar('mplgexs',prm.mplgexs,sclvec)
   s=DataMapMakeScalar('ifmode',prm.ifmode,sclvec)
-  s=DataMapMakeScalar('wide',prm.wide,sclvec)
+  s=DataMapMakeScalar('widetx',prm.widetx,sclvec)
   s=DataMapMakeScalar('nrang',prm.nrang,sclvec)
   s=DataMapMakeScalar('frang',prm.frang,sclvec)
   s=DataMapMakeScalar('rsep',prm.rsep,sclvec)
@@ -177,7 +177,7 @@ function RadarDecodeRadarPrm,prm,sclvec,arrvec
            'time.us','txpow','nave','atten','lagfr','smsep','ercod', $
            'stat.agc','stat.lopwr','noise.search','noise.mean','channel', $
            'bmnum','bmazm','scan','offset','rxrise','intt.sc','intt.us', $
-           'txpl', 'mpinc','mppul','mplgs','mplgexs','ifmode','wide','nrang', $
+           'txpl', 'mpinc','mppul','mplgs','mplgexs','ifmode','widetx','nrang', $
            'frang', 'rsep','xcf','tfreq', 'mxpwr','lvmax','combf']
 
   scltype=[1,1,1,9,9,2,2,2,2,2,2,2,2,3,2,2,2,2,2,2,2,2,4,4,2,2,4,2,2,2,2,3, $
@@ -260,7 +260,7 @@ function RadarDecodeRadarPrm,prm,sclvec,arrvec
   if (sclid[35] ne -1) then prm.mplgs=*(sclvec[sclid[35]].ptr)
   if (sclid[36] ne -1) then prm.mplgexs=*(sclvec[sclid[36]].ptr)
   if (sclid[37] ne -1) then prm.ifmode=*(sclvec[sclid[37]].ptr)
-  if (sclid[38] ne -1) then prm.wide=*(sclvec[sclid[38]].ptr)
+  if (sclid[38] ne -1) then prm.widetx=*(sclvec[sclid[38]].ptr)
   if (sclid[39] ne -1) then prm.nrang=*(sclvec[sclid[39]].ptr)
   if (sclid[40] ne -1) then prm.frang=*(sclvec[sclid[40]].ptr)
   if (sclid[41] ne -1) then prm.rsep=*(sclvec[sclid[41]].ptr)
@@ -272,7 +272,7 @@ function RadarDecodeRadarPrm,prm,sclvec,arrvec
      prm.pulse[0:prm.mppul-1]=*(arrvec[arrid[0]].ptr)
   if (prm.mplgs gt 0) && (arrid[1] ne -1) then $
      prm.lag[0:prm.mplgs,*]=(*(arrvec[arrid[1]].ptr))[*,*]
-  if (sclid[45] ne -1) then prm.combf=*(sclvec[sclid[45]].ptr)
+  if (sclid[46] ne -1) then prm.combf=*(sclvec[sclid[46]].ptr)
 
   return,0
 end

--- a/codebase/superdarn/src.idl/lib/main.1.25/snd.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/snd.pro
@@ -87,6 +87,7 @@ pro SndMakeSndData,snd
          rsep: 0, $
          xcf: 0, $
          tfreq: 0, $
+         wide: 0, $
          sky_noise: 0.0, $
          combf: '', $
          fit_revision: {rlstr, major: 0L, minor: 0L}, $
@@ -140,7 +141,7 @@ function SndRead,unit,snd
            'time.yr','time.mo','time.dy','time.hr','time.mt','time.sc', $
            'time.us','nave','lagfr','smsep','noise.search','noise.mean', $
            'channel','bmnum','bmazm','scan','rxrise','intt.sc','intt.us', $
-           'nrang','frang','rsep','xcf','tfreq','noise.sky', $
+           'nrang','frang','rsep','xcf','tfreq','wide','noise.sky', $
            'combf','fitacf.revision.major','fitacf.revision.minor', $
            'snd.revision.major','snd.revision.minor']
 
@@ -149,7 +150,7 @@ function SndRead,unit,snd
            2,2,2,2,2,2, $
            3,2,2,2,4,4, $
            2,2,4,2,2,2,3, $
-           2,2,2,2,2,4, $
+           2,2,2,2,2,2,4, $
            9,3,3, $
            2,2]
 
@@ -219,12 +220,13 @@ function SndRead,unit,snd
   if (sclid[28] ne -1) then snd.rsep=*(sclvec[sclid[28]].ptr)
   if (sclid[29] ne -1) then snd.xcf=*(sclvec[sclid[29]].ptr)
   if (sclid[30] ne -1) then snd.tfreq=*(sclvec[sclid[30]].ptr)
-  if (sclid[31] ne -1) then snd.sky_noise=*(sclvec[sclid[31]].ptr)
-  if (sclid[32] ne -1) then snd.combf=*(sclvec[sclid[32]].ptr)
-  if (sclid[33] ne -1) then snd.fit_revision.major=*(sclvec[sclid[33]].ptr)
-  if (sclid[34] ne -1) then snd.fit_revision.minor=*(sclvec[sclid[34]].ptr)
-  if (sclid[35] ne -1) then snd.snd_revision.major=*(sclvec[sclid[35]].ptr)
-  if (sclid[36] ne -1) then snd.snd_revision.minor=*(sclvec[sclid[36]].ptr)
+  if (sclid[31] ne -1) then snd.wide=*(sclvec[sclid[31]].ptr)
+  if (sclid[32] ne -1) then snd.sky_noise=*(sclvec[sclid[32]].ptr)
+  if (sclid[33] ne -1) then snd.combf=*(sclvec[sclid[33]].ptr)
+  if (sclid[34] ne -1) then snd.fit_revision.major=*(sclvec[sclid[34]].ptr)
+  if (sclid[35] ne -1) then snd.fit_revision.minor=*(sclvec[sclid[35]].ptr)
+  if (sclid[36] ne -1) then snd.snd_revision.major=*(sclvec[sclid[36]].ptr)
+  if (sclid[37] ne -1) then snd.snd_revision.minor=*(sclvec[sclid[37]].ptr)
 
   if (arrid[0] eq -1) then begin
     st=DataMapFreeScalar(sclvec)
@@ -317,6 +319,7 @@ function SndWrite,unit,snd
   s=DataMapMakeScalar('rsep',snd.rsep,sclvec)
   s=DataMapMakeScalar('xcf',snd.xcf,sclvec)
   s=DataMapMakeScalar('tfreq',snd.tfreq,sclvec)
+  s=DataMapMakeScalar('wide',snd.wide,sclvec)
   s=DataMapMakeScalar('noise.sky',snd.sky_noise,sclvec)
   s=DataMapMakeScalar('combf',snd.combf,sclvec)
   s=DataMapMakeScalar('snd.revision.major',snd.snd_revision.major,sclvec)

--- a/codebase/superdarn/src.idl/lib/main.1.25/snd.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/snd.pro
@@ -87,7 +87,7 @@ pro SndMakeSndData,snd
          rsep: 0, $
          xcf: 0, $
          tfreq: 0, $
-         wide: 0, $
+         widetx: 0, $
          sky_noise: 0.0, $
          combf: '', $
          fit_revision: {rlstr, major: 0L, minor: 0L}, $
@@ -141,7 +141,7 @@ function SndRead,unit,snd
            'time.yr','time.mo','time.dy','time.hr','time.mt','time.sc', $
            'time.us','nave','lagfr','smsep','noise.search','noise.mean', $
            'channel','bmnum','bmazm','scan','rxrise','intt.sc','intt.us', $
-           'nrang','frang','rsep','xcf','tfreq','wide','noise.sky', $
+           'nrang','frang','rsep','xcf','tfreq','widetx','noise.sky', $
            'combf','fitacf.revision.major','fitacf.revision.minor', $
            'snd.revision.major','snd.revision.minor']
 
@@ -220,7 +220,7 @@ function SndRead,unit,snd
   if (sclid[28] ne -1) then snd.rsep=*(sclvec[sclid[28]].ptr)
   if (sclid[29] ne -1) then snd.xcf=*(sclvec[sclid[29]].ptr)
   if (sclid[30] ne -1) then snd.tfreq=*(sclvec[sclid[30]].ptr)
-  if (sclid[31] ne -1) then snd.wide=*(sclvec[sclid[31]].ptr)
+  if (sclid[31] ne -1) then snd.widetx=*(sclvec[sclid[31]].ptr)
   if (sclid[32] ne -1) then snd.sky_noise=*(sclvec[sclid[32]].ptr)
   if (sclid[33] ne -1) then snd.combf=*(sclvec[sclid[33]].ptr)
   if (sclid[34] ne -1) then snd.fit_revision.major=*(sclvec[sclid[34]].ptr)
@@ -319,7 +319,7 @@ function SndWrite,unit,snd
   s=DataMapMakeScalar('rsep',snd.rsep,sclvec)
   s=DataMapMakeScalar('xcf',snd.xcf,sclvec)
   s=DataMapMakeScalar('tfreq',snd.tfreq,sclvec)
-  s=DataMapMakeScalar('wide',snd.wide,sclvec)
+  s=DataMapMakeScalar('widetx',snd.widetx,sclvec)
   s=DataMapMakeScalar('noise.sky',snd.sky_noise,sclvec)
   s=DataMapMakeScalar('combf',snd.combf,sclvec)
   s=DataMapMakeScalar('snd.revision.major',snd.snd_revision.major,sclvec)

--- a/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/include/rprmidl.h
+++ b/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/include/rprmidl.h
@@ -103,7 +103,7 @@ struct RadarIDLParm {
   short tfreq;
   short offset;
   short ifmode;
-  short wide;
+  short widetx;
 
   IDL_LONG mxpwr;
   IDL_LONG lvmax;

--- a/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/include/rprmidl.h
+++ b/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/include/rprmidl.h
@@ -103,6 +103,7 @@ struct RadarIDLParm {
   short tfreq;
   short offset;
   short ifmode;
+  short wide;
 
   IDL_LONG mxpwr;
   IDL_LONG lvmax;

--- a/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/src/rprmidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/src/rprmidl.c
@@ -87,7 +87,7 @@ void IDLCopyRadarParmFromIDL(struct RadarIDLParm *iprm,struct RadarParm *prm) {
   prm->tfreq=iprm->tfreq;
   prm->offset=iprm->offset;
   prm->ifmode=iprm->ifmode;
-  prm->wide=iprm->wide;
+  prm->widetx=iprm->widetx;
   prm->mxpwr=iprm->mxpwr;
   prm->lvmax=iprm->lvmax;
 
@@ -172,7 +172,7 @@ void IDLCopyRadarParmToIDL(struct RadarParm *prm,struct RadarIDLParm *iprm) {
   iprm->tfreq=prm->tfreq;
   iprm->offset=prm->offset;
   iprm->ifmode=prm->ifmode;
-  iprm->wide=prm->wide;
+  iprm->widetx=prm->widetx;
   iprm->mxpwr=prm->mxpwr;
   iprm->lvmax=prm->lvmax;
 
@@ -266,7 +266,7 @@ struct RadarIDLParm *IDLMakeRadarParm(IDL_VPTR *vptr) {
 
     {"OFFSET",0,(void *) IDL_TYP_INT}, /* 29 */
     {"IFMODE",0,(void *) IDL_TYP_INT}, /* 30 */
-    {"WIDE",0,(void *) IDL_TYP_INT},   /* 31 */
+    {"WIDETX",0,(void *) IDL_TYP_INT}, /* 31 */
     {"MXPWR",0,(void *) IDL_TYP_LONG}, /* 32 */
     {"LVMAX",0,(void *) IDL_TYP_LONG}, /* 33 */
     {"PULSE",pdim,(void *) IDL_TYP_INT}, /* 34 */

--- a/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/src/rprmidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/src/rprmidl.c
@@ -87,6 +87,7 @@ void IDLCopyRadarParmFromIDL(struct RadarIDLParm *iprm,struct RadarParm *prm) {
   prm->tfreq=iprm->tfreq;
   prm->offset=iprm->offset;
   prm->ifmode=iprm->ifmode;
+  prm->wide=iprm->wide;
   prm->mxpwr=iprm->mxpwr;
   prm->lvmax=iprm->lvmax;
 
@@ -171,6 +172,7 @@ void IDLCopyRadarParmToIDL(struct RadarParm *prm,struct RadarIDLParm *iprm) {
   iprm->tfreq=prm->tfreq;
   iprm->offset=prm->offset;
   iprm->ifmode=prm->ifmode;
+  iprm->wide=prm->wide;
   iprm->mxpwr=prm->mxpwr;
   iprm->lvmax=prm->lvmax;
 
@@ -264,11 +266,12 @@ struct RadarIDLParm *IDLMakeRadarParm(IDL_VPTR *vptr) {
 
     {"OFFSET",0,(void *) IDL_TYP_INT}, /* 29 */
     {"IFMODE",0,(void *) IDL_TYP_INT}, /* 30 */
-    {"MXPWR",0,(void *) IDL_TYP_LONG}, /* 31 */
-    {"LVMAX",0,(void *) IDL_TYP_LONG}, /* 32 */
-    {"PULSE",pdim,(void *) IDL_TYP_INT}, /* 33 */
-    {"LAG",ldim,(void *) IDL_TYP_INT}, /* 34 */
-    {"COMBF",0,(void *) IDL_TYP_STRING}, /* 35 */   
+    {"WIDE",0,(void *) IDL_TYP_INT},   /* 31 */
+    {"MXPWR",0,(void *) IDL_TYP_LONG}, /* 32 */
+    {"LVMAX",0,(void *) IDL_TYP_LONG}, /* 33 */
+    {"PULSE",pdim,(void *) IDL_TYP_INT}, /* 34 */
+    {"LAG",ldim,(void *) IDL_TYP_INT}, /* 35 */
+    {"COMBF",0,(void *) IDL_TYP_STRING}, /* 36 */
     {0}};
 
   static IDL_MEMINT ilDims[IDL_MAX_ARRAY_DIM];

--- a/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/include/sndidl.h
+++ b/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/include/sndidl.h
@@ -83,6 +83,7 @@ struct SndIDLData {
   short rsep;
   short xcf;
   short tfreq;
+  short wide;
 
   float sky_noise;
 

--- a/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/include/sndidl.h
+++ b/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/include/sndidl.h
@@ -83,7 +83,7 @@ struct SndIDLData {
   short rsep;
   short xcf;
   short tfreq;
-  short wide;
+  short widetx;
 
   float sky_noise;
 

--- a/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
@@ -80,7 +80,7 @@ void IDLCopySndDataFromIDL(int nrang, struct SndIDLData *isnd,
   snd->rsep = isnd->rsep;
   snd->xcf = isnd->xcf;
   snd->tfreq = isnd->tfreq;
-  snd->wide = isnd->wide;
+  snd->widetx = isnd->widetx;
   snd->sky_noise = isnd->sky_noise;
 
   if (strlen(IDL_STRING_STR(&isnd->combf)) !=0)
@@ -161,7 +161,7 @@ void IDLCopySndDataToIDL(int nrang, struct SndData *snd,
   isnd->rsep = snd->rsep;
   isnd->xcf = snd->xcf;
   isnd->tfreq = snd->tfreq;
-  isnd->wide = snd->wide;
+  isnd->widetx = snd->widetx;
   isnd->sky_noise = snd->sky_noise;
 
   if (snd->combf !=NULL) {
@@ -257,7 +257,7 @@ struct SndIDLData *IDLMakeSndData(IDL_VPTR *vptr) {
     {"RSEP",0,(void *) IDL_TYP_INT},    /* 17 */
     {"XCF",0,(void *) IDL_TYP_INT},     /* 18 */
     {"TFREQ",0,(void *) IDL_TYP_INT},   /* 19 */
-    {"WIDE",0,(void *) IDL_TYP_INT},    /* 20 */
+    {"WIDETX",0,(void *) IDL_TYP_INT},  /* 20 */
     {"SKY_NOISE",0,(void *) IDL_TYP_FLOAT}, /* 21 */
     {"COMBF",0,(void *) IDL_TYP_STRING}, /* 22 */
     {"FIT_REVISION",0,NULL},             /* 23 */

--- a/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
@@ -80,6 +80,7 @@ void IDLCopySndDataFromIDL(int nrang, struct SndIDLData *isnd,
   snd->rsep = isnd->rsep;
   snd->xcf = isnd->xcf;
   snd->tfreq = isnd->tfreq;
+  snd->wide = isnd->wide;
   snd->sky_noise = isnd->sky_noise;
 
   if (strlen(IDL_STRING_STR(&isnd->combf)) !=0)
@@ -160,6 +161,7 @@ void IDLCopySndDataToIDL(int nrang, struct SndData *snd,
   isnd->rsep = snd->rsep;
   isnd->xcf = snd->xcf;
   isnd->tfreq = snd->tfreq;
+  isnd->wide = snd->wide;
   isnd->sky_noise = snd->sky_noise;
 
   if (snd->combf !=NULL) {
@@ -255,19 +257,20 @@ struct SndIDLData *IDLMakeSndData(IDL_VPTR *vptr) {
     {"RSEP",0,(void *) IDL_TYP_INT},    /* 17 */
     {"XCF",0,(void *) IDL_TYP_INT},     /* 18 */
     {"TFREQ",0,(void *) IDL_TYP_INT},   /* 19 */
-    {"SKY_NOISE",0,(void *) IDL_TYP_FLOAT}, /* 20 */
-    {"COMBF",0,(void *) IDL_TYP_STRING}, /* 21 */
-    {"FIT_REVISION",0,NULL},             /* 22 */
-    {"SND_REVISION",0,NULL},             /* 23 */
-    {"QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 24 */
-    {"GFLG",rdim,(void *) IDL_TYP_BYTE}, /* 25 */
-    {"V",rdim,(void *) IDL_TYP_FLOAT},   /* 26 */
-    {"V_E",rdim,(void *) IDL_TYP_FLOAT}, /* 27 */
-    {"P_L",rdim,(void *) IDL_TYP_FLOAT}, /* 28 */
-    {"W_L",rdim,(void *) IDL_TYP_FLOAT}, /* 29 */
-    {"X_QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 30 */
-    {"PHI0",rdim,(void *) IDL_TYP_FLOAT}, /* 31 */
-    {"PHI0_E",rdim,(void *) IDL_TYP_FLOAT}, /* 32 */
+    {"WIDE",0,(void *) IDL_TYP_INT},    /* 20 */
+    {"SKY_NOISE",0,(void *) IDL_TYP_FLOAT}, /* 21 */
+    {"COMBF",0,(void *) IDL_TYP_STRING}, /* 22 */
+    {"FIT_REVISION",0,NULL},             /* 23 */
+    {"SND_REVISION",0,NULL},             /* 24 */
+    {"QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 25 */
+    {"GFLG",rdim,(void *) IDL_TYP_BYTE}, /* 26 */
+    {"V",rdim,(void *) IDL_TYP_FLOAT},   /* 27 */
+    {"V_E",rdim,(void *) IDL_TYP_FLOAT}, /* 28 */
+    {"P_L",rdim,(void *) IDL_TYP_FLOAT}, /* 29 */
+    {"W_L",rdim,(void *) IDL_TYP_FLOAT}, /* 30 */
+    {"X_QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 31 */
+    {"PHI0",rdim,(void *) IDL_TYP_FLOAT}, /* 32 */
+    {"PHI0_E",rdim,(void *) IDL_TYP_FLOAT}, /* 33 */
     {0}};
 
   static IDL_MEMINT ilDims[IDL_MAX_ARRAY_DIM];
@@ -277,8 +280,8 @@ struct SndIDLData *IDLMakeSndData(IDL_VPTR *vptr) {
   snddata[4].type=IDL_MakeStruct("TMSTR",time);
   snddata[8].type=IDL_MakeStruct("NSSTR",noise);
   snddata[14].type=IDL_MakeStruct("ITSTR",intt);
-  snddata[22].type=IDL_MakeStruct("RLSTR",fit_revision);
-  snddata[23].type=IDL_MakeStruct("SDSTR",snd_revision);
+  snddata[23].type=IDL_MakeStruct("RLSTR",fit_revision);
+  snddata[24].type=IDL_MakeStruct("SDSTR",snd_revision);
 
   s=IDL_MakeStruct("SNDDATA",snddata);
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/include/rprm.h
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/include/rprm.h
@@ -94,6 +94,7 @@ struct RadarParm {
   int16 tfreq;
   int16 offset; 
   int16 ifmode;
+  int16 wide;
 
   int32 mxpwr;
   int32 lvmax;

--- a/codebase/superdarn/src.lib/tk/radar.1.22/include/rprm.h
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/include/rprm.h
@@ -94,7 +94,7 @@ struct RadarParm {
   int16 tfreq;
   int16 offset; 
   int16 ifmode;
-  int16 wide;
+  int16 widetx;
 
   int32 mxpwr;
   int32 lvmax;

--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -278,8 +278,8 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
       prm->mplgexs=*(s->data.sptr);
     if ((strcmp(s->name,"ifmode")==0) && (s->type==DATASHORT))
       prm->ifmode=*(s->data.sptr);
-    if ((strcmp(s->name,"wide")==0) && (s->type==DATASHORT))
-      prm->wide=*(s->data.sptr);
+    if ((strcmp(s->name,"widetx")==0) && (s->type==DATASHORT))
+      prm->widetx=*(s->data.sptr);
     if ((strcmp(s->name,"nrang")==0) && (s->type==DATASHORT))
       prm->nrang=*(s->data.sptr);
     if ((strcmp(s->name,"frang")==0) && (s->type==DATASHORT))
@@ -365,7 +365,7 @@ int RadarParmEncode(struct DataMap *ptr,struct RadarParm *prm) {
   DataMapAddScalar(ptr,"mplgs",DATASHORT,&prm->mplgs);
   DataMapAddScalar(ptr,"mplgexs",DATASHORT,&prm->mplgexs);
   DataMapAddScalar(ptr,"ifmode",DATASHORT,&prm->ifmode);
-  DataMapAddScalar(ptr,"wide",DATASHORT,&prm->wide);
+  DataMapAddScalar(ptr,"widetx",DATASHORT,&prm->widetx);
 
   DataMapAddScalar(ptr,"nrang",DATASHORT,&prm->nrang);
   DataMapAddScalar(ptr,"frang",DATASHORT,&prm->frang);

--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -278,6 +278,8 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
       prm->mplgexs=*(s->data.sptr);
     if ((strcmp(s->name,"ifmode")==0) && (s->type==DATASHORT))
       prm->ifmode=*(s->data.sptr);
+    if ((strcmp(s->name,"wide")==0) && (s->type==DATASHORT))
+      prm->wide=*(s->data.sptr);
     if ((strcmp(s->name,"nrang")==0) && (s->type==DATASHORT))
       prm->nrang=*(s->data.sptr);
     if ((strcmp(s->name,"frang")==0) && (s->type==DATASHORT))
@@ -363,6 +365,7 @@ int RadarParmEncode(struct DataMap *ptr,struct RadarParm *prm) {
   DataMapAddScalar(ptr,"mplgs",DATASHORT,&prm->mplgs);
   DataMapAddScalar(ptr,"mplgexs",DATASHORT,&prm->mplgexs);
   DataMapAddScalar(ptr,"ifmode",DATASHORT,&prm->ifmode);
+  DataMapAddScalar(ptr,"wide",DATASHORT,&prm->wide);
 
   DataMapAddScalar(ptr,"nrang",DATASHORT,&prm->nrang);
   DataMapAddScalar(ptr,"frang",DATASHORT,&prm->frang);

--- a/codebase/superdarn/src.lib/tk/snd.1.0/include/snddata.h
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/include/snddata.h
@@ -83,7 +83,7 @@ struct SndData {
   int16 rsep;
   int16 xcf;
   int16 tfreq;
-  int16 wide;
+  int16 widetx;
 
   double sky_noise;
 

--- a/codebase/superdarn/src.lib/tk/snd.1.0/include/snddata.h
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/include/snddata.h
@@ -29,7 +29,7 @@ Modifications:
 
 
 #define SND_MAJOR_REVISION 1
-#define SND_MINOR_REVISION 1
+#define SND_MINOR_REVISION 2
 
 
 struct SndData {
@@ -83,6 +83,7 @@ struct SndData {
   int16 rsep;
   int16 xcf;
   int16 tfreq;
+  int16 wide;
 
   double sky_noise;
 

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
@@ -72,6 +72,7 @@ int FitToSnd(struct SndData *ptr, struct RadarParm *prm,
   ptr->rsep = prm->rsep;
   ptr->xcf = prm->xcf;
   ptr->tfreq = prm->tfreq;
+  ptr->wide = prm->wide;
   ptr->sky_noise = fit->noise.skynoise;
   ptr->fit_revision.major = fit->revision.major;
   ptr->fit_revision.minor = fit->revision.minor;

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
@@ -72,7 +72,7 @@ int FitToSnd(struct SndData *ptr, struct RadarParm *prm,
   ptr->rsep = prm->rsep;
   ptr->xcf = prm->xcf;
   ptr->tfreq = prm->tfreq;
-  ptr->wide = prm->wide;
+  ptr->widetx = prm->widetx;
   ptr->sky_noise = fit->noise.skynoise;
   ptr->fit_revision.major = fit->revision.major;
   ptr->fit_revision.minor = fit->revision.minor;

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndread.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndread.c
@@ -122,8 +122,8 @@ int SndDecode(struct DataMap *ptr, struct SndData *snd) {
       snd->xcf=*(s->data.sptr);
     if ((strcmp(s->name,"tfreq")==0) && (s->type==DATASHORT))
       snd->tfreq=*(s->data.sptr);
-    if ((strcmp(s->name,"wide")==0) && (s->type==DATASHORT))
-      snd->wide=*(s->data.sptr);
+    if ((strcmp(s->name,"widetx")==0) && (s->type==DATASHORT))
+      snd->widetx=*(s->data.sptr);
     if ((strcmp(s->name,"noise.sky")==0) && (s->type==DATAFLOAT))
       snd->sky_noise=*(s->data.fptr);
     if ((strcmp(s->name,"combf")==0) && (s->type==DATASTRING))

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndread.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndread.c
@@ -122,6 +122,8 @@ int SndDecode(struct DataMap *ptr, struct SndData *snd) {
       snd->xcf=*(s->data.sptr);
     if ((strcmp(s->name,"tfreq")==0) && (s->type==DATASHORT))
       snd->tfreq=*(s->data.sptr);
+    if ((strcmp(s->name,"wide")==0) && (s->type==DATASHORT))
+      snd->wide=*(s->data.sptr);
     if ((strcmp(s->name,"noise.sky")==0) && (s->type==DATAFLOAT))
       snd->sky_noise=*(s->data.fptr);
     if ((strcmp(s->name,"combf")==0) && (s->type==DATASTRING))

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
@@ -96,7 +96,7 @@ int SndWrite(int fid, struct SndData *snd) {
   DataMapAddScalar(ptr,"rsep",DATASHORT,&snd->rsep);
   DataMapAddScalar(ptr,"xcf",DATASHORT,&snd->xcf);
   DataMapAddScalar(ptr,"tfreq",DATASHORT,&snd->tfreq);
-  DataMapAddScalar(ptr,"wide",DATASHORT,&snd->wide);
+  DataMapAddScalar(ptr,"widetx",DATASHORT,&snd->widetx);
 
   sky_noise=snd->sky_noise;
   DataMapStoreScalar(ptr,"noise.sky",DATAFLOAT,&sky_noise);

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
@@ -96,6 +96,7 @@ int SndWrite(int fid, struct SndData *snd) {
   DataMapAddScalar(ptr,"rsep",DATASHORT,&snd->rsep);
   DataMapAddScalar(ptr,"xcf",DATASHORT,&snd->xcf);
   DataMapAddScalar(ptr,"tfreq",DATASHORT,&snd->tfreq);
+  DataMapAddScalar(ptr,"wide",DATASHORT,&snd->wide);
 
   sky_noise=snd->sky_noise;
   DataMapStoreScalar(ptr,"noise.sky",DATAFLOAT,&sky_noise);


### PR DESCRIPTION
This pull request modifies the C and IDL code to support a new `widetx` field in the radar parameter block to indicate if data were produced using a widebeam TX pattern.  For example, `dmapdump` will now show something like

```
	short	"mplgexs" = 0
	short	"ifmode" = 0
	short	"widetx" = 1
	short	"nrang" = 75
	short	"frang" = 180
	short	"rsep" = 45
```

To test, you can try reading / fitting files that were produced with and without this new field; all code should be compatible whether or not the field is present in the iqdat, rawacf, fitacf, or snd file.  On the develop branch the new `widetx` field will just be skipped over, but on this branch the `widetx` field should be correctly populated.