### PR TITLE
Improved metadata for file processing history

### DIFF
--- a/codebase/superdarn/src.bin/tk/tool/make_fit/make_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/make_fit/make_fit.c
@@ -507,8 +507,8 @@ int main(int argc,char *argv[]) {
     //set origin code = 1 which means produced not at a radar site
     prm->origin.code = 1;
     ctime = time((time_t) 0);
-    if (RadarParmSetOriginCommand(prm,command) == -1) {
-      fprintf(stderr,"Error: cannot set Origin Command\n");
+    if (RadarParmSetHistoryCommand(prm,command) == -1) {
+      fprintf(stderr,"Error: cannot set History Command\n");
       free_radarstructs(network, prm, raw);
       free_files(rawfp, fp, NULL, inxfp);
       free_fitstructs(fit_prms, fit, fblk);
@@ -517,8 +517,8 @@ int main(int argc,char *argv[]) {
 
     strcpy(tmstr,asctime(gmtime(&ctime)));
     tmstr[24]=0;
-    if (RadarParmSetOriginTime(prm,tmstr) == -1) {
-      fprintf(stderr,"Error: cannot set Origin Time\n");
+    if (RadarParmSetHistoryTime(prm,tmstr) == -1) {
+      fprintf(stderr,"Error: cannot set History Time\n");
       free_radarstructs(network, prm, raw);
       free_files(rawfp, fp, NULL, inxfp);
       free_fitstructs(fit_prms, fit, fblk);

--- a/codebase/superdarn/src.bin/tk/tool/map_addhmb.1.17/map_addhmb.c
+++ b/codebase/superdarn/src.bin/tk/tool/map_addhmb.1.17/map_addhmb.c
@@ -26,6 +26,7 @@ Modifications:
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <math.h>
 #include <sys/types.h>
 #include "rtypes.h"
@@ -104,7 +105,7 @@ int main(int argc,char *argv[])
   int tflg=0;
 
   int mlti;
-  int c;
+  int c,n;
 
   float latmin[3]={0,0,0};
   float lattmp[3];
@@ -140,6 +141,10 @@ int main(int argc,char *argv[])
   int (*Map_Read)(FILE *, struct CnvMapData *, struct GridData *);
   int (*Map_Write)(FILE *, struct CnvMapData *, struct GridData *);
   double (*MLTCnv)(int, int, double);
+
+  time_t ctime;
+  char command[128];
+  char tmstr[40];
 
   for (i=0;i<3;i++) {
     grd[i]=GridMake();
@@ -214,6 +219,19 @@ int main(int argc,char *argv[])
     exit(-1);
   }
 
+  command[0]=0;
+  n=0;
+  for (c=0;c<argc;c++) {
+    n+=strlen(argv[c])+1;
+    if (n>127) break;
+    if (c !=0) strcat(command," ");
+    strcat(command,argv[c]);
+  }
+
+  ctime = time((time_t) 0);
+  strcpy(tmstr,asctime(gmtime(&ctime)));
+  tmstr[24]=0;
+
   /* set function pointer to read/write old or new */
   if (old) {
     Map_Read  = &OldCnvMapFread;
@@ -259,6 +277,8 @@ int main(int argc,char *argv[])
 
       if (tflg == 0) {
         map_addhmb(yr,yrsec,map[0],bndnp,bndstep,latref,latmed,magflg);
+        CnvMapSetHistoryTime(map[0],tmstr);
+        CnvMapSetHistoryCommand(map[0],command);
         (*Map_Write)(stdout,map[0],grd[0]);
         TimeEpochToYMDHMS(grd[0]->st_time,&yr,&mo,&dy,&hr,&mt,&sc);
         if (vb==1) 
@@ -366,6 +386,8 @@ int main(int argc,char *argv[])
             if (latmed != -1) map_addhmb(yr,yrsec,map[0],bndnp,bndstep,
                                          latref,latmed,magflg);
             else map[0]->latmin = -1;
+            CnvMapSetHistoryTime(map[0],tmstr);
+            CnvMapSetHistoryCommand(map[0],command);
             (*Map_Write)(stdout,map[0],grd[0]);
 
             TimeEpochToYMDHMS(grd[0]->st_time,&yr,&mo,&dy,&hr,&mt,&sc);
@@ -387,6 +409,8 @@ int main(int argc,char *argv[])
           if (latmed != -1) map_addhmb(yr,yrsec,map[idx],bndnp,bndstep,
                                        latref,latmed,magflg);
           else map[idx]->latmin = -1;
+          CnvMapSetHistoryTime(map[idx],tmstr);
+          CnvMapSetHistoryCommand(map[idx],command);
           (*Map_Write)(stdout,map[idx],grd[idx]);
           TimeEpochToYMDHMS(grd[idx]->st_time,&yr,&mo,&dy,&hr,&mt,&sc);
           if (vb==1) 
@@ -409,7 +433,7 @@ int main(int argc,char *argv[])
     }
 
     if (cnt == 0) exit(0); /* no record to write out */
-  
+
     idx = buf-1;
     if (idx < 0) idx += 3;
 
@@ -419,6 +443,8 @@ int main(int argc,char *argv[])
         if (latmed != -1) map_addhmb(yr,yrsec,map[0],bndnp,bndstep,
                                      latref,latmed,magflg);
         else map[0]->latmin = -1;
+        CnvMapSetHistoryTime(map[0],tmstr);
+        CnvMapSetHistoryCommand(map[0],command);
         (*Map_Write)(stdout,map[0],grd[0]);
         TimeEpochToYMDHMS(grd[0]->st_time,&yr,&mo,&dy,&hr,&mt,&sc);
         if (vb == 1) 
@@ -439,6 +465,8 @@ int main(int argc,char *argv[])
       if (latmed != -1) map_addhmb(yr,yrsec,map[idx],bndnp,bndstep,
                                    latref,latmed,magflg);
       else map[idx]->latmin = -1;
+      CnvMapSetHistoryTime(map[idx],tmstr);
+      CnvMapSetHistoryCommand(map[idx],command);
       (*Map_Write)(stdout,map[idx],grd[idx]);
       TimeEpochToYMDHMS(grd[idx]->st_time,&yr,&mo,&dy,&hr,&mt,&sc);
       if (vb == 1) 

--- a/codebase/superdarn/src.bin/tk/tool/map_grd.1.16/map_grd.c
+++ b/codebase/superdarn/src.bin/tk/tool/map_grd.1.16/map_grd.c
@@ -25,6 +25,7 @@ Modifications:
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <math.h>
 #include <sys/types.h>
 #include "rtypes.h"
@@ -142,6 +143,11 @@ int main(int argc,char *argv[]) {
   int (*Map_Write)(FILE *, struct CnvMapData *, struct GridData *);
   double (*MLTCnv)(int, int, double);
 
+  time_t ctime;
+  int c,n;
+  char command[128];
+  char tmstr[40];
+
   grd=GridMake();
   map=CnvMapMake();
 
@@ -229,6 +235,21 @@ int main(int argc,char *argv[]) {
   map->error_wt=1;
   map->hemisphere=1;
   map->lat_shft=latshft;
+
+  command[0]=0;
+  n=0;
+  for (c=0;c<argc;c++) {
+    n+=strlen(argv[c])+1;
+    if (n>127) break;
+    if (c !=0) strcat(command," ");
+    strcat(command,argv[c]);
+  }
+
+  ctime = time((time_t) 0);
+  strcpy(tmstr,asctime(gmtime(&ctime)));
+  tmstr[24]=0;
+  CnvMapSetHistoryTime(map,tmstr);
+  CnvMapSetHistoryCommand(map,command);
 
   /* set function pointer to read/write old or new */
   if (old) {

--- a/codebase/superdarn/src.bin/tk/tool/trim_fit.1.20/trim_fit.c
+++ b/codebase/superdarn/src.bin/tk/tool/trim_fit.1.20/trim_fit.c
@@ -154,13 +154,13 @@ int main (int argc,char *argv[]) {
   char *chnstr=NULL;
   char *cpstr=NULL;
 
-  // origin time for when the file is produced
+  // history time for when the file is produced
   time_t ctime;
-  // counter for origin command length  
+  // counter for history command length
   int n=0;
-  // origin command array to hold the string
+  // history command array to hold the string
   char command[128];
-  // string to hold the origin time 
+  // string to hold the history time
   char tmstr[40];
 
   OptionAdd(&opt,"-help",'x',&help);
@@ -343,11 +343,11 @@ int main (int argc,char *argv[]) {
     // initialize array to be empty?
     command[0]=0;
     for (int c=0; c<argc; c++) {
-      // check if the origin command is too long
+      // check if the history command is too long
       n+=strlen(argv[c])+1;
       // if so cut it off
       if (n>127) break;
-      // add space between command line arguments and copy to origin command
+      // add space between command line arguments and copy to history command
       if (c !=0) strcat(command," ");
       strcat(command, argv[c]);
     }
@@ -440,14 +440,14 @@ int main (int argc,char *argv[]) {
                          (int) sc,prm->channel,
                          prm->bmnum,prm->cp);
 
-      // origin  code 1 means it is not produced on site
+      // origin code 1 means it is not produced on site
       prm->origin.code=1;
       // copy it over to the file
       ctime= time((time_t) 0);
-      RadarParmSetOriginCommand(prm,command);
+      RadarParmSetHistoryCommand(prm,command);
       strcpy(tmstr,asctime(gmtime(&ctime)));
       tmstr[24]=0;
-      RadarParmSetOriginTime(prm,tmstr);
+      RadarParmSetHistoryTime(prm,tmstr);
 
       status=FitFwrite(stdout,prm,fit);
 

--- a/codebase/superdarn/src.idl/lib/main.1.25/rprm.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/rprm.pro
@@ -96,6 +96,7 @@ pro RadarMakeRadarPrm,prm
          tfreq: 0, $
          offset: 0, $
          ifmode: 0, $
+         wide: 0, $
          mxpwr: 0L, $
          lvmax: 0L, $
          pulse: intarr(PULSE_SIZE), $
@@ -149,6 +150,7 @@ function RadarEncodeRadarPrm,prm,sclvec,arrvec,new=new
   s=DataMapMakeScalar('mplgs',prm.mplgs,sclvec)
   s=DataMapMakeScalar('mplgexs',prm.mplgexs,sclvec)
   s=DataMapMakeScalar('ifmode',prm.ifmode,sclvec)
+  s=DataMapMakeScalar('wide',prm.wide,sclvec)
   s=DataMapMakeScalar('nrang',prm.nrang,sclvec)
   s=DataMapMakeScalar('frang',prm.frang,sclvec)
   s=DataMapMakeScalar('rsep',prm.rsep,sclvec)
@@ -175,11 +177,11 @@ function RadarDecodeRadarPrm,prm,sclvec,arrvec
            'time.us','txpow','nave','atten','lagfr','smsep','ercod', $
            'stat.agc','stat.lopwr','noise.search','noise.mean','channel', $
            'bmnum','bmazm','scan','offset','rxrise','intt.sc','intt.us', $
-           'txpl', 'mpinc','mppul','mplgs','mplgexs','ifmode','nrang', $
+           'txpl', 'mpinc','mppul','mplgs','mplgexs','ifmode','wide','nrang', $
            'frang', 'rsep','xcf','tfreq', 'mxpwr','lvmax','combf']
 
   scltype=[1,1,1,9,9,2,2,2,2,2,2,2,2,3,2,2,2,2,2,2,2,2,4,4,2,2,4,2,2,2,2,3, $
-           2,2,2,2,2,2,2,2,2,2,2,3,3,9]
+           2,2,2,2,2,2,2,2,2,2,2,2,3,3,9]
   
   sclid=intarr(n_elements(sclname))
   sclid[*]=-1
@@ -258,13 +260,14 @@ function RadarDecodeRadarPrm,prm,sclvec,arrvec
   if (sclid[35] ne -1) then prm.mplgs=*(sclvec[sclid[35]].ptr)
   if (sclid[36] ne -1) then prm.mplgexs=*(sclvec[sclid[36]].ptr)
   if (sclid[37] ne -1) then prm.ifmode=*(sclvec[sclid[37]].ptr)
-  if (sclid[38] ne -1) then prm.nrang=*(sclvec[sclid[38]].ptr)
-  if (sclid[39] ne -1) then prm.frang=*(sclvec[sclid[39]].ptr)
-  if (sclid[40] ne -1) then prm.rsep=*(sclvec[sclid[40]].ptr)
-  if (sclid[41] ne -1) then prm.xcf=*(sclvec[sclid[41]].ptr)
-  if (sclid[42] ne -1) then prm.tfreq=*(sclvec[sclid[42]].ptr)
-  if (sclid[43] ne -1) then prm.mxpwr=*(sclvec[sclid[43]].ptr)
-  if (sclid[44] ne -1) then prm.lvmax=*(sclvec[sclid[44]].ptr)
+  if (sclid[38] ne -1) then prm.wide=*(sclvec[sclid[38]].ptr)
+  if (sclid[39] ne -1) then prm.nrang=*(sclvec[sclid[39]].ptr)
+  if (sclid[40] ne -1) then prm.frang=*(sclvec[sclid[40]].ptr)
+  if (sclid[41] ne -1) then prm.rsep=*(sclvec[sclid[41]].ptr)
+  if (sclid[42] ne -1) then prm.xcf=*(sclvec[sclid[42]].ptr)
+  if (sclid[43] ne -1) then prm.tfreq=*(sclvec[sclid[43]].ptr)
+  if (sclid[44] ne -1) then prm.mxpwr=*(sclvec[sclid[44]].ptr)
+  if (sclid[45] ne -1) then prm.lvmax=*(sclvec[sclid[45]].ptr)
   if (prm.mppul gt 0) && (arrid[0] ne -1) then $
      prm.pulse[0:prm.mppul-1]=*(arrvec[arrid[0]].ptr)
   if (prm.mplgs gt 0) && (arrid[1] ne -1) then $

--- a/codebase/superdarn/src.idl/lib/main.1.25/rprm.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/rprm.pro
@@ -96,7 +96,7 @@ pro RadarMakeRadarPrm,prm
          tfreq: 0, $
          offset: 0, $
          ifmode: 0, $
-         wide: 0, $
+         widetx: 0, $
          mxpwr: 0L, $
          lvmax: 0L, $
          pulse: intarr(PULSE_SIZE), $
@@ -150,7 +150,7 @@ function RadarEncodeRadarPrm,prm,sclvec,arrvec,new=new
   s=DataMapMakeScalar('mplgs',prm.mplgs,sclvec)
   s=DataMapMakeScalar('mplgexs',prm.mplgexs,sclvec)
   s=DataMapMakeScalar('ifmode',prm.ifmode,sclvec)
-  s=DataMapMakeScalar('wide',prm.wide,sclvec)
+  s=DataMapMakeScalar('widetx',prm.widetx,sclvec)
   s=DataMapMakeScalar('nrang',prm.nrang,sclvec)
   s=DataMapMakeScalar('frang',prm.frang,sclvec)
   s=DataMapMakeScalar('rsep',prm.rsep,sclvec)
@@ -177,7 +177,7 @@ function RadarDecodeRadarPrm,prm,sclvec,arrvec
            'time.us','txpow','nave','atten','lagfr','smsep','ercod', $
            'stat.agc','stat.lopwr','noise.search','noise.mean','channel', $
            'bmnum','bmazm','scan','offset','rxrise','intt.sc','intt.us', $
-           'txpl', 'mpinc','mppul','mplgs','mplgexs','ifmode','wide','nrang', $
+           'txpl', 'mpinc','mppul','mplgs','mplgexs','ifmode','widetx','nrang', $
            'frang', 'rsep','xcf','tfreq', 'mxpwr','lvmax','combf']
 
   scltype=[1,1,1,9,9,2,2,2,2,2,2,2,2,3,2,2,2,2,2,2,2,2,4,4,2,2,4,2,2,2,2,3, $
@@ -260,7 +260,7 @@ function RadarDecodeRadarPrm,prm,sclvec,arrvec
   if (sclid[35] ne -1) then prm.mplgs=*(sclvec[sclid[35]].ptr)
   if (sclid[36] ne -1) then prm.mplgexs=*(sclvec[sclid[36]].ptr)
   if (sclid[37] ne -1) then prm.ifmode=*(sclvec[sclid[37]].ptr)
-  if (sclid[38] ne -1) then prm.wide=*(sclvec[sclid[38]].ptr)
+  if (sclid[38] ne -1) then prm.widetx=*(sclvec[sclid[38]].ptr)
   if (sclid[39] ne -1) then prm.nrang=*(sclvec[sclid[39]].ptr)
   if (sclid[40] ne -1) then prm.frang=*(sclvec[sclid[40]].ptr)
   if (sclid[41] ne -1) then prm.rsep=*(sclvec[sclid[41]].ptr)
@@ -272,7 +272,7 @@ function RadarDecodeRadarPrm,prm,sclvec,arrvec
      prm.pulse[0:prm.mppul-1]=*(arrvec[arrid[0]].ptr)
   if (prm.mplgs gt 0) && (arrid[1] ne -1) then $
      prm.lag[0:prm.mplgs,*]=(*(arrvec[arrid[1]].ptr))[*,*]
-  if (sclid[45] ne -1) then prm.combf=*(sclvec[sclid[45]].ptr)
+  if (sclid[46] ne -1) then prm.combf=*(sclvec[sclid[46]].ptr)
 
   return,0
 end

--- a/codebase/superdarn/src.idl/lib/main.1.25/snd.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/snd.pro
@@ -87,6 +87,7 @@ pro SndMakeSndData,snd
          rsep: 0, $
          xcf: 0, $
          tfreq: 0, $
+         wide: 0, $
          sky_noise: 0.0, $
          combf: '', $
          fit_revision: {rlstr, major: 0L, minor: 0L}, $
@@ -140,7 +141,7 @@ function SndRead,unit,snd
            'time.yr','time.mo','time.dy','time.hr','time.mt','time.sc', $
            'time.us','nave','lagfr','smsep','noise.search','noise.mean', $
            'channel','bmnum','bmazm','scan','rxrise','intt.sc','intt.us', $
-           'nrang','frang','rsep','xcf','tfreq','noise.sky', $
+           'nrang','frang','rsep','xcf','tfreq','wide','noise.sky', $
            'combf','fitacf.revision.major','fitacf.revision.minor', $
            'snd.revision.major','snd.revision.minor']
 
@@ -149,7 +150,7 @@ function SndRead,unit,snd
            2,2,2,2,2,2, $
            3,2,2,2,4,4, $
            2,2,4,2,2,2,3, $
-           2,2,2,2,2,4, $
+           2,2,2,2,2,2,4, $
            9,3,3, $
            2,2]
 
@@ -219,12 +220,13 @@ function SndRead,unit,snd
   if (sclid[28] ne -1) then snd.rsep=*(sclvec[sclid[28]].ptr)
   if (sclid[29] ne -1) then snd.xcf=*(sclvec[sclid[29]].ptr)
   if (sclid[30] ne -1) then snd.tfreq=*(sclvec[sclid[30]].ptr)
-  if (sclid[31] ne -1) then snd.sky_noise=*(sclvec[sclid[31]].ptr)
-  if (sclid[32] ne -1) then snd.combf=*(sclvec[sclid[32]].ptr)
-  if (sclid[33] ne -1) then snd.fit_revision.major=*(sclvec[sclid[33]].ptr)
-  if (sclid[34] ne -1) then snd.fit_revision.minor=*(sclvec[sclid[34]].ptr)
-  if (sclid[35] ne -1) then snd.snd_revision.major=*(sclvec[sclid[35]].ptr)
-  if (sclid[36] ne -1) then snd.snd_revision.minor=*(sclvec[sclid[36]].ptr)
+  if (sclid[31] ne -1) then snd.wide=*(sclvec[sclid[31]].ptr)
+  if (sclid[32] ne -1) then snd.sky_noise=*(sclvec[sclid[32]].ptr)
+  if (sclid[33] ne -1) then snd.combf=*(sclvec[sclid[33]].ptr)
+  if (sclid[34] ne -1) then snd.fit_revision.major=*(sclvec[sclid[34]].ptr)
+  if (sclid[35] ne -1) then snd.fit_revision.minor=*(sclvec[sclid[35]].ptr)
+  if (sclid[36] ne -1) then snd.snd_revision.major=*(sclvec[sclid[36]].ptr)
+  if (sclid[37] ne -1) then snd.snd_revision.minor=*(sclvec[sclid[37]].ptr)
 
   if (arrid[0] eq -1) then begin
     st=DataMapFreeScalar(sclvec)
@@ -317,6 +319,7 @@ function SndWrite,unit,snd
   s=DataMapMakeScalar('rsep',snd.rsep,sclvec)
   s=DataMapMakeScalar('xcf',snd.xcf,sclvec)
   s=DataMapMakeScalar('tfreq',snd.tfreq,sclvec)
+  s=DataMapMakeScalar('wide',snd.wide,sclvec)
   s=DataMapMakeScalar('noise.sky',snd.sky_noise,sclvec)
   s=DataMapMakeScalar('combf',snd.combf,sclvec)
   s=DataMapMakeScalar('snd.revision.major',snd.snd_revision.major,sclvec)

--- a/codebase/superdarn/src.idl/lib/main.1.25/snd.pro
+++ b/codebase/superdarn/src.idl/lib/main.1.25/snd.pro
@@ -87,7 +87,7 @@ pro SndMakeSndData,snd
          rsep: 0, $
          xcf: 0, $
          tfreq: 0, $
-         wide: 0, $
+         widetx: 0, $
          sky_noise: 0.0, $
          combf: '', $
          fit_revision: {rlstr, major: 0L, minor: 0L}, $
@@ -141,7 +141,7 @@ function SndRead,unit,snd
            'time.yr','time.mo','time.dy','time.hr','time.mt','time.sc', $
            'time.us','nave','lagfr','smsep','noise.search','noise.mean', $
            'channel','bmnum','bmazm','scan','rxrise','intt.sc','intt.us', $
-           'nrang','frang','rsep','xcf','tfreq','wide','noise.sky', $
+           'nrang','frang','rsep','xcf','tfreq','widetx','noise.sky', $
            'combf','fitacf.revision.major','fitacf.revision.minor', $
            'snd.revision.major','snd.revision.minor']
 
@@ -220,7 +220,7 @@ function SndRead,unit,snd
   if (sclid[28] ne -1) then snd.rsep=*(sclvec[sclid[28]].ptr)
   if (sclid[29] ne -1) then snd.xcf=*(sclvec[sclid[29]].ptr)
   if (sclid[30] ne -1) then snd.tfreq=*(sclvec[sclid[30]].ptr)
-  if (sclid[31] ne -1) then snd.wide=*(sclvec[sclid[31]].ptr)
+  if (sclid[31] ne -1) then snd.widetx=*(sclvec[sclid[31]].ptr)
   if (sclid[32] ne -1) then snd.sky_noise=*(sclvec[sclid[32]].ptr)
   if (sclid[33] ne -1) then snd.combf=*(sclvec[sclid[33]].ptr)
   if (sclid[34] ne -1) then snd.fit_revision.major=*(sclvec[sclid[34]].ptr)
@@ -319,7 +319,7 @@ function SndWrite,unit,snd
   s=DataMapMakeScalar('rsep',snd.rsep,sclvec)
   s=DataMapMakeScalar('xcf',snd.xcf,sclvec)
   s=DataMapMakeScalar('tfreq',snd.tfreq,sclvec)
-  s=DataMapMakeScalar('wide',snd.wide,sclvec)
+  s=DataMapMakeScalar('widetx',snd.widetx,sclvec)
   s=DataMapMakeScalar('noise.sky',snd.sky_noise,sclvec)
   s=DataMapMakeScalar('combf',snd.combf,sclvec)
   s=DataMapMakeScalar('snd.revision.major',snd.snd_revision.major,sclvec)

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/include/cnvmap.h
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/include/cnvmap.h
@@ -33,6 +33,11 @@ struct CnvMapData {
   int major_rev,minor_rev;
   char source[256];
 
+  struct {
+    char *time;
+    char *command;
+  } history;
+
   double st_time;
   double ed_time;
 
@@ -94,6 +99,9 @@ struct CnvMapData {
 
 struct CnvMapData *CnvMapMake();
 void CnvMapFree(struct CnvMapData *ptr);
+
+int CnvMapSetHistoryTime(struct CnvMapData *ptr,char *str);
+int CnvMapSetHistoryCommand(struct CnvMapData *ptr,char *str);
 
 #endif
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/cnvmap.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/cnvmap.c
@@ -38,6 +38,8 @@ struct CnvMapData *CnvMapMake() {
   if (ptr==NULL) return 0;
 
   memset(ptr,0,sizeof(struct CnvMapData));
+  ptr->history.time=NULL;
+  ptr->history.command=NULL;
   ptr->coef=NULL;
   ptr->model=NULL;
   ptr->bnd_lat=NULL;
@@ -45,12 +47,71 @@ struct CnvMapData *CnvMapMake() {
   return ptr;
 }
 
+
 void CnvMapFree(struct CnvMapData *ptr) {
   if (ptr==NULL);
+  if (ptr->history.time !=NULL) free(ptr->history.time);
+  if (ptr->history.command !=NULL) free(ptr->history.command);
   if (ptr->coef !=NULL) free(ptr->coef);
   if (ptr->model !=NULL) free(ptr->model);
   if (ptr->bnd_lat !=NULL) free(ptr->bnd_lat);
   if (ptr->bnd_lon !=NULL) free(ptr->bnd_lon);
   free (ptr);
+}
+
+
+int CnvMapSetHistoryTime(struct CnvMapData *ptr,char *str) {
+  char *tmp=NULL;
+  if (ptr==NULL) return -1;
+
+  if (str==NULL) {
+    if (ptr->history.time !=NULL) free(ptr->history.time);
+    ptr->history.time=NULL;
+    return 0;
+  }
+
+  if (ptr->history.time==NULL) tmp=malloc(strlen(str)+1);
+  else tmp=realloc(ptr->history.time,strlen(ptr->history.time)+strlen(str)+3);
+
+  if (tmp==NULL) return -1;
+
+  if (ptr->history.time==NULL) {
+    strcpy(tmp,str);
+  } else {
+    strcat(tmp,"; ");
+    strcat(tmp,str);
+  }
+
+  ptr->history.time=tmp;
+  return 0;
+
+}
+
+
+int CnvMapSetHistoryCommand(struct CnvMapData *ptr,char *str) {
+  char *tmp=NULL;
+  if (ptr==NULL) return -1;
+
+  if (str==NULL) {
+    if (ptr->history.command !=NULL) free(ptr->history.command);
+    ptr->history.command=NULL;
+    return 0;
+  }
+
+  if (ptr->history.command==NULL) tmp=malloc(strlen(str)+1);
+  else tmp=realloc(ptr->history.command,strlen(ptr->history.command)+strlen(str)+3);
+
+  if (tmp==NULL) return -1;
+
+  if (ptr->history.command==NULL) {
+    strcpy(tmp,str);
+  } else {
+    strcat(tmp,"; ");
+    strcat(tmp,str);
+  }
+
+  ptr->history.command=tmp;
+  return 0;
+
 }
 

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/readmap.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/readmap.c
@@ -47,7 +47,8 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
 
   void *tmp;
 
-  char *sname[]={"start.year","start.month","start.day","start.hour",
+  char *sname[]={"history.time","history.command",
+                 "start.year","start.month","start.day","start.hour",
                  "start.minute","start.second",
                  "end.year","end.month","end.day","end.hour",
                  "end.minute","end.second",
@@ -86,11 +87,10 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
                  "pot.max.err",
                  "pot.min",
                  "pot.min.err",
-
-
                  0};
 
-  int stype[]={DATASHORT,DATASHORT,DATASHORT,DATASHORT,DATASHORT,DATADOUBLE,
+  int stype[]={DATASTRING,DATASTRING,
+               DATASHORT,DATASHORT,DATASHORT,DATASHORT,DATASHORT,DATADOUBLE,
                DATASHORT,DATASHORT,DATASHORT,DATASHORT,DATASHORT,DATADOUBLE,
                DATASHORT,DATASHORT,
                DATASTRING,
@@ -130,7 +130,7 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
                0
               };
 
-  struct DataMapScalar *sdata[48];
+  struct DataMapScalar *sdata[50];
 
   char *aname[]={"stid","channel","nvec",
                  "freq","major.revision","minor.revision",
@@ -190,15 +190,15 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
   }
 
   for (x=0;sname[x] !=0;x++) {
-    if (x==14) continue;
-    if (x==23) continue;
-    if (x==24) continue;
-    if (x==25) continue;  /* EGT */
-    if (x==26) continue;  /* SGS */
-    if (x==27) continue;
-    if (x==28) continue;
-    if (x==29) continue;  /* SGS */
-    if (x==31) continue;
+    if (x==16) continue;
+    if (x==25) continue;
+    if (x==26) continue;
+    if (x==27) continue;  /* EGT */
+    if (x==28) continue;  /* SGS */
+    if (x==29) continue;
+    if (x==30) continue;
+    if (x==31) continue;  /* SGS */
+    if (x==33) continue;
     if (sdata[x]==NULL) break;
   }
 
@@ -213,80 +213,83 @@ int CnvMapRead(int fid,struct CnvMapData *map,struct GridData *grd) {
     return -1;
   }
 
-  yr=*(sdata[0]->data.sptr);
-  mo=*(sdata[1]->data.sptr);
-  dy=*(sdata[2]->data.sptr);
-  hr=*(sdata[3]->data.sptr);
-  mt=*(sdata[4]->data.sptr);
-  sc=*(sdata[5]->data.dptr);
+  CnvMapSetHistoryTime(map,*((char **) sdata[0]->data.vptr));
+  CnvMapSetHistoryCommand(map,*((char **) sdata[1]->data.vptr));
+
+  yr=*(sdata[2]->data.sptr);
+  mo=*(sdata[3]->data.sptr);
+  dy=*(sdata[4]->data.sptr);
+  hr=*(sdata[5]->data.sptr);
+  mt=*(sdata[6]->data.sptr);
+  sc=*(sdata[7]->data.dptr);
   grd->st_time=TimeYMDHMSToEpoch(yr,mo,dy,hr,mt,sc);
   map->st_time=TimeYMDHMSToEpoch(yr,mo,dy,hr,mt,sc);
 
-  yr=*(sdata[6]->data.sptr);
-  mo=*(sdata[7]->data.sptr);
-  dy=*(sdata[8]->data.sptr);
-  hr=*(sdata[9]->data.sptr);
-  mt=*(sdata[10]->data.sptr);
-  sc=*(sdata[11]->data.dptr);
+  yr=*(sdata[8]->data.sptr);
+  mo=*(sdata[9]->data.sptr);
+  dy=*(sdata[10]->data.sptr);
+  hr=*(sdata[11]->data.sptr);
+  mt=*(sdata[12]->data.sptr);
+  sc=*(sdata[13]->data.dptr);
   grd->ed_time=TimeYMDHMSToEpoch(yr,mo,dy,hr,mt,sc);
   map->ed_time=TimeYMDHMSToEpoch(yr,mo,dy,hr,mt,sc);
 
-  map->major_rev=*(sdata[12]->data.sptr);
-  map->minor_rev=*(sdata[13]->data.sptr);
+  map->major_rev=*(sdata[14]->data.sptr);
+  map->minor_rev=*(sdata[15]->data.sptr);
 
-  if (sdata[14] !=NULL)
-    strncpy(map->source,*((char **) sdata[14]->data.vptr),256);
+  if (sdata[16] !=NULL)
+    strncpy(map->source,*((char **) sdata[16]->data.vptr),256);
 
-  map->doping_level=*(sdata[15]->data.sptr);
-  map->model_wt=*(sdata[16]->data.sptr);
-  map->error_wt=*(sdata[17]->data.sptr);
-  map->imf_flag=*(sdata[18]->data.sptr);
-  map->imf_delay=*(sdata[19]->data.sptr);
+  map->doping_level=*(sdata[17]->data.sptr);
+  map->model_wt=*(sdata[18]->data.sptr);
+  map->error_wt=*(sdata[19]->data.sptr);
+  map->imf_flag=*(sdata[20]->data.sptr);
+  map->imf_delay=*(sdata[21]->data.sptr);
 
-  map->Bx=*(sdata[20]->data.dptr);
-  map->By=*(sdata[21]->data.dptr);
-  map->Bz=*(sdata[22]->data.dptr);
-  if (sdata[23] !=NULL)
-    map->Vx=*(sdata[23]->data.dptr);
-  if (sdata[24] !=NULL)
-    map->tilt=*(sdata[24]->data.dptr);
+  map->Bx=*(sdata[22]->data.dptr);
+  map->By=*(sdata[23]->data.dptr);
+  map->Bz=*(sdata[24]->data.dptr);
   if (sdata[25] !=NULL)
-    map->Kp=*(sdata[25]->data.dptr);
-
+    map->Vx=*(sdata[25]->data.dptr);
   if (sdata[26] !=NULL)
-    strncpy(map->imf_model[0],*((char **) sdata[26]->data.vptr),64);
+    map->tilt=*(sdata[26]->data.dptr);
   if (sdata[27] !=NULL)
-    strncpy(map->imf_model[1],*((char **) sdata[27]->data.vptr),64);
+    map->Kp=*(sdata[27]->data.dptr);
+
   if (sdata[28] !=NULL)
-    strncpy(map->imf_model[2],*((char **) sdata[28]->data.vptr),64);
+    strncpy(map->imf_model[0],*((char **) sdata[28]->data.vptr),64);
   if (sdata[29] !=NULL)
-    strncpy(map->imf_model[3],*((char **) sdata[29]->data.vptr),64);
-
-  map->hemisphere=*(sdata[30]->data.sptr);
+    strncpy(map->imf_model[1],*((char **) sdata[29]->data.vptr),64);
+  if (sdata[30] !=NULL)
+    strncpy(map->imf_model[2],*((char **) sdata[30]->data.vptr),64);
   if (sdata[31] !=NULL)
-    map->noigrf=*(sdata[31]->data.sptr);
-  map->fit_order=*(sdata[32]->data.sptr);
-  map->latmin=*(sdata[33]->data.fptr);
+    strncpy(map->imf_model[3],*((char **) sdata[31]->data.vptr),64);
 
-  map->chi_sqr=*(sdata[34]->data.dptr);
-  map->chi_sqr_dat=*(sdata[35]->data.dptr);
-  map->rms_err=*(sdata[36]->data.dptr);
+  map->hemisphere=*(sdata[32]->data.sptr);
+  if (sdata[33] !=NULL)
+    map->noigrf=*(sdata[33]->data.sptr);
+  map->fit_order=*(sdata[34]->data.sptr);
+  map->latmin=*(sdata[35]->data.fptr);
 
-  map->lat_shft=*(sdata[37]->data.fptr);
-  map->lon_shft=*(sdata[38]->data.fptr);
+  map->chi_sqr=*(sdata[36]->data.dptr);
+  map->chi_sqr_dat=*(sdata[37]->data.dptr);
+  map->rms_err=*(sdata[38]->data.dptr);
 
-  map->mlt.start=*(sdata[39]->data.dptr);
-  map->mlt.end=*(sdata[40]->data.dptr);
-  map->mlt.av=*(sdata[41]->data.dptr);
+  map->lat_shft=*(sdata[39]->data.fptr);
+  map->lon_shft=*(sdata[40]->data.fptr);
 
-  map->pot_drop=*(sdata[42]->data.dptr);
-  map->pot_drop_err=*(sdata[43]->data.dptr);
+  map->mlt.start=*(sdata[41]->data.dptr);
+  map->mlt.end=*(sdata[42]->data.dptr);
+  map->mlt.av=*(sdata[43]->data.dptr);
 
-  map->pot_max=*(sdata[44]->data.dptr);
-  map->pot_max_err=*(sdata[45]->data.dptr);
+  map->pot_drop=*(sdata[44]->data.dptr);
+  map->pot_drop_err=*(sdata[45]->data.dptr);
 
-  map->pot_min=*(sdata[46]->data.dptr);
-  map->pot_min_err=*(sdata[47]->data.dptr);
+  map->pot_max=*(sdata[46]->data.dptr);
+  map->pot_max_err=*(sdata[47]->data.dptr);
+
+  map->pot_min=*(sdata[48]->data.dptr);
+  map->pot_min_err=*(sdata[49]->data.dptr);
 
   grd->stnum=adata[0]->rng[0];
   if (grd->stnum==0) {

--- a/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/writemap.c
+++ b/codebase/superdarn/src.lib/tk/cnvmap.1.17/src/writemap.c
@@ -352,6 +352,9 @@ int CnvMapWrite(int fid,struct CnvMapData *map,struct GridData *grd) {
 
   data=DataMapMake();
 
+  DataMapAddScalar(data,"history.time",DATASTRING,&map->history.time);
+  DataMapAddScalar(data,"history.command",DATASTRING,&map->history.command);
+
   DataMapAddScalar(data,"start.year",DATASHORT,&syr);
   DataMapAddScalar(data,"start.month",DATASHORT,&smo);
   DataMapAddScalar(data,"start.day",DATASHORT,&sdy);

--- a/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/include/rprmidl.h
+++ b/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/include/rprmidl.h
@@ -103,7 +103,7 @@ struct RadarIDLParm {
   short tfreq;
   short offset;
   short ifmode;
-  short wide;
+  short widetx;
 
   IDL_LONG mxpwr;
   IDL_LONG lvmax;

--- a/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/include/rprmidl.h
+++ b/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/include/rprmidl.h
@@ -103,6 +103,7 @@ struct RadarIDLParm {
   short tfreq;
   short offset;
   short ifmode;
+  short wide;
 
   IDL_LONG mxpwr;
   IDL_LONG lvmax;

--- a/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/src/rprmidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/src/rprmidl.c
@@ -87,7 +87,7 @@ void IDLCopyRadarParmFromIDL(struct RadarIDLParm *iprm,struct RadarParm *prm) {
   prm->tfreq=iprm->tfreq;
   prm->offset=iprm->offset;
   prm->ifmode=iprm->ifmode;
-  prm->wide=iprm->wide;
+  prm->widetx=iprm->widetx;
   prm->mxpwr=iprm->mxpwr;
   prm->lvmax=iprm->lvmax;
 
@@ -172,7 +172,7 @@ void IDLCopyRadarParmToIDL(struct RadarParm *prm,struct RadarIDLParm *iprm) {
   iprm->tfreq=prm->tfreq;
   iprm->offset=prm->offset;
   iprm->ifmode=prm->ifmode;
-  iprm->wide=prm->wide;
+  iprm->widetx=prm->widetx;
   iprm->mxpwr=prm->mxpwr;
   iprm->lvmax=prm->lvmax;
 
@@ -266,7 +266,7 @@ struct RadarIDLParm *IDLMakeRadarParm(IDL_VPTR *vptr) {
 
     {"OFFSET",0,(void *) IDL_TYP_INT}, /* 29 */
     {"IFMODE",0,(void *) IDL_TYP_INT}, /* 30 */
-    {"WIDE",0,(void *) IDL_TYP_INT},   /* 31 */
+    {"WIDETX",0,(void *) IDL_TYP_INT}, /* 31 */
     {"MXPWR",0,(void *) IDL_TYP_LONG}, /* 32 */
     {"LVMAX",0,(void *) IDL_TYP_LONG}, /* 33 */
     {"PULSE",pdim,(void *) IDL_TYP_INT}, /* 34 */

--- a/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/src/rprmidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/rprmidl.1.6/src/rprmidl.c
@@ -87,6 +87,7 @@ void IDLCopyRadarParmFromIDL(struct RadarIDLParm *iprm,struct RadarParm *prm) {
   prm->tfreq=iprm->tfreq;
   prm->offset=iprm->offset;
   prm->ifmode=iprm->ifmode;
+  prm->wide=iprm->wide;
   prm->mxpwr=iprm->mxpwr;
   prm->lvmax=iprm->lvmax;
 
@@ -171,6 +172,7 @@ void IDLCopyRadarParmToIDL(struct RadarParm *prm,struct RadarIDLParm *iprm) {
   iprm->tfreq=prm->tfreq;
   iprm->offset=prm->offset;
   iprm->ifmode=prm->ifmode;
+  iprm->wide=prm->wide;
   iprm->mxpwr=prm->mxpwr;
   iprm->lvmax=prm->lvmax;
 
@@ -264,11 +266,12 @@ struct RadarIDLParm *IDLMakeRadarParm(IDL_VPTR *vptr) {
 
     {"OFFSET",0,(void *) IDL_TYP_INT}, /* 29 */
     {"IFMODE",0,(void *) IDL_TYP_INT}, /* 30 */
-    {"MXPWR",0,(void *) IDL_TYP_LONG}, /* 31 */
-    {"LVMAX",0,(void *) IDL_TYP_LONG}, /* 32 */
-    {"PULSE",pdim,(void *) IDL_TYP_INT}, /* 33 */
-    {"LAG",ldim,(void *) IDL_TYP_INT}, /* 34 */
-    {"COMBF",0,(void *) IDL_TYP_STRING}, /* 35 */   
+    {"WIDE",0,(void *) IDL_TYP_INT},   /* 31 */
+    {"MXPWR",0,(void *) IDL_TYP_LONG}, /* 32 */
+    {"LVMAX",0,(void *) IDL_TYP_LONG}, /* 33 */
+    {"PULSE",pdim,(void *) IDL_TYP_INT}, /* 34 */
+    {"LAG",ldim,(void *) IDL_TYP_INT}, /* 35 */
+    {"COMBF",0,(void *) IDL_TYP_STRING}, /* 36 */
     {0}};
 
   static IDL_MEMINT ilDims[IDL_MAX_ARRAY_DIM];

--- a/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/include/sndidl.h
+++ b/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/include/sndidl.h
@@ -83,6 +83,7 @@ struct SndIDLData {
   short rsep;
   short xcf;
   short tfreq;
+  short wide;
 
   float sky_noise;
 

--- a/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/include/sndidl.h
+++ b/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/include/sndidl.h
@@ -83,7 +83,7 @@ struct SndIDLData {
   short rsep;
   short xcf;
   short tfreq;
-  short wide;
+  short widetx;
 
   float sky_noise;
 

--- a/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
@@ -80,7 +80,7 @@ void IDLCopySndDataFromIDL(int nrang, struct SndIDLData *isnd,
   snd->rsep = isnd->rsep;
   snd->xcf = isnd->xcf;
   snd->tfreq = isnd->tfreq;
-  snd->wide = isnd->wide;
+  snd->widetx = isnd->widetx;
   snd->sky_noise = isnd->sky_noise;
 
   if (strlen(IDL_STRING_STR(&isnd->combf)) !=0)
@@ -161,7 +161,7 @@ void IDLCopySndDataToIDL(int nrang, struct SndData *snd,
   isnd->rsep = snd->rsep;
   isnd->xcf = snd->xcf;
   isnd->tfreq = snd->tfreq;
-  isnd->wide = snd->wide;
+  isnd->widetx = snd->widetx;
   isnd->sky_noise = snd->sky_noise;
 
   if (snd->combf !=NULL) {
@@ -257,7 +257,7 @@ struct SndIDLData *IDLMakeSndData(IDL_VPTR *vptr) {
     {"RSEP",0,(void *) IDL_TYP_INT},    /* 17 */
     {"XCF",0,(void *) IDL_TYP_INT},     /* 18 */
     {"TFREQ",0,(void *) IDL_TYP_INT},   /* 19 */
-    {"WIDE",0,(void *) IDL_TYP_INT},    /* 20 */
+    {"WIDETX",0,(void *) IDL_TYP_INT},  /* 20 */
     {"SKY_NOISE",0,(void *) IDL_TYP_FLOAT}, /* 21 */
     {"COMBF",0,(void *) IDL_TYP_STRING}, /* 22 */
     {"FIT_REVISION",0,NULL},             /* 23 */

--- a/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
+++ b/codebase/superdarn/src.lib/tk/idl/sndidl.1.0/src/sndidl.c
@@ -80,6 +80,7 @@ void IDLCopySndDataFromIDL(int nrang, struct SndIDLData *isnd,
   snd->rsep = isnd->rsep;
   snd->xcf = isnd->xcf;
   snd->tfreq = isnd->tfreq;
+  snd->wide = isnd->wide;
   snd->sky_noise = isnd->sky_noise;
 
   if (strlen(IDL_STRING_STR(&isnd->combf)) !=0)
@@ -160,6 +161,7 @@ void IDLCopySndDataToIDL(int nrang, struct SndData *snd,
   isnd->rsep = snd->rsep;
   isnd->xcf = snd->xcf;
   isnd->tfreq = snd->tfreq;
+  isnd->wide = snd->wide;
   isnd->sky_noise = snd->sky_noise;
 
   if (snd->combf !=NULL) {
@@ -255,19 +257,20 @@ struct SndIDLData *IDLMakeSndData(IDL_VPTR *vptr) {
     {"RSEP",0,(void *) IDL_TYP_INT},    /* 17 */
     {"XCF",0,(void *) IDL_TYP_INT},     /* 18 */
     {"TFREQ",0,(void *) IDL_TYP_INT},   /* 19 */
-    {"SKY_NOISE",0,(void *) IDL_TYP_FLOAT}, /* 20 */
-    {"COMBF",0,(void *) IDL_TYP_STRING}, /* 21 */
-    {"FIT_REVISION",0,NULL},             /* 22 */
-    {"SND_REVISION",0,NULL},             /* 23 */
-    {"QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 24 */
-    {"GFLG",rdim,(void *) IDL_TYP_BYTE}, /* 25 */
-    {"V",rdim,(void *) IDL_TYP_FLOAT},   /* 26 */
-    {"V_E",rdim,(void *) IDL_TYP_FLOAT}, /* 27 */
-    {"P_L",rdim,(void *) IDL_TYP_FLOAT}, /* 28 */
-    {"W_L",rdim,(void *) IDL_TYP_FLOAT}, /* 29 */
-    {"X_QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 30 */
-    {"PHI0",rdim,(void *) IDL_TYP_FLOAT}, /* 31 */
-    {"PHI0_E",rdim,(void *) IDL_TYP_FLOAT}, /* 32 */
+    {"WIDE",0,(void *) IDL_TYP_INT},    /* 20 */
+    {"SKY_NOISE",0,(void *) IDL_TYP_FLOAT}, /* 21 */
+    {"COMBF",0,(void *) IDL_TYP_STRING}, /* 22 */
+    {"FIT_REVISION",0,NULL},             /* 23 */
+    {"SND_REVISION",0,NULL},             /* 24 */
+    {"QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 25 */
+    {"GFLG",rdim,(void *) IDL_TYP_BYTE}, /* 26 */
+    {"V",rdim,(void *) IDL_TYP_FLOAT},   /* 27 */
+    {"V_E",rdim,(void *) IDL_TYP_FLOAT}, /* 28 */
+    {"P_L",rdim,(void *) IDL_TYP_FLOAT}, /* 29 */
+    {"W_L",rdim,(void *) IDL_TYP_FLOAT}, /* 30 */
+    {"X_QFLG",rdim,(void *) IDL_TYP_BYTE}, /* 31 */
+    {"PHI0",rdim,(void *) IDL_TYP_FLOAT}, /* 32 */
+    {"PHI0_E",rdim,(void *) IDL_TYP_FLOAT}, /* 33 */
     {0}};
 
   static IDL_MEMINT ilDims[IDL_MAX_ARRAY_DIM];
@@ -277,8 +280,8 @@ struct SndIDLData *IDLMakeSndData(IDL_VPTR *vptr) {
   snddata[4].type=IDL_MakeStruct("TMSTR",time);
   snddata[8].type=IDL_MakeStruct("NSSTR",noise);
   snddata[14].type=IDL_MakeStruct("ITSTR",intt);
-  snddata[22].type=IDL_MakeStruct("RLSTR",fit_revision);
-  snddata[23].type=IDL_MakeStruct("SDSTR",snd_revision);
+  snddata[23].type=IDL_MakeStruct("RLSTR",fit_revision);
+  snddata[24].type=IDL_MakeStruct("SDSTR",snd_revision);
 
   s=IDL_MakeStruct("SNDDATA",snddata);
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/include/rprm.h
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/include/rprm.h
@@ -94,6 +94,7 @@ struct RadarParm {
   int16 tfreq;
   int16 offset; 
   int16 ifmode;
+  int16 wide;
 
   int32 mxpwr;
   int32 lvmax;

--- a/codebase/superdarn/src.lib/tk/radar.1.22/include/rprm.h
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/include/rprm.h
@@ -94,7 +94,7 @@ struct RadarParm {
   int16 tfreq;
   int16 offset; 
   int16 ifmode;
-  int16 wide;
+  int16 widetx;
 
   int32 mxpwr;
   int32 lvmax;

--- a/codebase/superdarn/src.lib/tk/radar.1.22/include/rprm.h
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/include/rprm.h
@@ -42,6 +42,11 @@ struct RadarParm {
     char *command;
   } origin;
 
+  struct {
+    char *time;
+    char *command;
+  } history;
+
   int16 cp;
   int16 stid;
 
@@ -111,6 +116,10 @@ void RadarParmFree(struct RadarParm *ptr);
 int RadarParmSetOriginTime(struct RadarParm *ptr,char *str);
 
 int RadarParmSetOriginCommand(struct RadarParm *ptr,char *str);
+
+int RadarParmSetHistoryTime(struct RadarParm *ptr,char *str);
+
+int RadarParmSetHistoryCommand(struct RadarParm *ptr,char *str);
 
 int RadarParmSetCombf(struct RadarParm *ptr,char *str);
 

--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -278,8 +278,8 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
       prm->mplgexs=*(s->data.sptr);
     if ((strcmp(s->name,"ifmode")==0) && (s->type==DATASHORT))
       prm->ifmode=*(s->data.sptr);
-    if ((strcmp(s->name,"wide")==0) && (s->type==DATASHORT))
-      prm->wide=*(s->data.sptr);
+    if ((strcmp(s->name,"widetx")==0) && (s->type==DATASHORT))
+      prm->widetx=*(s->data.sptr);
     if ((strcmp(s->name,"nrang")==0) && (s->type==DATASHORT))
       prm->nrang=*(s->data.sptr);
     if ((strcmp(s->name,"frang")==0) && (s->type==DATASHORT))
@@ -365,7 +365,7 @@ int RadarParmEncode(struct DataMap *ptr,struct RadarParm *prm) {
   DataMapAddScalar(ptr,"mplgs",DATASHORT,&prm->mplgs);
   DataMapAddScalar(ptr,"mplgexs",DATASHORT,&prm->mplgexs);
   DataMapAddScalar(ptr,"ifmode",DATASHORT,&prm->ifmode);
-  DataMapAddScalar(ptr,"wide",DATASHORT,&prm->wide);
+  DataMapAddScalar(ptr,"widetx",DATASHORT,&prm->widetx);
 
   DataMapAddScalar(ptr,"nrang",DATASHORT,&prm->nrang);
   DataMapAddScalar(ptr,"frang",DATASHORT,&prm->frang);

--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -278,6 +278,8 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
       prm->mplgexs=*(s->data.sptr);
     if ((strcmp(s->name,"ifmode")==0) && (s->type==DATASHORT))
       prm->ifmode=*(s->data.sptr);
+    if ((strcmp(s->name,"wide")==0) && (s->type==DATASHORT))
+      prm->wide=*(s->data.sptr);
     if ((strcmp(s->name,"nrang")==0) && (s->type==DATASHORT))
       prm->nrang=*(s->data.sptr);
     if ((strcmp(s->name,"frang")==0) && (s->type==DATASHORT))
@@ -363,6 +365,7 @@ int RadarParmEncode(struct DataMap *ptr,struct RadarParm *prm) {
   DataMapAddScalar(ptr,"mplgs",DATASHORT,&prm->mplgs);
   DataMapAddScalar(ptr,"mplgexs",DATASHORT,&prm->mplgexs);
   DataMapAddScalar(ptr,"ifmode",DATASHORT,&prm->ifmode);
+  DataMapAddScalar(ptr,"wide",DATASHORT,&prm->wide);
 
   DataMapAddScalar(ptr,"nrang",DATASHORT,&prm->nrang);
   DataMapAddScalar(ptr,"frang",DATASHORT,&prm->frang);

--- a/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
+++ b/codebase/superdarn/src.lib/tk/radar.1.22/src/rprm.c
@@ -43,6 +43,8 @@ struct RadarParm *RadarParmMake() {
   memset(ptr,0,sizeof(struct RadarParm));
   ptr->origin.time=NULL;
   ptr->origin.command=NULL;
+  ptr->history.time=NULL;
+  ptr->history.command=NULL;
   ptr->pulse=NULL;
   ptr->lag[0]=NULL;
   ptr->lag[1]=NULL;
@@ -50,16 +52,20 @@ struct RadarParm *RadarParmMake() {
   return ptr;
 }
 
+
 void RadarParmFree(struct RadarParm *ptr) {
   if (ptr==NULL) return;
   if (ptr->origin.time !=NULL) free(ptr->origin.time);
   if (ptr->origin.command !=NULL) free(ptr->origin.command);
+  if (ptr->history.time !=NULL) free(ptr->history.time);
+  if (ptr->history.command !=NULL) free(ptr->history.command);
   if (ptr->pulse !=NULL) free(ptr->pulse);
   if (ptr->lag[0] !=NULL) free(ptr->lag[0]);
   if (ptr->lag[1] !=NULL) free(ptr->lag[1]);
   if (ptr->combf !=NULL) free(ptr->combf);
   free(ptr);
 }
+
 
 int RadarParmSetOriginTime(struct RadarParm *ptr,char *str) {
   char *tmp=NULL;
@@ -82,7 +88,6 @@ int RadarParmSetOriginTime(struct RadarParm *ptr,char *str) {
 }
 
 
-
 int RadarParmSetOriginCommand(struct RadarParm *ptr,char *str) {
   char *tmp=NULL;
   if (ptr==NULL) return -1;
@@ -102,6 +107,63 @@ int RadarParmSetOriginCommand(struct RadarParm *ptr,char *str) {
   return 0;
 
 }
+
+
+int RadarParmSetHistoryTime(struct RadarParm *ptr,char *str) {
+  char *tmp=NULL;
+  if (ptr==NULL) return -1;
+
+  if (str==NULL) {
+    if (ptr->history.time !=NULL) free(ptr->history.time);
+    ptr->history.time=NULL;
+    return 0;
+  }
+
+  if (ptr->history.time==NULL) tmp=malloc(strlen(str)+1);
+  else tmp=realloc(ptr->history.time,strlen(ptr->history.time)+strlen(str)+3);
+
+  if (tmp==NULL) return -1;
+
+  if (ptr->history.time==NULL) {
+    strcpy(tmp,str);
+  } else {
+    strcat(tmp,"; ");
+    strcat(tmp,str);
+  }
+
+  ptr->history.time=tmp;
+  return 0;
+
+}
+
+
+int RadarParmSetHistoryCommand(struct RadarParm *ptr,char *str) {
+  char *tmp=NULL;
+  if (ptr==NULL) return -1;
+
+  if (str==NULL) {
+    if (ptr->history.command !=NULL) free(ptr->history.command);
+    ptr->history.command=NULL;
+    return 0;
+  }
+
+  if (ptr->history.command==NULL) tmp=malloc(strlen(str)+1);
+  else tmp=realloc(ptr->history.command,strlen(ptr->history.command)+strlen(str)+3);
+
+  if (tmp==NULL) return -1;
+
+  if (ptr->history.command==NULL) {
+    strcpy(tmp,str);
+  } else {
+    strcat(tmp,"; ");
+    strcat(tmp,str);
+  }
+
+  ptr->history.command=tmp;
+  return 0;
+
+}
+
 
 int RadarParmSetCombf(struct RadarParm *ptr,char *str) {
   void *tmp=NULL;
@@ -144,6 +206,7 @@ int RadarParmSetPulse(struct RadarParm *ptr,int mppul,int16 *pulse) {
   return 0;
 }
 
+
 int RadarParmSetLag(struct RadarParm *ptr,int mplgs,int16 *lag) {
   int n,x;
   void *tmp=NULL;
@@ -168,10 +231,6 @@ int RadarParmSetLag(struct RadarParm *ptr,int mplgs,int16 *lag) {
 }
 
 
-
-
-
-
 int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
 
   int n,c;
@@ -183,6 +242,8 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
 
   if (prm->origin.time !=NULL) free(prm->origin.time);
   if (prm->origin.command !=NULL) free(prm->origin.command);
+  if (prm->history.time !=NULL) free(prm->history.time);
+  if (prm->history.command !=NULL) free(prm->history.command);
   if (prm->pulse !=NULL) free(prm->pulse);
   for (n=0;n<2;n++) if (prm->lag[n] !=NULL) free(prm->lag[n]);
   if (prm->combf !=NULL) free(prm->combf);
@@ -190,6 +251,8 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
   memset(prm,0,sizeof(struct RadarParm));
   prm->origin.time=NULL;
   prm->origin.command=NULL;
+  prm->history.time=NULL;
+  prm->history.command=NULL;
   prm->pulse=NULL;
   prm->lag[0]=NULL;
   prm->lag[1]=NULL;
@@ -211,6 +274,12 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
 
     if ((strcmp(s->name,"origin.command")==0) && (s->type==DATASTRING))
       RadarParmSetOriginCommand(prm,*((char **) s->data.vptr));
+
+    if ((strcmp(s->name,"history.time")==0) && (s->type==DATASTRING))
+      RadarParmSetHistoryTime(prm,*((char **) s->data.vptr));
+
+    if ((strcmp(s->name,"history.command")==0) && (s->type==DATASTRING))
+      RadarParmSetHistoryCommand(prm,*((char **) s->data.vptr));
 
     if ((strcmp(s->name,"cp")==0) && (s->type==DATASHORT))
       prm->cp=*(s->data.sptr);
@@ -312,6 +381,7 @@ int RadarParmDecode(struct DataMap *ptr,struct RadarParm *prm) {
   return 0;
 }
 
+
 int RadarParmEncode(struct DataMap *ptr,struct RadarParm *prm) {
 
   int n,x;
@@ -329,6 +399,8 @@ int RadarParmEncode(struct DataMap *ptr,struct RadarParm *prm) {
   DataMapAddScalar(ptr,"origin.code",DATACHAR,&prm->origin.code);
   DataMapAddScalar(ptr,"origin.time",DATASTRING,&prm->origin.time);
   DataMapAddScalar(ptr,"origin.command",DATASTRING,&prm->origin.command);
+  DataMapAddScalar(ptr,"history.time",DATASTRING,&prm->history.time);
+  DataMapAddScalar(ptr,"history.command",DATASTRING,&prm->history.command);
   DataMapAddScalar(ptr,"cp",DATASHORT,&prm->cp);
   DataMapAddScalar(ptr,"stid",DATASHORT,&prm->stid);
   DataMapAddScalar(ptr,"time.yr",DATASHORT,&prm->time.yr);
@@ -412,6 +484,8 @@ void *RadarParmFlatten(struct RadarParm *ptr,size_t *size) {
 
   if (ptr->origin.time !=NULL) s+=strlen(ptr->origin.time)+1;
   if (ptr->origin.command !=NULL) s+=strlen(ptr->origin.command)+1;
+  if (ptr->history.time !=NULL) s+=strlen(ptr->history.time)+1;
+  if (ptr->history.command !=NULL) s+=strlen(ptr->history.command)+1;
   if (ptr->combf !=NULL) s+=strlen(ptr->combf)+1;
   if (ptr->pulse !=NULL) s+=ptr->mppul*sizeof(int16);
   if (ptr->lag[0] !=NULL) s+=(lnum)*sizeof(int16);
@@ -437,6 +511,18 @@ void *RadarParmFlatten(struct RadarParm *ptr,size_t *size) {
     p+=strlen(ptr->origin.command)+1;
   }
 
+  if (ptr->history.time !=NULL) {
+    strcpy(buf+p,ptr->history.time);
+    r->history.time=(void *) p;
+    p+=strlen(ptr->history.time)+1;
+  }
+
+  if (ptr->history.command !=NULL) {
+    strcpy(buf+p,ptr->history.command);
+    r->history.command=(void *) p;
+    p+=strlen(ptr->history.command)+1;
+  }
+
   if (ptr->combf !=NULL) {
     strcpy(buf+p,ptr->combf);
     r->combf=(void *) p;
@@ -459,6 +545,7 @@ void *RadarParmFlatten(struct RadarParm *ptr,size_t *size) {
   return buf;
 }
 
+
 int RadarParmExpand(struct RadarParm *ptr,void *buffer) {
   void *p;
   int n,lnum;
@@ -467,6 +554,8 @@ int RadarParmExpand(struct RadarParm *ptr,void *buffer) {
 
   if (ptr->origin.time !=NULL) free(ptr->origin.time);
   if (ptr->origin.command !=NULL) free(ptr->origin.command);
+  if (ptr->history.time !=NULL) free(ptr->history.time);
+  if (ptr->history.command !=NULL) free(ptr->history.command);
   if (ptr->pulse !=NULL) free(ptr->pulse);
   if (ptr->lag[0] !=NULL) free(ptr->lag[0]);
   if (ptr->lag[1] !=NULL) free(ptr->lag[1]);
@@ -483,6 +572,18 @@ int RadarParmExpand(struct RadarParm *ptr,void *buffer) {
     p=buffer+(size_t) ptr->origin.command;
     ptr->origin.command=malloc(strlen(p)+1);
     strcpy(ptr->origin.command,p);
+  }
+
+  if (ptr->history.time !=NULL) {
+    p=buffer+(size_t) ptr->history.time;
+    ptr->history.time=malloc(strlen(p)+1);
+    strcpy(ptr->history.time,p);
+  }
+
+  if (ptr->history.command !=NULL) {
+    p=buffer+(size_t) ptr->history.command;
+    ptr->history.command=malloc(strlen(p)+1);
+    strcpy(ptr->history.command,p);
   }
 
   if (ptr->combf !=NULL) {

--- a/codebase/superdarn/src.lib/tk/snd.1.0/include/snddata.h
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/include/snddata.h
@@ -83,7 +83,7 @@ struct SndData {
   int16 rsep;
   int16 xcf;
   int16 tfreq;
-  int16 wide;
+  int16 widetx;
 
   double sky_noise;
 

--- a/codebase/superdarn/src.lib/tk/snd.1.0/include/snddata.h
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/include/snddata.h
@@ -29,7 +29,7 @@ Modifications:
 
 
 #define SND_MAJOR_REVISION 1
-#define SND_MINOR_REVISION 1
+#define SND_MINOR_REVISION 2
 
 
 struct SndData {
@@ -83,6 +83,7 @@ struct SndData {
   int16 rsep;
   int16 xcf;
   int16 tfreq;
+  int16 wide;
 
   double sky_noise;
 

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
@@ -72,6 +72,7 @@ int FitToSnd(struct SndData *ptr, struct RadarParm *prm,
   ptr->rsep = prm->rsep;
   ptr->xcf = prm->xcf;
   ptr->tfreq = prm->tfreq;
+  ptr->wide = prm->wide;
   ptr->sky_noise = fit->noise.skynoise;
   ptr->fit_revision.major = fit->revision.major;
   ptr->fit_revision.minor = fit->revision.minor;

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/fitsnd.c
@@ -72,7 +72,7 @@ int FitToSnd(struct SndData *ptr, struct RadarParm *prm,
   ptr->rsep = prm->rsep;
   ptr->xcf = prm->xcf;
   ptr->tfreq = prm->tfreq;
-  ptr->wide = prm->wide;
+  ptr->widetx = prm->widetx;
   ptr->sky_noise = fit->noise.skynoise;
   ptr->fit_revision.major = fit->revision.major;
   ptr->fit_revision.minor = fit->revision.minor;

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndread.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndread.c
@@ -122,8 +122,8 @@ int SndDecode(struct DataMap *ptr, struct SndData *snd) {
       snd->xcf=*(s->data.sptr);
     if ((strcmp(s->name,"tfreq")==0) && (s->type==DATASHORT))
       snd->tfreq=*(s->data.sptr);
-    if ((strcmp(s->name,"wide")==0) && (s->type==DATASHORT))
-      snd->wide=*(s->data.sptr);
+    if ((strcmp(s->name,"widetx")==0) && (s->type==DATASHORT))
+      snd->widetx=*(s->data.sptr);
     if ((strcmp(s->name,"noise.sky")==0) && (s->type==DATAFLOAT))
       snd->sky_noise=*(s->data.fptr);
     if ((strcmp(s->name,"combf")==0) && (s->type==DATASTRING))

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndread.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndread.c
@@ -122,6 +122,8 @@ int SndDecode(struct DataMap *ptr, struct SndData *snd) {
       snd->xcf=*(s->data.sptr);
     if ((strcmp(s->name,"tfreq")==0) && (s->type==DATASHORT))
       snd->tfreq=*(s->data.sptr);
+    if ((strcmp(s->name,"wide")==0) && (s->type==DATASHORT))
+      snd->wide=*(s->data.sptr);
     if ((strcmp(s->name,"noise.sky")==0) && (s->type==DATAFLOAT))
       snd->sky_noise=*(s->data.fptr);
     if ((strcmp(s->name,"combf")==0) && (s->type==DATASTRING))

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
@@ -96,7 +96,7 @@ int SndWrite(int fid, struct SndData *snd) {
   DataMapAddScalar(ptr,"rsep",DATASHORT,&snd->rsep);
   DataMapAddScalar(ptr,"xcf",DATASHORT,&snd->xcf);
   DataMapAddScalar(ptr,"tfreq",DATASHORT,&snd->tfreq);
-  DataMapAddScalar(ptr,"wide",DATASHORT,&snd->wide);
+  DataMapAddScalar(ptr,"widetx",DATASHORT,&snd->widetx);
 
   sky_noise=snd->sky_noise;
   DataMapStoreScalar(ptr,"noise.sky",DATAFLOAT,&sky_noise);

--- a/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
+++ b/codebase/superdarn/src.lib/tk/snd.1.0/src/sndwrite.c
@@ -96,6 +96,7 @@ int SndWrite(int fid, struct SndData *snd) {
   DataMapAddScalar(ptr,"rsep",DATASHORT,&snd->rsep);
   DataMapAddScalar(ptr,"xcf",DATASHORT,&snd->xcf);
   DataMapAddScalar(ptr,"tfreq",DATASHORT,&snd->tfreq);
+  DataMapAddScalar(ptr,"wide",DATASHORT,&snd->wide);
 
   sky_noise=snd->sky_noise;
   DataMapStoreScalar(ptr,"noise.sky",DATAFLOAT,&sky_noise);


### PR DESCRIPTION
This is an initial draft attempt at improving how we track the processing stages and modification history of our standard files using the radar parameter block (eg, iqdat, rawacf, fitacf).

The idea is that instead of overwriting the `origin.time` and `origin.command` fields (which contain useful information about the radar operating mode and any specific options), a new set of `history.time` and `history.command` fields will be appended to each time another processing routine is applied to a file.  For the moment I've only added this functionality to `make_fit` and `trim_fit` for testing purposes.

So for example, if someone runs `make_fit` on a rawacf file followed by `trim_fit`, the `dmapdump` output of the resulting `fitacf` file would look something like this:

```
scalars:
	char	"radar.revision.major" = 4
	char	"radar.revision.minor" = 6
	char	"origin.code" = 1
	string	"origin.time" = "Tue Jun 23 00:00:05 2026"
	string	"origin.command" = "pcodescan -stid ice -c 1 -fast -sb 0 -eb 23 -baud 5 -rsep 15 -df 10600 -nf 10600 -rfrate 10"
	string	"history.time" = "Thu Jun 25 15:09:22 2026; Thu Jun 25 15:24:57 2026"
	string	"history.command" = "make_fit -fitacf2 20260623.0000.02.ice.a.rawacf; trim_fit -sd 20260623 -st 00:00 -et 24:00 20260623.0000.02.ice.a.fitacf"
	short	"cp" = 999
	short	"stid" = 211
	short	"time.yr" = 2026
	short	"time.mo" = 6
	short	"time.dy" = 23
	short	"time.hr" = 0
	short	"time.mt" = 0
	short	"time.sc" = 2
	int	"time.us" = 345700
...
```

The history will still be retained even if piping the output from one to the other, eg

`make_fit -fitacf2 20260623.0000.02.ice.a.rawacf | trim_fit -sd 20260623 -st 00:00 -et 02:00 > out.fitacf`

will show the following with `dmapdump`:

```
scalars:
	char	"radar.revision.major" = 4
	char	"radar.revision.minor" = 6
	char	"origin.code" = 1
	string	"origin.time" = "Tue Jun 23 00:00:09 2026"
	string	"origin.command" = "pcodescan -stid ice -c 1 -fast -sb 0 -eb 23 -baud 5 -rsep 15 -df 10600 -nf 10600 -rfrate 10"
	string	"history.time" = "Thu Jun 25 16:50:50 2026; Thu Jun 25 16:50:50 2026"
	string	"history.command" = "make_fit -fitacf2 20260623.0000.02.ice.a.rawacf; trim_fit -sd 20260623 -st 00:00 -et 02:00"
	short	"cp" = 999
	short	"stid" = 211
	short	"time.yr" = 2026
	short	"time.mo" = 6
	short	"time.dy" = 23
	short	"time.hr" = 0
	short	"time.mt" = 0
	short	"time.sc" = 6
	int	"time.us" = 928100
...
```

In terms of file size, these new fields can add about ~1 MB for an uncompressed 2-hour fitacf file.  When compressed with bzip2, the file sizes with / without the new fields are nearly identical.